### PR TITLE
Reduce the required bison version

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -16,7 +16,7 @@ typedef void* yyscan_t;
 #endif
 }
 
-%require "3.1"
+%require "3.0"
 
 %define api.pure full
 %lex-param   { yyscan_t scanner }


### PR DESCRIPTION
The latest version available through apt-get is lower that 3.1 

Lowered the required version to 3.0
