### PR TITLE
init script works for mac and linux

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,8 +1,21 @@
+case "$OSTYPE" in
+  darwin*)
+    update="brew update"
+    command="brew install -y" ;;
+  linux*)
+    update="sudo apt-get update"
+    command="sudo apt-get install" ;;
+  *)
+    echo "unknown OS: $OSTYPE" ;;
+esac
+
 if [[   -z  `which cargo` ]]; then
-sudo apt-get install cargo
+  $update
+  $command cargo
 fi
 if [[   -z  `which cmake` ]]; then
-  sudo apt-get install cmake
+  $update
+  $command cmake
 fi
 
 git submodule init
@@ -15,4 +28,3 @@ cd ../../..
 mkdir -p build
 cd build
 cmake ..
-


### PR DESCRIPTION
The initialization script determines the os and installs cmake and cargo using apt-get for linux or brew for mac