### PR TITLE
Adding parser/resolver support for aggregation, group by, and joins

### DIFF
--- a/optimizer/quickstep/query_optimizer/resolver/HustleResolver.cpp
+++ b/optimizer/quickstep/query_optimizer/resolver/HustleResolver.cpp
@@ -110,8 +110,8 @@ logical::LogicalPtr HustleResolver::resolve_select(shared_ptr<SelectNode> select
 }
 
 logical::TableReferencePtr HustleResolver::resolve_reference(shared_ptr<ReferenceNode> reference_node) {
-    const quickstep::CatalogRelation *relation = catalog_database_.getRelationByName(reference_node->reference);
-    return logical::TableReference::Create(relation, reference_node->reference, context_);
+    const quickstep::CatalogRelation *relation = catalog_database_.getRelationByName(reference_node->attribute);
+    return logical::TableReference::Create(relation, reference_node->attribute, context_);
 }
 
 expressions::ScalarPtr HustleResolver::resolve_expression(
@@ -124,7 +124,7 @@ expressions::ScalarPtr HustleResolver::resolve_expression(
 
             auto found_attribute_reference = find_if(attribute_references.begin(), attribute_references.end(),
                     [&project_reference_parse](const expressions::AttributeReferencePtr attribute_reference) {
-                        return attribute_reference->attribute_name() == project_reference_parse->reference;
+                        return attribute_reference->attribute_name() == project_reference_parse->attribute;
                     });
             return found_attribute_reference[0];
         }

--- a/optimizer/quickstep/query_optimizer/resolver/HustleResolver.h
+++ b/optimizer/quickstep/query_optimizer/resolver/HustleResolver.h
@@ -11,6 +11,7 @@
 #include "parser/FunctionNode.h"
 #include "catalog/CatalogDatabase.hpp"
 #include "query_optimizer/OptimizerContext.hpp"
+#include "query_optimizer/expressions/Alias.hpp"
 #include "query_optimizer/logical/Logical.hpp"
 #include "query_optimizer/logical/TableReference.hpp"
 
@@ -34,7 +35,8 @@ private:
     quickstep::optimizer::logical::LogicalPtr resolve_select(std::shared_ptr<SelectNode> select_node);
     quickstep::optimizer::logical::TableReferencePtr resolve_reference(std::shared_ptr<ReferenceNode> reference_node);
     quickstep::optimizer::expressions::ScalarPtr resolve_expression(std::shared_ptr<ParseNode> parse_node,
-            std::vector<quickstep::optimizer::expressions::AttributeReferencePtr> attribute_references);
+            std::vector<quickstep::optimizer::expressions::AttributeReferencePtr> attribute_references,
+            std::vector<quickstep::optimizer::expressions::AliasPtr> *aggregate_expressions);
 };
 
 

--- a/optimizer/quickstep/query_optimizer/resolver/HustleResolver.h
+++ b/optimizer/quickstep/query_optimizer/resolver/HustleResolver.h
@@ -9,6 +9,7 @@
 #include "parser/SelectNode.h"
 #include "parser/ReferenceNode.h"
 #include "parser/FunctionNode.h"
+#include "parser/OperatorNode.h"
 #include "catalog/CatalogDatabase.hpp"
 #include "query_optimizer/OptimizerContext.hpp"
 #include "query_optimizer/expressions/Alias.hpp"

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
         SelectNode.h SelectNode.cpp
         ReferenceNode.h ReferenceNode.cpp
         FunctionNode.h FunctionNode.cpp
+        OperatorNode.h OperatorNode.cpp
         ${BISON_PARSER_OUTPUTS}
         ${FLEX_LEXER_OUTPUTS}
 )

--- a/parser/FunctionNode.cpp
+++ b/parser/FunctionNode.cpp
@@ -1,8 +1,11 @@
 #include "FunctionNode.h"
 
+#include <sstream>
+
 using namespace std;
 
-FunctionNode::FunctionNode(const string name, vector<shared_ptr<ParseNode>> arguments) : ParseNode(FUNCTION), arguments(move(arguments)) {
+FunctionNode::FunctionNode(const string name, vector<shared_ptr<ParseNode>> arguments)
+        : ParseNode(FUNCTION), arguments(arguments) {
     this->name = name;
 }
 
@@ -16,4 +19,10 @@ unordered_map<string, vector<shared_ptr<ParseNode>>> FunctionNode::get_children_
     return {
             {"arguments", arguments}
     };
+}
+
+string FunctionNode::to_sql_string() {
+    stringstream sql_stream;
+    sql_stream << name << "(" << ParseNode::to_sql_string(arguments) << ")";
+    return sql_stream.str();
 }

--- a/parser/FunctionNode.h
+++ b/parser/FunctionNode.h
@@ -11,6 +11,7 @@ public:
     FunctionNode(std::string name, std::vector<std::shared_ptr<ParseNode>> arguments);
     std::unordered_map<std::string, std::string> get_attributes() override;
     std::unordered_map<std::string, std::vector<std::shared_ptr<ParseNode>>> get_children_lists() override;
+    std::string to_sql_string() override;
     std::string name;
     std::vector<std::shared_ptr<ParseNode> > arguments;
 };

--- a/parser/OperatorNode.cpp
+++ b/parser/OperatorNode.cpp
@@ -1,3 +1,4 @@
+#include <utility>
 #include <string>
 
 #include "OperatorNode.h"
@@ -5,7 +6,7 @@
 using namespace std;
 
 OperatorNode::OperatorNode(OperatorType operator_type, vector<shared_ptr<ParseNode>> operands)
-        : operator_type(operator_type), operands(operands) { }
+        : operator_type(operator_type), operands(move(operands)) { }
 
 unordered_map<string, string> OperatorNode::get_attributes() {
     auto attributes = ParseNode::get_attributes();

--- a/parser/OperatorNode.cpp
+++ b/parser/OperatorNode.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 
 OperatorNode::OperatorNode(OperatorType operator_type, vector<shared_ptr<ParseNode>> operands)
-        : operator_type(operator_type), operands(move(operands)) { }
+        : ParseNode(OPERATOR), operator_type(operator_type), operands(move(operands)) { }
 
 unordered_map<string, string> OperatorNode::get_attributes() {
     auto attributes = ParseNode::get_attributes();

--- a/parser/OperatorNode.cpp
+++ b/parser/OperatorNode.cpp
@@ -1,0 +1,20 @@
+#include <string>
+
+#include "OperatorNode.h"
+
+using namespace std;
+
+OperatorNode::OperatorNode(OperatorType operator_type, vector<shared_ptr<ParseNode>> operands)
+        : operator_type(operator_type), operands(operands) { }
+
+unordered_map<string, string> OperatorNode::get_attributes() {
+    auto attributes = ParseNode::get_attributes();
+    attributes.insert({"operator", to_string(operator_type)});
+    return attributes;
+}
+
+unordered_map<string, vector<shared_ptr<ParseNode>>> OperatorNode::get_children_lists() {
+    return {
+            {"operands", operands}
+    };
+}

--- a/parser/OperatorNode.h
+++ b/parser/OperatorNode.h
@@ -1,0 +1,18 @@
+#ifndef HUSTLE_OPERATORNODE_H
+#define HUSTLE_OPERATORNODE_H
+
+#include "ParseNode.h"
+
+enum OperatorType {EQ};
+
+class OperatorNode: public ParseNode {
+public:
+    OperatorNode(OperatorType operator_type, std::vector<std::shared_ptr<ParseNode>> operands);
+    OperatorType operator_type;
+    std::vector<std::shared_ptr<ParseNode>> operands;
+    std::unordered_map<std::string, std::string> get_attributes() override;
+    std::unordered_map<std::string, std::vector<std::shared_ptr<ParseNode>>> get_children_lists() override;
+};
+
+
+#endif //HUSTLE_OPERATORNODE_H

--- a/parser/ParseNode.cpp
+++ b/parser/ParseNode.cpp
@@ -31,6 +31,17 @@ void ParseNode::json_stringify() {
         key_index++;
     }
 
+    for (const auto &child : children) {
+        if (child.second) {
+            cout << child.first << ":";
+            child.second->json_stringify();
+            if (key_index < num_keys - 1) {
+                cout << ",";
+            }
+        }
+        key_index++;
+    }
+
     for (const auto &child : children_lists) {
         cout << child.first << ":[";
         for (size_t i = 0; i < child.second.size(); ++i) {

--- a/parser/ParseNode.cpp
+++ b/parser/ParseNode.cpp
@@ -1,6 +1,7 @@
 #include "ParseNode.h"
 
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 
@@ -60,4 +61,19 @@ unordered_map<string, shared_ptr<ParseNode>> ParseNode::get_children() {
 
 unordered_map<string, vector<shared_ptr<ParseNode>>> ParseNode::get_children_lists() {
     return {};
+}
+
+string ParseNode::to_sql_string() {
+    return string();
+}
+
+string ParseNode::to_sql_string(vector<shared_ptr<ParseNode>> nodes) {
+    stringstream sql_stream;
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        if (i != 0) {
+            sql_stream << ", ";
+        }
+        sql_stream << nodes[i]->to_sql_string();
+    }
+    return sql_stream.str();
 }

--- a/parser/ParseNode.h
+++ b/parser/ParseNode.h
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
-enum NodeType {NONE, SELECT, REFERENCE, FUNCTION};
+enum NodeType {NONE, SELECT, REFERENCE, FUNCTION, OPERATOR};
 
 class ParseNode {
 public:

--- a/parser/ParseNode.h
+++ b/parser/ParseNode.h
@@ -15,7 +15,10 @@ public:
     virtual std::unordered_map<std::string, std::string> get_attributes();
     virtual std::unordered_map<std::string, std::shared_ptr<ParseNode>> get_children();
     virtual std::unordered_map<std::string, std::vector<std::shared_ptr<ParseNode>>> get_children_lists();
+    virtual std::string to_sql_string();
     NodeType type;
+protected:
+    static std::string to_sql_string(std::vector<std::shared_ptr<ParseNode>> nodes);
 };
 
 #endif //HUSTLE_PARSE_NODE_H

--- a/parser/ParserDriver.cpp
+++ b/parser/ParserDriver.cpp
@@ -12,6 +12,7 @@ int ParserDriver::parse(std::string s) {
     yy::parser parser(*this);
     parser.set_debug_level(false);
     int res = parser.parse();
+    std::cout << syntax_tree->to_sql_string() << std::endl;
     yy_delete_buffer(state);
 //    this->syntax_tree->json_stringify();
     optimizer(syntax_tree);

--- a/parser/ReferenceNode.cpp
+++ b/parser/ReferenceNode.cpp
@@ -2,16 +2,23 @@
 
 using namespace std;
 
-ReferenceNode::ReferenceNode(const string reference) : ParseNode(REFERENCE) {
-    this->reference = reference;
+ReferenceNode::ReferenceNode(const string attribute, const string relation) : ParseNode(REFERENCE) {
+    this->attribute = attribute;
+    this->relation = relation;
 }
 
 unordered_map<string, string> ReferenceNode::get_attributes() {
     auto attributes = ParseNode::get_attributes();
-    attributes.insert({"reference", reference});
+    attributes.insert({
+        {"attribute", attribute},
+        {"relation", relation}
+    });
     return attributes;
 }
 
 string ReferenceNode::to_sql_string() {
-    return reference;
+    if (relation.empty()) {
+        return attribute;
+    }
+    return relation + "." + attribute;
 }

--- a/parser/ReferenceNode.cpp
+++ b/parser/ReferenceNode.cpp
@@ -11,3 +11,7 @@ unordered_map<string, string> ReferenceNode::get_attributes() {
     attributes.insert({"reference", reference});
     return attributes;
 }
+
+string ReferenceNode::to_sql_string() {
+    return reference;
+}

--- a/parser/ReferenceNode.h
+++ b/parser/ReferenceNode.h
@@ -7,10 +7,11 @@
 
 class ReferenceNode: public ParseNode {
 public:
-    explicit ReferenceNode(std::string reference);
+    explicit ReferenceNode(std::string attribute, std::string relation = "");
     std::unordered_map<std::string, std::string> get_attributes() override;
     std::string to_sql_string() override;
-    std::string reference;
+    std::string attribute;
+    std::string relation;
 };
 
 

--- a/parser/ReferenceNode.h
+++ b/parser/ReferenceNode.h
@@ -9,6 +9,7 @@ class ReferenceNode: public ParseNode {
 public:
     explicit ReferenceNode(std::string reference);
     std::unordered_map<std::string, std::string> get_attributes() override;
+    std::string to_sql_string() override;
     std::string reference;
 };
 

--- a/parser/SelectNode.cpp
+++ b/parser/SelectNode.cpp
@@ -1,10 +1,19 @@
+#include <utility>
+
 #include "SelectNode.h"
 
 using namespace std;
 
 SelectNode::SelectNode(vector<shared_ptr<ParseNode>> target, vector<shared_ptr<ParseNode>> from,
-                       vector<shared_ptr<ParseNode>> group_by) : ParseNode(SELECT),
-                       target(move(target)), from(move(from)), group_by(move(group_by)) { }
+        shared_ptr<ParseNode> where, vector<shared_ptr<ParseNode>> group_by) : ParseNode(SELECT),
+        target(move(target)), from(move(from)), where(move(where)), group_by(move(group_by)) { }
+
+
+unordered_map<string, shared_ptr<ParseNode>> SelectNode::get_children() {
+    return {
+            {"where", where}
+    };
+}
 
 unordered_map<string, vector<shared_ptr<ParseNode>>> SelectNode::get_children_lists() {
     return {
@@ -13,3 +22,5 @@ unordered_map<string, vector<shared_ptr<ParseNode>>> SelectNode::get_children_li
             {"group_by", group_by}
     };
 }
+
+

--- a/parser/SelectNode.h
+++ b/parser/SelectNode.h
@@ -11,10 +11,12 @@
 class SelectNode: public ParseNode {
 public:
     SelectNode(std::vector<std::shared_ptr<ParseNode>> target, std::vector<std::shared_ptr<ParseNode>> from,
-            std::vector<std::shared_ptr<ParseNode>> group_by);
+            std::shared_ptr<ParseNode> where, std::vector<std::shared_ptr<ParseNode>> group_by);
+    std::unordered_map<std::string, std::shared_ptr<ParseNode>> get_children() override;
     std::unordered_map<std::string, std::vector<std::shared_ptr<ParseNode>>> get_children_lists() override;
     std::vector<std::shared_ptr<ParseNode>> target;
     std::vector<std::shared_ptr<ParseNode>> from;
+    std::shared_ptr<ParseNode> where;
     std::vector<std::shared_ptr<ParseNode>> group_by;
 };
 

--- a/parser/lexer.l
+++ b/parser/lexer.l
@@ -56,7 +56,6 @@ DROP            		{ return yy::parser::make_DROP(loc); }
 EACH            		{ return yy::parser::make_EACH(loc); }
 ELSE            		{ return yy::parser::make_ELSE(loc); }
 END             		{ return yy::parser::make_END(loc); }
-EQ              		{ return yy::parser::make_EQ(loc); }
 ESCAPE          		{ return yy::parser::make_ESCAPE(loc); }
 EXCEPT          		{ return yy::parser::make_EXCEPT(loc); }
 EXCLUSIVE       		{ return yy::parser::make_EXCLUSIVE(loc); }
@@ -154,6 +153,7 @@ WITHOUT         		{ return yy::parser::make_WITHOUT(loc); }
 ","                   	{ return yy::parser::make_COMMA(loc); }
 "||"                  	{ return yy::parser::make_CONCAT(loc); }
 "."						{ return yy::parser::make_DOT(loc); }
+"="                     { return yy::parser::make_EQ(loc); }
 [0-9]*\.[0-9]+			{ return yy::parser::make_FLOAT(loc); }
 ">="					{ return yy::parser::make_GE(loc); }
 ">"						{ return yy::parser::make_GT(loc); }

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -666,7 +666,9 @@ expr:
     $$ = std::shared_ptr<ReferenceNode>(new ReferenceNode($1));
   }
 | JOIN_KW { error(drv.location, "join keyword in expression not yet supported"); }
-| nm DOT nm { error(drv.location, "nm.nm in expression not yet supported"); }
+| nm DOT nm {
+    $$ = std::shared_ptr<ReferenceNode>(new ReferenceNode($3, $1));
+  }
 | nm DOT nm DOT nm { error(drv.location, "nm.nm.nm in expression not yet supported"); }
 | VARIABLE { error(drv.location, "VARIABLE not yet supported"); }
 | expr COLLATE ids { error(drv.location, "COLLATE not yet supported"); }

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -218,6 +218,7 @@ class ParserDriver;
   nexprlist
   sclp
   selcollist
+  stl_prefix
   seltablist
 
 %%
@@ -538,13 +539,16 @@ from:
 ;
 
 stl_prefix:
-  seltablist joinop
-| /* empty */
+  seltablist joinop {
+    $$ = std::move($1);
+  }
+| /* empty */ {}
 ;
 
 seltablist:
   stl_prefix nm dbnm as indexed_opt on_opt using_opt {
-    $$.push_back(std::shared_ptr<ReferenceNode>(new ReferenceNode($2)));
+    $$ = std::move($1);
+    $$.push_back(std::shared_ptr<ReferenceNode>(new ReferenceNode(std::string(), $2)));
   }
 | stl_prefix nm dbnm LP exprlist RP as on_opt using_opt { error(drv.location, "parentheses in FROM clause not yet supported"); }
 | stl_prefix LP select RP as on_opt using_opt { error(drv.location, "nested select not yet supported"); }


### PR DESCRIPTION
This adds support for aggregate functions, group by clauses, and simple joins to the parser and resolver. Currently, `AVG`, `COUNT`, `MAX`, `MIN`, and `SUM` are the aggregate functions supported. Joins are of the form `WHERE a.i = b.j`. Join keywords will be supported in a future PR.