### PR TITLE
Storage manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ file(COPY ${CMAKE_SOURCE_DIR}/test-data DESTINATION ${CMAKE_BINARY_DIR})
 
 enable_testing()
 
+add_subdirectory(storage)
 add_subdirectory(execution)
 add_subdirectory(optimizer)
 add_subdirectory(parser)

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+/.idea

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,0 +1,21 @@
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CARGO_BUILD cargo build)
+    set(TARGET_DIR debug)
+else()
+    set(CARGO_BUILD cargo build --release)
+    set(TARGET_DIR release)
+endif()
+
+set(STORAGE ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}storage${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(STORAGE ${STORAGE} PARENT_SCOPE)
+
+add_custom_target(
+        storage ALL
+        COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} ${CARGO_BUILD}
+        COMMAND cp ${STORAGE} ${CMAKE_CURRENT_BINARY_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_test(NAME storage_tests
+        COMMAND cargo test
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,3 +5,8 @@ authors = ["gaffneyk <kpgaffney@wisc.edu>"]
 
 [dependencies]
 memmap = "0.7.0"
+
+[lib]
+name = "storage"
+path = "src/lib.rs"
+crate-type = ["rlib", "dylib", "staticlib"]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "storage"
+version = "0.1.0"
+authors = ["gaffneyk <kpgaffney@wisc.edu>"]
+
+[dependencies]
+memmap = "0.7.0"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod lru_buffer;

--- a/storage/src/lru_buffer.rs
+++ b/storage/src/lru_buffer.rs
@@ -1,0 +1,141 @@
+extern crate memmap;
+
+use self::memmap::Mmap;
+use std::collections::{HashMap, VecDeque};
+use std::error::Error;
+use std::fs::{self, File};
+use std::path::PathBuf;
+use std::time::Instant;
+
+struct LruBufferRecord {
+    value: Mmap,
+    pinned: bool,
+}
+
+impl LruBufferRecord {
+    pub fn new(value: Mmap) -> LruBufferRecord {
+        LruBufferRecord {
+            value,
+            pinned: false,
+        }
+    }
+}
+
+pub struct LruBuffer {
+    k: u8,
+    capacity: u64,
+    fill: u64,
+    records: HashMap<String, LruBufferRecord>,
+    reference_log: HashMap<String, VecDeque<Instant>>,
+    start_instant: Instant
+}
+
+impl LruBuffer {
+
+    pub fn new(k: u8, capacity: u64) -> LruBuffer {
+        LruBuffer {
+            k,
+            capacity,
+            fill: 0,
+            records: HashMap::new(),
+            reference_log: HashMap::new(),
+            start_instant: Instant::now()
+        }
+    }
+
+    pub fn put(&mut self, key: &str, value: &[u8]) -> Result<(), Box<Error>> {
+        // First persist the changes to storage
+        let path = self.get_file_path(key);
+        fs::write(path, value)?;
+
+        // Easiest now to deload the old record and load the new record into the buffer
+        // May eventually be able to perform updates without remapping the underlying file
+        self.deload(key);
+        self.load(key)?;
+        Ok(())
+    }
+
+    pub fn get(&mut self, key: &str) -> Result<(usize, *const u8), Box<Error>> {
+        let mmap = self.load(key)?;
+        Ok((mmap.len(), mmap.as_ptr()))
+    }
+
+    pub fn delete(&mut self, key: &str) -> Result<(), Box<Error>> {
+        let path = self.get_file_path(key);
+        fs::remove_file(path)?;
+        self.deload(key);
+        Ok(())
+    }
+
+    pub fn pin(&mut self, key: &str) {
+        self.records.get_mut(key).expect("Attempt to pin a nonexistent key").pinned = true;
+    }
+
+    pub fn release(&mut self, key: &str) {
+        self.records.get_mut(key).expect("Attempt to release a nonexistent key").pinned = false;
+    }
+
+    fn load(&mut self, key: &str) -> Result<&Mmap, Box<Error>> {
+        let time = Instant::now();
+
+        // If the record is already in the buffer, update LRU log and return
+        if self.records.contains_key(key) {
+            self.log_reference(key, time);
+            return Ok(&self.records.get(key).unwrap().value)
+        }
+
+        // The record must be loaded from storage
+        let path = self.get_file_path(key);
+        let file = File::open(path)?;
+        let space_needed = file.metadata()?.len();
+
+        // Remove the LRU-K record from the buffer until there is enough space
+        while self.capacity - self.fill < space_needed {
+            let key_to_remove = self.records
+                .iter()
+                .filter(|record| !record.1.pinned)
+                .min_by_key(|record| self.reference_log.get(record.0.as_str()).unwrap().front().unwrap())
+                .unwrap().0.clone();
+            self.deload(key_to_remove.as_str());
+        }
+
+        // Load the record from storage
+        let mmap = unsafe { Mmap::map(&file)? };
+        self.records.insert(String::from(key), LruBufferRecord::new(mmap));
+        self.fill += space_needed;
+
+        // Initialize LRU log if it does not exist
+        if !self.reference_log.contains_key(key) {
+            let mut new_reference_log = VecDeque::new();
+            for _i in 0..self.k {
+                new_reference_log.push_back(self.start_instant);
+            }
+            self.reference_log.insert(String::from(key), new_reference_log);
+        }
+
+        // Update LRU log
+        self.log_reference(key, time);
+
+        // Return the buffered record
+        Ok(&self.records.get(key).unwrap().value)
+    }
+
+    fn deload(&mut self, key: &str) {
+        if let Some(removed_record) = self.records.remove(key) {
+            self.fill -= removed_record.value.len() as u64;
+        }
+    }
+
+    fn log_reference(&mut self, key: &str, time: Instant) {
+        if let Some(log) = self.reference_log.get_mut(key) {
+            log.pop_front();
+            log.push_back(time);
+        }
+    }
+
+    fn get_file_path(&mut self, key: &str) -> PathBuf {
+        let mut path = PathBuf::from(key);
+        path.set_extension("hustle");
+        path
+    }
+}

--- a/storage/tests/lru_buffer_test.rs
+++ b/storage/tests/lru_buffer_test.rs
@@ -1,0 +1,89 @@
+extern crate storage;
+
+#[cfg(test)]
+#[allow(unused_must_use)]
+mod tests {
+    use storage::lru_buffer::LruBuffer;
+    use std::slice;
+
+    #[test]
+    fn put_get() {
+        let mut buffer = LruBuffer::new(1, 1000);
+        let key = "k_put_get";
+        let expected_value = b"value";
+        buffer.put(key, expected_value);
+        get_and_assert_eq(&mut buffer, key, expected_value);
+        buffer.delete(key);
+    }
+
+    #[test]
+    fn put_update_get() {
+        let mut buffer = LruBuffer::new(1, 1000);
+        let key = "k_put_update_get";
+        let expected_value = b"value";
+        buffer.put(key, b"old_value");
+        buffer.put(key, expected_value);
+        get_and_assert_eq(&mut buffer, key, expected_value);
+        buffer.delete(key);
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_nonexistent_key() {
+        LruBuffer::new(1, 1000).get("nonexistent_key").unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn delete_get() {
+        let mut buffer = LruBuffer::new(1, 1000);
+        let key = "k_delete";
+        let value = b"value";
+        buffer.put(key, value);
+        buffer.delete(key);
+        buffer.get(key).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn pin_nonexistent_key() {
+        LruBuffer::new(1, 1000).pin("nonexistent_key");
+    }
+
+    #[test]
+    fn pin_release() {
+        let mut buffer = LruBuffer::new(1, 1000);
+        let key1 = "k_pin_release_1";
+        let key2 = "k_pin_release_2";
+        let key3 = "k_pin_release_3";
+        let expected_value: [u8; 500] = [0; 500];
+
+        // Put all three records in the storage manager
+        buffer.put(key1, &expected_value);
+        buffer.put(key2, &expected_value);
+        buffer.put(key3, &expected_value);
+
+        // Get and pin a pointer to one record
+        let (len, ptr) = buffer.get(key1).unwrap();
+        buffer.pin(key1);
+
+        // Load the other two records into the buffer
+        buffer.get(key2);
+        buffer.get(key3);
+
+        // Assert that the pointer is still valid and points to the correct data
+        assert!(!ptr.is_null());
+        let actual_value = unsafe { slice::from_raw_parts(ptr, len) };
+        assert_eq!(&expected_value[..], actual_value);
+
+        buffer.delete(key1);
+        buffer.delete(key2);
+        buffer.delete(key3);
+    }
+
+    fn get_and_assert_eq(buffer: &mut LruBuffer, key: &str, expected_value: &[u8]) {
+        let (len, ptr) = buffer.get(key).unwrap();
+        let actual_value = unsafe { slice::from_raw_parts(ptr, len) };
+        assert_eq!(expected_value, actual_value);
+    }
+}


### PR DESCRIPTION
This is the first version of the Hustle storage manager. It is essentially a very basic key-value store, where the keys are strings and the values are variable-length byte arrays. The implementation is a buffer that memory maps files up to a specified capacity, using the [LRU-K](http://www.cs.cmu.edu/~christos/courses/721-resources/p297-o_neil.pdf) algorithm to unmap when capacity is reached. The memory-mapped arrays are stored as values in a HashMap.

The API is:
- **`put(key, value)`**: saves the key-value pair on persistent storage.
- **`get(key) -> (value_len, *value)`**: memory-maps the value and returns a tuple containing the length of the buffer and a pointer to the beginning of the buffer.
- **`delete(key)`**: removes the key-value pair from the buffer and storage.
- **`pin(key)`**: prevents the buffer from unmapping the corresponding value, guaranteeing the pointer's validity until `release(key)` is called.
- **`release(key)`**: allows the buffer to unmap the corresponding value.