### PR TITLE
Persistent catalog at the optimizer

### DIFF
--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <string>
 
+#include "glog/logging.h"
+
 #include "parser/ParserDriver.h"
 #include "optimizer/optimizer_wrapper.hpp"
 
@@ -11,6 +13,7 @@
 using namespace std;
 
 int main(int argc, char **argv) {
+    google::InitGoogleLogging("hustle");
     char buffer[BUFFER_SIZE];
 
     cout << "Hustle version " << HUSTLE_VERSION << endl;

--- a/optimizer/optimizer_catalog_schema.txt
+++ b/optimizer/optimizer_catalog_schema.txt
@@ -1,7 +1,5 @@
 {relation name, {column, type}}
 
-{T, {a:int}, {b:int}}
-{A, {w:int}, {x:int}, {y:int}, {z:int}}
-{B, {w:int}, {x:int}}
-{C, {x:int}, {y:int}}
-{D, {y:int}, {z:int}}
+{t, {a:int}, {b:int}}
+{a, {w:int}, {x:int}, {y:int}, {z:int}}
+{b, {w:int}, {x:int}}

--- a/optimizer/optimizer_wrapper.cpp
+++ b/optimizer/optimizer_wrapper.cpp
@@ -7,7 +7,10 @@ using namespace std;
 extern "C" void execute_plan(char*);
 
 int optimizer(const shared_ptr<ParseNode> &syntax_tree, const string &sql) {
-  std::string pplan = hustle_optimize(syntax_tree, sql);
+  std::unique_ptr<quickstep::OptimizerWrapper> optmizer =
+      std::make_unique<quickstep::OptimizerWrapper>();
+
+  std::string pplan = optmizer->hustle_optimize(syntax_tree, sql);
   if (pplan.size() == 0) { return -1; } // Quickstep optimizer failed
 
   char *pplan_char = new char[pplan.size() + 1];

--- a/optimizer/quickstep/query_optimizer/CMakeLists.txt
+++ b/optimizer/quickstep/query_optimizer/CMakeLists.txt
@@ -61,7 +61,12 @@ target_link_libraries(hustle_optimizer
         quickstep_queryoptimizer_OptimizerContext
         quickstep_queryoptimizer_PhysicalGenerator
         quickstep_queryoptimizer_resolver_Resolver
-        quickstep_utility_Macros)
+        quickstep_utility_Macros
+        quickstep_catalog_Catalog
+        quickstep_catalog_Catalog_proto
+        quickstep_catalog_CatalogDatabase
+        quickstep_catalog_CatalogTypedefs
+        )
 
 #target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
 #                      ${GFLAGS_LIB_NAME}

--- a/optimizer/quickstep/query_optimizer/HustleOptimizer.cpp
+++ b/optimizer/quickstep/query_optimizer/HustleOptimizer.cpp
@@ -49,7 +49,7 @@ void OptimizerWrapper::CreateDefaultCatalog() {
   quickstep::CatalogDatabase *catalog_database =
       catalog_->getDatabaseByNameMutable("default_db");
 
-  std::vector<std::string> rel_names = {"T", "A", "B"};
+  std::vector<std::string> rel_names = {"t", "a", "b"};
   std::vector<std::vector<std::pair<std::string, quickstep::TypeID>>>
       rel_columns = {
       {{"a", quickstep::kInt}, {"b", quickstep::kInt}},

--- a/optimizer/quickstep/query_optimizer/HustleOptimizer.cpp
+++ b/optimizer/quickstep/query_optimizer/HustleOptimizer.cpp
@@ -6,16 +6,94 @@
 #include "parser/SqlParserWrapper.hpp"
 #include "query_optimizer/tests/TestDatabaseLoader.hpp"
 #include "utility/SqlError.hpp"
+#include "types/TypeID.hpp"
+#include "catalog/Catalog.hpp"
+#include "catalog/Catalog.pb.h"
 
-std::string hustle_optimize(const std::shared_ptr<ParseNode> &syntax_tree,
-                            const std::string &sql) {
+#include <fstream>
+#include <memory>
+#include <string>
 
+namespace quickstep {
+
+void OptimizerWrapper::readCatalog() {
+  quickstep::serialization::Catalog catalog_proto;
+  std::ifstream catalog_file(std::string(kCatalogPath).c_str());
+  if (!catalog_file.good()) {
+    throw UnableToReadCatalogE(kCatalogPath);
+  }
+
+  if (!catalog_proto.ParseFromIstream(&catalog_file)) {
+    throw CatalogNotProtoE(kCatalogPath);
+  }
+  catalog_file.close();
+  catalog_ = std::make_shared<Catalog>(catalog_proto);
+}
+
+void OptimizerWrapper::saveCatalog() {
+  std::ofstream catalog_file(std::string(kCatalogPath).c_str());
+
+  if (!catalog_->getProto().SerializeToOstream(&catalog_file)) {
+    throw UnableToWriteCatalogE(kCatalogPath);
+  }
+
+  catalog_file.close();
+}
+
+void OptimizerWrapper::CreateDefaultCatalog() {
+
+  catalog_->addDatabase(new quickstep::CatalogDatabase(nullptr /* parent */,
+                                                      "default_db" /* name */,
+                                                      0 /* id */));
+
+  quickstep::CatalogDatabase *catalog_database =
+      catalog_->getDatabaseByNameMutable("default_db");
+
+  std::vector<std::string> rel_names = {"T", "A", "B"};
+  std::vector<std::vector<std::pair<std::string, quickstep::TypeID>>>
+      rel_columns = {
+      {{"a", quickstep::kInt}, {"b", quickstep::kInt}},
+      {{"w", quickstep::kInt}, {"x", quickstep::kInt}, {"y", quickstep::kInt},
+       {"z", quickstep::kInt}},
+      {{"w", quickstep::kInt}, {"x", quickstep::kInt}}
+  };
+
+  for (std::size_t rel_idx = 0; rel_idx < rel_names.size(); ++rel_idx) {
+    std::unique_ptr<quickstep::CatalogRelation> relation(
+        new quickstep::CatalogRelation(catalog_database,
+                                       rel_names[rel_idx],
+                                       -1 /* id */,
+                                       true /* temporary */));
+
+    const std::vector<std::pair<std::string, quickstep::TypeID>>
+        &columns = rel_columns[rel_idx];
+    int attr_id = -1;
+    for (std::size_t col_idx = 0; col_idx < columns.size(); ++col_idx) {
+      relation->addAttribute(new quickstep::CatalogAttribute(
+          relation.get(),
+          columns[col_idx].first,
+          quickstep::TypeFactory::GetType(columns[col_idx].second),
+          ++attr_id));
+    }
+    catalog_database->addRelation(relation.release());
+  }
+}
+
+std::string OptimizerWrapper::hustle_optimize(const std::shared_ptr<ParseNode> &syntax_tree,
+                                              const std::string &sql) {
   quickstep::optimizer::OptimizerContext optimizer_context;
+  catalog_.reset();
 
-  quickstep::optimizer::TestDatabaseLoader test_database_loader_;
-  test_database_loader_.createHustleTestRelation(false /* allow_vchar */);
-  test_database_loader_.loadHustleTestRelation();
-  test_database_loader_.createHustleJoinRelations();
+  try {
+    readCatalog();
+  } catch (UnableToReadCatalogE &read_exception) {
+    printf("Catalog initialized. \n");
+    catalog_ = std::make_shared<Catalog>();
+    CreateDefaultCatalog();
+  }
+
+  quickstep::CatalogDatabase *catalog_database =
+      catalog_->getDatabaseByNameMutable("default_db");
 
   quickstep::optimizer::LogicalGenerator logical_generator(&optimizer_context);
   quickstep::optimizer::PhysicalGenerator
@@ -27,28 +105,28 @@ std::string hustle_optimize(const std::shared_ptr<ParseNode> &syntax_tree,
     // If the sql is empty the parser/resolver of Hustle is used.
     if (sql.empty()) {
       lplan = logical_generator.hustleGeneratePlan(
-          *test_database_loader_.catalog_database(), syntax_tree);
+          *catalog_database, syntax_tree);
     } else {  // Parse the query using the quickstep parser
       quickstep::SqlParserWrapper sql_parser_;
       auto query = new std::string(sql);
       sql_parser_.feedNextBuffer(query);
       quickstep::ParseResult result = sql_parser_.getNextStatement();
       if (result.condition == quickstep::ParseResult::kError) {
-        printf( "%s", result.error_message.c_str());
+        printf("%s", result.error_message.c_str());
         return "";
       }
       const quickstep::ParseStatement
           &parse_statement = *result.parsed_statement;
       // Convert the query to the logical plan using quickstep's optimizer
       lplan = logical_generator.generatePlan(
-          *test_database_loader_.catalog_database(), parse_statement);
+          catalog_database, parse_statement);
     }
 
 //    std::cout<< "Logical Plan: " << lplan->jsonString() << std::endl;
 //    std::cout << " --------------------- " << std::endl;
     pplan =
         physical_generator.generatePlan(
-            lplan, test_database_loader_.catalog_database());
+            lplan, catalog_database);
 
 //    std::cout<< "Physical Plan: " << pplan->jsonString() << std::endl;
   } catch (const quickstep::SqlError &sql_error) {
@@ -56,5 +134,8 @@ std::string hustle_optimize(const std::shared_ptr<ParseNode> &syntax_tree,
     return "";
   }
 
+  saveCatalog();
+
   return pplan->jsonString();
+}
 }

--- a/optimizer/quickstep/query_optimizer/HustleOptimizer.cpp
+++ b/optimizer/quickstep/query_optimizer/HustleOptimizer.cpp
@@ -119,7 +119,7 @@ std::string OptimizerWrapper::hustle_optimize(const std::shared_ptr<ParseNode> &
           &parse_statement = *result.parsed_statement;
       // Convert the query to the logical plan using quickstep's optimizer
       lplan = logical_generator.generatePlan(
-          catalog_database, parse_statement);
+          catalog_database, parse_statement, true /* husteMode */);
     }
 
 //    std::cout<< "Logical Plan: " << lplan->jsonString() << std::endl;

--- a/optimizer/quickstep/query_optimizer/HustleOptimizer.hpp
+++ b/optimizer/quickstep/query_optimizer/HustleOptimizer.hpp
@@ -4,6 +4,87 @@
 #include <memory>
 #include "parser/ParseNode.h"
 
-std::string hustle_optimize(const std::shared_ptr<ParseNode> &syntax_tree, const std::string &sql = std::string());
+namespace quickstep {
+class Catalog;
+
+class UnableToReadCatalogE : public std::exception {
+ public:
+  explicit UnableToReadCatalogE(const std::string &filename)
+      : message_("UnableToReadCatalog: Unable to read catalog from file ") {
+    message_.append(filename);
+  }
+
+  ~UnableToReadCatalogE() throw() {
+  }
+
+  virtual const char* what() const throw() {
+    return message_.c_str();
+  }
+
+ private:
+  std::string message_;
+};
+
+class UnableToWriteCatalogE : public std::exception {
+ public:
+
+  explicit UnableToWriteCatalogE(const std::string &filename)
+      : message_("UnableToWriteCatalog: Unable to write catalog to file ") {
+    message_.append(filename);
+  }
+
+  ~UnableToWriteCatalogE() throw() {
+  }
+
+  virtual const char* what() const throw() {
+    return message_.c_str();
+  }
+
+ private:
+  std::string message_;
+};
+
+class CatalogNotProtoE : public std::exception {
+ public:
+  explicit CatalogNotProtoE(const std::string &filename)
+      : message_("CatalogNotProto: The file ") {
+    message_.append(filename).append(" is not valid Proto");
+  }
+
+  ~CatalogNotProtoE() throw() {
+  }
+
+  virtual const char* what() const throw() {
+    return message_.c_str();
+  }
+
+ private:
+  std::string message_;
+};
+
+constexpr char kCatalogPath[] = "test-data/hustlecatalog.pb.bin";
+
+class OptimizerWrapper {
+ public:
+  OptimizerWrapper(){}
+
+  std::string hustle_optimize(const std::shared_ptr<ParseNode> &syntax_tree,
+                              const std::string &sql = std::string());
+
+ private:
+  void readCatalog();
+
+  void saveCatalog();
+
+  void CreateDefaultCatalog();
+
+  std::shared_ptr<quickstep::Catalog> catalog_;
+
+  // TODO(chronis): changed shared to unique, need to figure out why the
+  // catalog.hpp fails to be included here.
+};
+
+
+}
 
 #endif //QUICKSTEP_HUSTLEOPTIMIZER_H

--- a/optimizer/quickstep/query_optimizer/LogicalGenerator.cpp
+++ b/optimizer/quickstep/query_optimizer/LogicalGenerator.cpp
@@ -49,7 +49,7 @@ LogicalGenerator::LogicalGenerator(OptimizerContext *optimizer_context)
 LogicalGenerator::~LogicalGenerator() {}
 
 L::LogicalPtr LogicalGenerator::generatePlan(
-        const CatalogDatabase &catalog_database,
+        CatalogDatabase *catalog_database,
         const ParseStatement &parse_statement) {
     resolver::Resolver resolver(catalog_database, optimizer_context_);
     DVLOG(4) << "Parse tree:\n" << parse_statement.toString();

--- a/optimizer/quickstep/query_optimizer/LogicalGenerator.cpp
+++ b/optimizer/quickstep/query_optimizer/LogicalGenerator.cpp
@@ -50,8 +50,9 @@ LogicalGenerator::~LogicalGenerator() {}
 
 L::LogicalPtr LogicalGenerator::generatePlan(
         CatalogDatabase *catalog_database,
-        const ParseStatement &parse_statement) {
-    resolver::Resolver resolver(catalog_database, optimizer_context_);
+        const ParseStatement &parse_statement,
+        bool hustelMode) {
+    resolver::Resolver resolver(catalog_database, optimizer_context_, hustelMode);
     DVLOG(4) << "Parse tree:\n" << parse_statement.toString();
 
   logical_plan_ = resolver.resolve(parse_statement);

--- a/optimizer/quickstep/query_optimizer/LogicalGenerator.hpp
+++ b/optimizer/quickstep/query_optimizer/LogicalGenerator.hpp
@@ -68,7 +68,8 @@ class LogicalGenerator {
    * @return An optimized logical plan.
    */
   logical::LogicalPtr generatePlan(CatalogDatabase *catalog_database,
-                                   const ParseStatement &parse_statement);
+                                   const ParseStatement &parse_statement,
+                                   bool HustleMode = false);
 
   logical::LogicalPtr hustleGeneratePlan(const CatalogDatabase &catalog_database,
                                          std::shared_ptr<ParseNode> syntax_tree);

--- a/optimizer/quickstep/query_optimizer/LogicalGenerator.hpp
+++ b/optimizer/quickstep/query_optimizer/LogicalGenerator.hpp
@@ -67,7 +67,7 @@ class LogicalGenerator {
    * @param parse_statement The parse tree to be converted.
    * @return An optimized logical plan.
    */
-  logical::LogicalPtr generatePlan(const CatalogDatabase &catalog_database,
+  logical::LogicalPtr generatePlan(CatalogDatabase *catalog_database,
                                    const ParseStatement &parse_statement);
 
   logical::LogicalPtr hustleGeneratePlan(const CatalogDatabase &catalog_database,

--- a/optimizer/quickstep/query_optimizer/resolver/Resolver.cpp
+++ b/optimizer/quickstep/query_optimizer/resolver/Resolver.cpp
@@ -620,7 +620,7 @@ L::LogicalPtr Resolver::resolveCreateTable(
   // Resolve relation name.
   const std::string relation_name =
       create_table_statement.relation_name()->value();
-  if (catalog_database_.hasRelationWithName(relation_name)) {
+  if (catalog_database_->hasRelationWithName(relation_name)) {
     THROW_SQL_ERROR_AT(create_table_statement.relation_name())
         << "Relation " << create_table_statement.relation_name()->value()
         << " already exists";
@@ -661,6 +661,22 @@ L::LogicalPtr Resolver::resolveCreateTable(
 
   std::shared_ptr<const S::PartitionSchemeHeader> partition_scheme_header_proto(
       resolvePartitionClause(create_table_statement));
+
+  // Create catalog Relation
+  std::unique_ptr<CatalogRelation> catalog_relation(new CatalogRelation(catalog_database_,
+                                             create_table_statement.relation_name()->value() ,
+                                             -1 /* id */,
+                                             false /* temporary */));
+
+  for (E::AttributeReferencePtr attr : attributes) {
+    int attr_id = -1;
+    catalog_relation->addAttribute(new CatalogAttribute(
+          catalog_relation.get(),
+          attr->attribute_name(),
+          attr->getValueType(),
+          ++attr_id));
+  }
+  catalog_database_->addRelation(catalog_relation.release());
 
   return L::CreateTable::Create(relation_name, attributes, block_properties, partition_scheme_header_proto);
 }
@@ -2121,7 +2137,7 @@ E::WindowInfo Resolver::resolveWindow(const ParseWindow &parse_window,
 const CatalogRelation* Resolver::resolveRelationName(
     const ParseString *relation_name) {
   const CatalogRelation *relation =
-      catalog_database_.getRelationByName(
+      catalog_database_->getRelationByName(
           ToLower(relation_name->value()));
   if (relation == nullptr) {
     THROW_SQL_ERROR_AT(relation_name) << "Unrecognized relation "

--- a/optimizer/quickstep/query_optimizer/resolver/Resolver.cpp
+++ b/optimizer/quickstep/query_optimizer/resolver/Resolver.cpp
@@ -991,8 +991,13 @@ L::LogicalPtr Resolver::resolveDelete(
 
 L::LogicalPtr Resolver::resolveDropTable(
     const ParseStatementDropTable &drop_table_statement) {
-  return L::DropTable::Create(
-      resolveRelationName(drop_table_statement.relation_name()));
+
+  const CatalogRelation* rel = resolveRelationName(drop_table_statement.relation_name());
+
+  // Update Catalog
+  catalog_database_->dropRelationByName(drop_table_statement.relation_name()->value());
+
+  return L::DropTable::Create(rel);
 }
 
 L::LogicalPtr Resolver::resolveInsertSelection(

--- a/optimizer/quickstep/query_optimizer/resolver/Resolver.hpp
+++ b/optimizer/quickstep/query_optimizer/resolver/Resolver.hpp
@@ -101,7 +101,7 @@ class Resolver {
    * @param catalog_database The database that the query is executed on.
    * @param context The context of this query.
    */
-  Resolver(const CatalogDatabase &catalog_database, OptimizerContext *context)
+  Resolver(CatalogDatabase *catalog_database, OptimizerContext *context)
       : catalog_database_(catalog_database),
         context_(context) {}
 
@@ -732,7 +732,7 @@ class Resolver {
       std::vector<expressions::NamedExpressionPtr> *select_list_expressions,
       logical::LogicalPtr *logical_plan);
 
-  const CatalogDatabase &catalog_database_;
+  CatalogDatabase *catalog_database_;
 
   OptimizerContext *context_;
   WithQueriesInfo with_queries_info_;

--- a/optimizer/quickstep/query_optimizer/resolver/Resolver.hpp
+++ b/optimizer/quickstep/query_optimizer/resolver/Resolver.hpp
@@ -101,9 +101,10 @@ class Resolver {
    * @param catalog_database The database that the query is executed on.
    * @param context The context of this query.
    */
-  Resolver(CatalogDatabase *catalog_database, OptimizerContext *context)
+  Resolver(CatalogDatabase *catalog_database, OptimizerContext *context, bool hustleMode = false)
       : catalog_database_(catalog_database),
-        context_(context) {}
+        context_(context),
+        hustleMode_(hustleMode){}
 
   /**
    * @brief Validates the query is semantically correct and converts the parse
@@ -738,6 +739,8 @@ class Resolver {
   WithQueriesInfo with_queries_info_;
 
   logical::LogicalPtr logical_plan_;
+
+  const bool hustleMode_;
 
   DISALLOW_COPY_AND_ASSIGN(Resolver);
 };

--- a/optimizer/quickstep/query_optimizer/tests/OptimizerTextTestRunner.cpp
+++ b/optimizer/quickstep/query_optimizer/tests/OptimizerTextTestRunner.cpp
@@ -113,7 +113,7 @@ void OptimizerTextTestRunner::runTestCase(const std::string &input,
 logical::LogicalPtr OptimizerTextTestRunner::resolveParseTree(
     const ParseStatement &parse_statement,
     OptimizerContext *optimizer_context) {
-  resolver::Resolver resolver(*test_database_loader_.catalog_database(), optimizer_context);
+  resolver::Resolver resolver(test_database_loader_.catalog_database(), optimizer_context);
   return resolver.resolve(parse_statement);
 }
 
@@ -121,7 +121,7 @@ logical::LogicalPtr OptimizerTextTestRunner::generateLogicalPlan(
     const ParseStatement &parse_statement,
     OptimizerContext *optimizer_context) {
   LogicalGenerator logical_generator(optimizer_context);
-  return logical_generator.generatePlan(*test_database_loader_.catalog_database(),
+  return logical_generator.generatePlan(test_database_loader_.catalog_database(),
                                         parse_statement);
 }
 


### PR DESCRIPTION
The optimizer maintains the catalog. If no catalog exists then it is initialized to contain tables t,a,b.
The catalog is saved to a file in a protobuff format,  after each query optimization.
Create Table and Drop Table are supported.

Note: the catalog is updated before the query is executed. But after the Resolver validates that a table can be created or dropped.