### PR TITLE
Fix drop table execution plan

### DIFF
--- a/optimizer/optimizer_wrapper.cpp
+++ b/optimizer/optimizer_wrapper.cpp
@@ -16,8 +16,7 @@ int optimizer(const shared_ptr<ParseNode> &syntax_tree, const string &sql) {
   char *pplan_char = new char[pplan.size() + 1];
   std::copy(pplan.begin(), pplan.end(), pplan_char);
   pplan_char[pplan.size()] = '\0';
- // std::cout << pplan_char << std::endl;
-  execute_plan(pplan_char);
 //  std::cout << pplan_char << std::endl;
+  execute_plan(pplan_char);
   return 0;
 }

--- a/optimizer/quickstep/query_optimizer/logical/DropTable.cpp
+++ b/optimizer/quickstep/query_optimizer/logical/DropTable.cpp
@@ -40,7 +40,7 @@ void DropTable::getFieldStringItems(
     std::vector<std::string> *container_child_field_names,
     std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const {
   inline_field_names->push_back("relation");
-  inline_field_values->push_back(catalog_relation_->getName());
+  inline_field_values->push_back(relation_name_);
 }
 
 }  // namespace logical

--- a/optimizer/quickstep/query_optimizer/logical/DropTable.hpp
+++ b/optimizer/quickstep/query_optimizer/logical/DropTable.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+#include "catalog/CatalogRelation.hpp"
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/logical/Logical.hpp"
@@ -58,12 +59,12 @@ class DropTable : public Logical {
   /**
    * @return Gets the catalog relation to be dropped.
    */
-  const CatalogRelation* catalog_relation() const { return catalog_relation_; }
+  const std::string& relation_name() const { return relation_name_; }
 
   LogicalPtr copyWithNewChildren(
       const std::vector<LogicalPtr> &new_children) const override {
     DCHECK(new_children.empty());
-    return Create(catalog_relation_);
+    return Create(relation_name_);
   }
 
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override {
@@ -80,8 +81,8 @@ class DropTable : public Logical {
    * @param catalog_relation The relation to be dropped.
    * @return An immutable DropTable node.
    */
-  static DropTablePtr Create(const CatalogRelation *catalog_relation) {
-    return DropTablePtr(new DropTable(catalog_relation));
+  static DropTablePtr Create(const std::string relation_name) {
+    return DropTablePtr(new DropTable(relation_name));
   }
 
  protected:
@@ -94,10 +95,10 @@ class DropTable : public Logical {
       std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const override;
 
  private:
-  explicit DropTable(const CatalogRelation *catalog_relation)
-      : catalog_relation_(catalog_relation) {}
+  explicit DropTable(const std::string relation_name)
+      : relation_name_(relation_name) {}
 
-  const CatalogRelation *catalog_relation_;
+  const std::string relation_name_;
 
   DISALLOW_COPY_AND_ASSIGN(DropTable);
 };

--- a/optimizer/quickstep/query_optimizer/logical/DropTable.hpp
+++ b/optimizer/quickstep/query_optimizer/logical/DropTable.hpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <vector>
 
-#include "catalog/CatalogRelation.hpp"
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/logical/Logical.hpp"

--- a/optimizer/quickstep/query_optimizer/physical/DropTable.cpp
+++ b/optimizer/quickstep/query_optimizer/physical/DropTable.cpp
@@ -37,7 +37,7 @@ void DropTable::getFieldStringItems(
     std::vector<std::string> *container_child_field_names,
     std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const {
   inline_field_names->push_back("relation");
-  inline_field_values->push_back(catalog_relation_->getName());
+  inline_field_values->push_back(relation_name_);
 }
 
 }  // namespace physical

--- a/optimizer/quickstep/query_optimizer/physical/DropTable.hpp
+++ b/optimizer/quickstep/query_optimizer/physical/DropTable.hpp
@@ -60,12 +60,12 @@ class DropTable : public Physical {
   /**
    * @return Gets the catalog relation to be dropped.
    */
-  const CatalogRelation* catalog_relation() const { return catalog_relation_; }
+  const std::string& relation_name() const { return relation_name_; }
 
   PhysicalPtr copyWithNewChildren(
       const std::vector<PhysicalPtr> &new_children) const override {
     DCHECK_EQ(getNumChildren(), new_children.size());
-    return Create(catalog_relation_);
+    return Create(relation_name_);
   }
 
   std::vector<expressions::AttributeReferencePtr> getOutputAttributes() const override {
@@ -88,8 +88,8 @@ class DropTable : public Physical {
    * @param catalog_relation The relation to be dropped.
    * @return An immutable DropTable node.
    */
-  static DropTablePtr Create(const CatalogRelation *catalog_relation) {
-    return DropTablePtr(new DropTable(catalog_relation));
+  static DropTablePtr Create(const std::string relation_name) {
+    return DropTablePtr(new DropTable(relation_name));
   }
 
  protected:
@@ -102,10 +102,10 @@ class DropTable : public Physical {
       std::vector<std::vector<OptimizerTreeBaseNodePtr>> *container_child_fields) const override;
 
  private:
-  explicit DropTable(const CatalogRelation *catalog_relation)
-      : catalog_relation_(catalog_relation) {}
+  explicit DropTable(const std::string relation_name)
+      : relation_name_(relation_name) {}
 
-  const CatalogRelation *catalog_relation_;
+  const std::string relation_name_;
 
   DISALLOW_COPY_AND_ASSIGN(DropTable);
 };

--- a/optimizer/quickstep/query_optimizer/resolver/Resolver.cpp
+++ b/optimizer/quickstep/query_optimizer/resolver/Resolver.cpp
@@ -996,11 +996,14 @@ L::LogicalPtr Resolver::resolveDropTable(
 
   const CatalogRelation* rel = resolveRelationName(drop_table_statement.relation_name());
 
+  L::LogicalPtr l = L::DropTable::Create(rel->getName());
+
   // Update Catalog
   if (hustleMode_) {
     catalog_database_->dropRelationByName(drop_table_statement.relation_name()->value());
   }
-  return L::DropTable::Create(rel);
+
+  return l;
 }
 
 L::LogicalPtr Resolver::resolveInsertSelection(

--- a/optimizer/quickstep/query_optimizer/strategy/OneToOne.cpp
+++ b/optimizer/quickstep/query_optimizer/strategy/OneToOne.cpp
@@ -152,7 +152,7 @@ bool OneToOne::generatePlan(const L::LogicalPtr &logical_input,
     case L::LogicalType::kDropTable: {
       const L::DropTablePtr drop_table =
           std::static_pointer_cast<const L::DropTable>(logical_input);
-      *physical_output = P::DropTable::Create(drop_table->catalog_relation());
+      *physical_output = P::DropTable::Create(drop_table->relation_name());
       return true;
     }
     case L::LogicalType::kInsertSelection: {


### PR DESCRIPTION
The execution plan produced by the optimizer contains the relation name in a drop table query.

DropTable logical and physical operators updated to maintain the name of the dropped relation.