### PR TITLE
Delete support

### DIFF
--- a/execution/src/physical_operators/delete.rs
+++ b/execution/src/physical_operators/delete.rs
@@ -1,0 +1,64 @@
+use logical_entities::relation::Relation;
+use logical_entities::predicates::Predicate;
+use physical_operators::Operator;
+use super::storage::StorageManager;
+use type_system::borrowed_buffer::BorrowedBuffer;
+use type_system::Buffer;
+use logical_entities::row::Row;
+
+pub struct Delete {
+    relation: Relation,
+    predicate: Option<Box<Predicate>>
+}
+
+impl Delete {
+    pub fn new(relation: Relation, predicate: Option<Box<Predicate>>) -> Self {
+        Delete {
+            relation,
+            predicate
+        }
+    }
+}
+
+impl Operator for Delete {
+    fn get_target_relation(&self) -> Relation {
+        self.relation.clone()
+    }
+
+    fn execute(&self, storage_manager: &StorageManager) -> Result<Relation, String> {
+        let schema = self.relation.get_schema();
+        let physical_relation = storage_manager
+            .relational_engine()
+            .get(self.relation.get_name())
+            .unwrap();
+
+        if let Some(ref predicate) = self.predicate {
+            for mut block in physical_relation.blocks() {
+                let mut row_i = 0;
+                while row_i < block.get_n_rows() {
+                    // Assemble values in the current row (this is very inefficient!).
+                    let mut values = vec![];
+                    for col_i in 0..schema.get_columns().len() {
+                        let data = block.get_row_col(row_i, col_i).unwrap();
+                        let data_type = schema.get_columns()[col_i].data_type();
+                        let buff = BorrowedBuffer::new(&data, data_type, false);
+                        values.push(buff.marshall());
+                    }
+
+                    // Check whether the current row satisfies the predicate.
+                    let row = Row::new(schema.clone(), values);
+                    if predicate.evaluate(&row) {
+                        block.delete_row(row_i);
+                    } else {
+                        row_i += 1;
+                    }
+                }
+            }
+
+        } else {
+            physical_relation.clear();
+        }
+
+        Ok(self.get_target_relation())
+    }
+}

--- a/execution/src/physical_operators/mod.rs
+++ b/execution/src/physical_operators/mod.rs
@@ -4,6 +4,7 @@ pub mod drop_table;
 pub mod export_csv;
 pub mod import_csv;
 pub mod insert;
+pub mod delete;
 pub mod update;
 pub mod join;
 pub mod limit;

--- a/storage/src/physical_relation.rs
+++ b/storage/src/physical_relation.rs
@@ -67,6 +67,24 @@ impl<'a> PhysicalRelation<'a> {
         block.insert_row()
     }
 
+    /// Deletes all rows in the `PhysicalRelation`, but maintains the relation itself by keeping
+    /// the first block on storage.
+    pub fn clear(&self) {
+
+        let first_block = self.get_block(0)
+            .expect("Could not find block 0 for relation.");
+        first_block.clear();
+
+        let mut block_index = 1;
+        let mut key_for_block = RelationalStorageEngine::formatted_key_for_block(
+            self.key, block_index);
+        while self.buffer_manager.exists(&key_for_block) {
+            self.buffer_manager.erase(&key_for_block);
+            block_index += 1;
+            key_for_block = RelationalStorageEngine::formatted_key_for_block(self.key, block_index);
+        }
+    }
+
     /// Returns the entire data of the `PhysicalRelation`, concatenated into a vector of bytes in
     /// row-major format.
     pub fn bulk_read(&self) -> Vec<u8> {

--- a/storage/tests/storage_manager_tests.rs
+++ b/storage/tests/storage_manager_tests.rs
@@ -48,33 +48,6 @@ mod storage_manager_tests {
     }
 
     #[test]
-    fn insert() {
-        let sm = StorageManager::new();
-        let rl_engine = sm.relational_engine();
-        let pr = rl_engine.create("key_insert", vec![1, 2]);
-
-        {
-            let mut row_builder = pr.insert_row();
-            row_builder.push(b"a");
-            row_builder.push(b"bb");
-        }
-
-        {
-            let mut row_builder = pr.insert_row();
-            row_builder.push(b"c");
-            row_builder.push(b"dd");
-        }
-
-        let block = pr.get_block(0).unwrap();
-        assert_eq!(&block.get_row_col(0, 0).unwrap(), &b"a");
-        assert_eq!(&block.get_row_col(0, 1).unwrap(), &b"bb");
-        assert_eq!(&block.get_row_col(1, 0).unwrap(), &b"c");
-        assert_eq!(&block.get_row_col(1, 1).unwrap(), &b"dd");
-
-        rl_engine.drop("key_insert");
-    }
-
-    #[test]
     fn get_row_col() {
         let sm = StorageManager::new();
         let rl_engine = sm.relational_engine();
@@ -105,6 +78,57 @@ mod storage_manager_tests {
         assert_eq!(&block.bulk_read()[0..6], b"ebbcff");
 
         rl_engine.drop("key_set_row_col");
+    }
+
+    #[test]
+    fn insert_row() {
+        let sm = StorageManager::new();
+        let rl_engine = sm.relational_engine();
+        let pr = rl_engine.create("key_insert_row", vec![1, 2]);
+
+        {
+            let mut row_builder = pr.insert_row();
+            row_builder.push(b"a");
+            row_builder.push(b"bb");
+        }
+
+        {
+            let mut row_builder = pr.insert_row();
+            row_builder.push(b"c");
+            row_builder.push(b"dd");
+        }
+
+        let block = pr.get_block(0).unwrap();
+        assert_eq!(&block.get_row_col(0, 0).unwrap(), &b"a");
+        assert_eq!(&block.get_row_col(0, 1).unwrap(), &b"bb");
+        assert_eq!(&block.get_row_col(1, 0).unwrap(), &b"c");
+        assert_eq!(&block.get_row_col(1, 1).unwrap(), &b"dd");
+
+        rl_engine.drop("key_insert_row");
+    }
+
+    #[test]
+    fn delete_row() {
+        let sm = StorageManager::new();
+        let rl_engine = sm.relational_engine();
+        let pr = rl_engine.create("key_delete_row", vec![1, 2]);
+
+        pr.bulk_write(b"abbcddeff");
+
+        let mut block = pr.get_block(0).unwrap();
+
+        block.delete_row(0);
+        assert_eq!(block.get_n_rows(), 2);
+        assert_eq!(&block.bulk_read(), b"effcdd");
+
+        block.delete_row(1);
+        assert_eq!(block.get_n_rows(), 1);
+        assert_eq!(&block.bulk_read(), b"eff");
+
+        block.delete_row(0);
+        assert_eq!(block.get_n_rows(), 0);
+
+        rl_engine.drop("key_delete_row");
     }
 
     #[test]


### PR DESCRIPTION
This adds support for SQL deletes to the execution engine and the storage manager. Currently we maintain block packing by replacing the deleted row with the last row in the block, but this will change in the future.