### PR TITLE
Remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "optimizer/quickstep/third_party/src/protobuf"]
-	path = optimizer/quickstep/third_party/src/protobuf
-	url = https://github.com/google/protobuf.git


### PR DESCRIPTION
.gitmodules is not needed now that the quickstep optimizer is gone 