### PR TITLE
Build as Rust project in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,82 +1,10 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-# NOTE(quickstep-team): In Travis-CI, jobs timeout if they take more than 50
-# mins or if there is no log output for more than 10 mins. Hence, we use -O0 to
-# speed up compilation in release build. Also, jobs can only use upto 20GB of
-# disk space. Hence, we minimize the amount of debug symbol using -g0 (DEBUG
-# builds were taking > 20GB of space with clang).
-# Also, to reduce the total CI time, we explicitly run the most time-consuming
-# build first, using gcc in debug build with joinwithbinaryexpressions.
-
-language: cpp
-
-cache: ccache
-
-compiler:
-- clang
-
-install:
-- export TEST_JOBS=2;
-- if [ "$CC" = "gcc" ]; then
-  export CC="gcc-5";
-  export CXX="g++-5";
-  elif [ "$CC" = "clang" ]; then
-  export CC="clang-3.7";
-  export CXX="clang++-3.7";
-  fi
-- export CLINKER=`which gold`
-- export DEBUG_FLAGS="-g0";
-- export RELEASE_FLAGS="-O0 -DNDEBUG";
-- export LINKER_FLAGS="-s"
-
-before_script:
-- curl https://sh.rustup.rs -sSf | sh -s -- -y
-- source $HOME/.cargo/env
-- rustup component add clippy
-- $CC --version
-- $CXX --version
-- $CLINKER --version
-- cmake --version
-
-script:
-- cargo build -vv
-- cargo test
-
-after_failure:
-- df -h
-- free -m
-- dmesg
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.7
-    - george-edison55-precise-backports # For cmake 3.x
-    packages:
-    - gcc-5
-    - g++-5
-    - clang-3.7
-    - binutils-gold
-    - python-networkx
-    - cmake-data
-    - cmake
-    - flex
-    - bison
-    - python3
-    - python3-pip
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: beta nightly
+  fast_finish: true
+cache: cargo


### PR DESCRIPTION
This changes the Travis configuration from C++ to Rust. The configuration specifies that Hustle is built and tested on the stable, beta, and nightly channels, but only failures on the stable channel will fail the build. It also uses cargo to cache dependencies to reduce build time.

This closes #98.