### PR TITLE
Use specific Abseil release instead of master branch

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,7 @@ FetchContent_MakeAvailable(googletest)
 FetchContent_Declare(
         abseil
         GIT_REPOSITORY  https://github.com/abseil/abseil-cpp.git
-        GIT_TAG         master
+        GIT_TAG         20200225.1
 )
 FetchContent_MakeAvailable(abseil)
 


### PR DESCRIPTION
There was a bug on the master branch of Abseil's source code. The git tag has been changed to pull the latest release instead of the master branch. We can update this as new versions of Abseil are released.