### PR TITLE
Fixed parser bugs in SQLite3 directory

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -5,15 +5,15 @@ add_library(
 
 target_link_libraries(hustleDB sqlite_utils catalog)
 
-#add_executable(hustle_hustleDB_test "tests/hustleDB_test.cpp")
-#target_link_libraries(hustle_hustleDB_test
-#        gtest
-#        gtest_main
-#        gmock
-#        catalog
-#        sqlite3
-#        absl::container absl::hash
-#        absl::flat_hash_map
-#        hustleDB
-#        )
-#add_test(HustleDB_test hustle_hustleDB_test)
+add_executable(hustle_hustleDB_test "tests/hustleDB_test.cpp")
+target_link_libraries(hustle_hustleDB_test
+        gtest
+        gtest_main
+        gmock
+        catalog
+        sqlite3
+        absl::container absl::hash
+        absl::flat_hash_map
+        hustleDB
+        )
+add_test(HustleDB_test hustle_hustleDB_test)

--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -16,14 +16,14 @@ target_link_libraries(
         sqlite_utils
 )
 
-#add_executable(hustle_catalog_test "tests/HustleCatalog_test.cpp")
-#target_link_libraries(hustle_catalog_test
-#        gtest
-#        gtest_main
-#        gmock
-#        catalog
-#        sqlite3
-#        absl::container absl::hash
-#        absl::flat_hash_map
-#        )
-#add_test(HustleCatalog_test hustle_catalog_test)
+add_executable(hustle_catalog_test "tests/HustleCatalog_test.cpp")
+target_link_libraries(hustle_catalog_test
+        gtest
+        gtest_main
+        gmock
+        catalog
+        sqlite3
+        absl::container absl::hash
+        absl::flat_hash_map
+        )
+add_test(HustleCatalog_test hustle_catalog_test)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -8,26 +8,26 @@ target_link_libraries(parser
         catalog
 )
 
-#add_executable(hustle_parser_simple_test tests/HustleParser_simple_test.cpp)
-#target_link_libraries(hustle_parser_simple_test
-#        gtest
-#        gtest_main
-#        gmock
-#        catalog
-#        sqlite3
-#        hustleDB
-#        parser
-#        )
-#add_test(HustleParser_test hustle_parser_simple_test)
-#
-#add_executable(hustle_parser_ssb_test "tests/HustleParser_ssb_test.cpp")
-#target_link_libraries(hustle_parser_ssb_test
-#        gtest
-#        gtest_main
-#        gmock
-#        catalog
-#        sqlite3
-#        hustleDB
-#        parser
-#        )
-#add_test(HustleParser_test hustle_parser_ssb_test)
+add_executable(hustle_parser_simple_test tests/HustleParser_simple_test.cpp)
+target_link_libraries(hustle_parser_simple_test
+        gtest
+        gtest_main
+        gmock
+        catalog
+        sqlite3
+        hustleDB
+        parser
+        )
+add_test(HustleParser_test hustle_parser_simple_test)
+
+add_executable(hustle_parser_ssb_test "tests/HustleParser_ssb_test.cpp")
+target_link_libraries(hustle_parser_ssb_test
+        gtest
+        gtest_main
+        gmock
+        catalog
+        sqlite3
+        hustleDB
+        parser
+        )
+add_test(HustleParser_test hustle_parser_ssb_test)

--- a/src/resolver/CMakeLists.txt
+++ b/src/resolver/CMakeLists.txt
@@ -7,30 +7,30 @@ add_library(
 target_link_libraries(resolver
         parser
 )
-#
-#add_executable(hustle_resolver_simple_test "tests/HustleResolver_simple_test.cpp")
-#target_link_libraries(hustle_resolver_simple_test
-#        gtest
-#        gtest_main
-#        gmock
-#        catalog
-#        sqlite3
-#        hustleDB
-#        table
-#        resolver
-#        )
-#add_test(HustleResolver_test hustle_resolver_simple_test)
-#
-#
-#add_executable(hustle_resolver_ssb_test "tests/HustleResolver_ssb_test.cpp")
-#target_link_libraries(hustle_resolver_ssb_test
-#        gtest
-#        gtest_main
-#        gmock
-#        catalog
-#        sqlite3
-#        hustleDB
-#        table
-#        resolver
-#        )
-#add_test(HustleResolver_test hustle_resolver_ssb_test)
+
+add_executable(hustle_resolver_simple_test "tests/HustleResolver_simple_test.cpp")
+target_link_libraries(hustle_resolver_simple_test
+        gtest
+        gtest_main
+        gmock
+        catalog
+        sqlite3
+        hustleDB
+        table
+        resolver
+        )
+add_test(HustleResolver_test hustle_resolver_simple_test)
+
+
+add_executable(hustle_resolver_ssb_test "tests/HustleResolver_ssb_test.cpp")
+target_link_libraries(hustle_resolver_ssb_test
+        gtest
+        gtest_main
+        gmock
+        catalog
+        sqlite3
+        hustleDB
+        table
+        resolver
+        )
+add_test(HustleResolver_test hustle_resolver_ssb_test)

--- a/third_party/sqlite3/sqlite3-5.c
+++ b/third_party/sqlite3/sqlite3-5.c
@@ -20343,12 +20343,14 @@ SQLITE_PRIVATE void resolveExpr(Expr *pExpr) {
       break;
 
     case TK_COLUMN:
-    case TK_AGG_COLUMN:currPos += sprintf(currPos,
-                                          "{\"type\": \"%s\", \"column_name\": \"%s\", \"i_table\": %d, \"i_column\": %d}",
-                                          "ColumnReference",
-                                          pExpr->y.pTab->aCol[pExpr->iColumn].zName,
-                                          pExpr->iTable,
-                                          pExpr->iColumn);
+    case TK_AGG_COLUMN:
+      if (pExpr->iColumn < 0) return;
+      currPos += sprintf(currPos,
+                         "{\"type\": \"%s\", \"column_name\": \"%s\", \"i_table\": %d, \"i_column\": %d}",
+                         "ColumnReference",
+                         pExpr->y.pTab->aCol[pExpr->iColumn].zName,
+                         pExpr->iTable,
+                         pExpr->iColumn);
       break;
 
     case TK_BETWEEN:


### PR DESCRIPTION
This PR fixes a bug hidden inside the parser code in SQLite3 directory.
Now all the tests can pass consistently.
Closes #20 