### PR TITLE
change the circleci arrow cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-            keys: my-cache-v1
+            keys: my-cache-v2
       - run: ./install_requirements.sh
       - run: ./install_arrow.sh
       - save_cache:
-            key: my-cache-v1
+            key: my-cache-v2
             paths:
               - arrow
               - cmake-3.15.5

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Hustle is an efficient data platform, organized as a collection of data processi
 Hustle is built on [Apache Arrow](https://github.com/apache/arrow). 
 
 ## Coding Guidelinees
-We follow [these guidelines](https://arrow.apache.org/docs/developers/cpp/development.html).
-
+We follow [these guidelines](https://arrow.apache.org/docs/developers/cpp/development.html) for development.
 
 ## Build Hustle
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hustle is an efficient data platform, organized as a collection of data processi
 ## Building blocks
 Hustle is built on [Apache Arrow](https://github.com/apache/arrow). 
 
-## Coding Guidelinees
+## Coding Guidelines
 We follow [these guidelines](https://arrow.apache.org/docs/developers/cpp/development.html) for development.
 
 ## Build Hustle


### PR DESCRIPTION
### Summary

Changing the cache version in the circleci config, since we are using the latest arrow release version in the install arrow script now, https://github.com/UWHustle/hustle/blob/master/install_arrow.sh#L5