### PR TITLE
Select Operator - simplification and re-organization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-            keys: my-cache-v1
+            keys: my-cache-v2
       - run: ./install_requirements.sh
       - run: ./install_arrow.sh
       - save_cache:
-            key: my-cache-v1
+            key: my-cache-v2
             paths:
               - arrow
               - cmake-3.15.5

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then use cmake to build Hustle:
 ```
 mkdir build
 cd build
-cmake -D CMAKE_BUILD_TYPE=DEBUG .. 
+cmake -D CMAKE_BUILD_TYPE=RELEASE .. 
 make -j<number of cores>
 ```
 

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -204,8 +204,8 @@ void SSB::q11() {
 
   ////////////////////////////////////////////////////////////////////////////
 
-  Select lo_select_op(0, lo_result_in, lo_select_result_out, lo_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select lo_select_op(0, lo, lo_result_in, lo_select_result_out, lo_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out};
 
@@ -282,8 +282,8 @@ void SSB::q12() {
 
   ////////////////////////////////////////////////////////////////////////////
 
-  Select lo_select_op(0, lo_result_in, lo_select_result_out, lo_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select lo_select_op(0, lo, lo_result_in, lo_select_result_out, lo_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out};
 
@@ -373,8 +373,8 @@ void SSB::q13() {
 
   ////////////////////////////////////////////////////////////////////////////
 
-  Select lo_select_op(0, lo_result_in, lo_select_result_out, lo_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select lo_select_op(0, lo, lo_result_in, lo_select_result_out, lo_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out};
 
@@ -446,8 +446,8 @@ void SSB::q21() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     p_select_result_out, s_select_result_out};
@@ -542,8 +542,8 @@ void SSB::q22() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     p_select_result_out, s_select_result_out};
@@ -614,8 +614,8 @@ void SSB::q23() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     p_select_result_out, s_select_result_out};
@@ -697,9 +697,9 @@ void SSB::q31() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     s_select_result_out, c_select_result_out};
@@ -785,9 +785,9 @@ void SSB::q32() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     s_select_result_out, c_select_result_out};
@@ -897,9 +897,9 @@ void SSB::q33() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     s_select_result_out, c_select_result_out};
@@ -1007,9 +1007,9 @@ void SSB::q34() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     s_select_result_out, c_select_result_out};
@@ -1103,9 +1103,9 @@ void SSB::q41() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     p_select_result_out, s_select_result_out,
@@ -1210,10 +1210,10 @@ void SSB::q42() {
 
   lo_select_result_out->append(lo);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     p_select_result_out, s_select_result_out,
@@ -1313,10 +1313,10 @@ void SSB::q43() {
 
   lo_select_result_out->append(lo);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out,
                     p_select_result_out, s_select_result_out,

--- a/src/benchmark/ssb_workload_lip.cc
+++ b/src/benchmark/ssb_workload_lip.cc
@@ -70,8 +70,8 @@ void SSB::q11_lip() {
 
   ////////////////////////////////////////////////////////////////////////////
 
-  Select lo_select_op(0, lo_result_in, lo_select_result_out, lo_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select lo_select_op(0, lo, lo_result_in, lo_select_result_out, lo_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out};
 
@@ -173,8 +173,8 @@ void SSB::q12_lip() {
 
   ////////////////////////////////////////////////////////////////////////////
 
-  Select lo_select_op(0, lo_result_in, lo_select_result_out, lo_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select lo_select_op(0, lo, lo_result_in, lo_select_result_out, lo_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out};
 
@@ -289,8 +289,8 @@ void SSB::q13_lip() {
 
   ////////////////////////////////////////////////////////////////////////////
 
-  Select lo_select_op(0, lo_result_in, lo_select_result_out, lo_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select lo_select_op(0, lo, lo_result_in, lo_select_result_out, lo_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   join_result_in = {lo_select_result_out, d_select_result_out};
 
@@ -366,8 +366,8 @@ void SSB::q21_lip() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    p_select_result_out, s_select_result_out};
@@ -452,8 +452,8 @@ void SSB::q22_lip() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    p_select_result_out, s_select_result_out};
@@ -528,8 +528,8 @@ void SSB::q23_lip() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    p_select_result_out, s_select_result_out};
@@ -622,9 +622,9 @@ void SSB::q31_lip() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    s_select_result_out, c_select_result_out};
@@ -723,9 +723,9 @@ void SSB::q32_lip() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    s_select_result_out, c_select_result_out};
@@ -848,9 +848,9 @@ void SSB::q33_lip() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    s_select_result_out, c_select_result_out};
@@ -964,9 +964,9 @@ void SSB::q34_lip() {
 
   lo_select_result_out->append(lo);
 
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    s_select_result_out, c_select_result_out};
@@ -1064,9 +1064,9 @@ void SSB::q41_lip() {
   lo_select_result_out->append(lo);
   d_select_result_out->append(d);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    p_select_result_out, s_select_result_out,
@@ -1182,10 +1182,10 @@ void SSB::q42_lip() {
 
   lo_select_result_out->append(lo);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    p_select_result_out, s_select_result_out,
@@ -1294,10 +1294,10 @@ void SSB::q43_lip() {
 
   lo_select_result_out->append(lo);
 
-  Select p_select_op(0, p_result_in, p_select_result_out, p_pred_tree);
-  Select s_select_op(0, s_result_in, s_select_result_out, s_pred_tree);
-  Select c_select_op(0, c_result_in, c_select_result_out, c_pred_tree);
-  Select d_select_op(0, d_result_in, d_select_result_out, d_pred_tree);
+  Select p_select_op(0, p, p_result_in, p_select_result_out, p_pred_tree);
+  Select s_select_op(0, s, s_result_in, s_select_result_out, s_pred_tree);
+  Select c_select_op(0, c, c_result_in, c_select_result_out, c_pred_tree);
+  Select d_select_op(0, d, d_result_in, d_select_result_out, d_pred_tree);
 
   lip_result_in = {lo_select_result_out, d_select_result_out,
                    p_select_result_out, s_select_result_out,

--- a/src/operators/select.cc
+++ b/src/operators/select.cc
@@ -20,100 +20,92 @@
 #include <arrow/api.h>
 #include <arrow/compute/api.h>
 
-#include <iostream>
+#include <algorithm>
+#include <climits>
+#include <cmath>
 #include <utility>
 
+#include "storage/table.h"
 #include "storage/util.h"
+#include "utils/bit_utils.h"
 
 namespace hustle {
 namespace operators {
 
-void pack(int64_t length, const uint8_t *arr,
-          std::shared_ptr<arrow::BooleanArray> *out) {
-  auto packed = std::static_pointer_cast<arrow::BooleanArray>(
-      arrow::MakeArrayFromScalar(arrow::BooleanScalar(false), length)
-          .ValueOrDie());
-
-  uint8_t *packed_arr = packed->values()->mutable_data();
-
-  uint8_t current_byte;
-  const uint8_t *src_byte = arr;
-  uint8_t *dst_byte = packed_arr;
-
-  int64_t remaining_bytes = length / 8;
-  while (remaining_bytes-- > 0) {
-    current_byte = 0u;
-    current_byte = *src_byte++ ? current_byte | 0x01u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x02u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x04u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x08u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x10u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x20u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x40u : current_byte;
-    current_byte = *src_byte++ ? current_byte | 0x80u : current_byte;
-    *dst_byte++ = current_byte;
-  }
-
-  int64_t remaining_bits = length % 8;
-  if (remaining_bits) {
-    current_byte = 0;
-    uint8_t bit_mask = 0x01;
-    while (remaining_bits-- > 0) {
-      current_byte = *src_byte++ ? current_byte | bit_mask : current_byte;
-      bit_mask = bit_mask << 1u;
-    }
-    *dst_byte++ = current_byte;
-  }
-
-  *out = packed;
-}
-
-Select::Select(const std::size_t query_id,
+Select::Select(const std::size_t query_id, std::shared_ptr<Table> table,
                std::shared_ptr<OperatorResult> prev_result,
                std::shared_ptr<OperatorResult> output_result,
                std::shared_ptr<PredicateTree> tree)
-    : Operator(query_id) {
-  output_result_ = output_result;
-  tree_ = tree;
-
-  auto node = tree_->root_;
-
-  // We can figure out which table we are performing the selection on if we
-  // look at the LHS of one of the leaf nodes.
-  while (!node->is_leaf()) {
-    node = node->left_child_;
-  }
-  table_ = node->predicate_->col_ref_.table;
+    : Operator(query_id),
+      table_(table),
+      output_result_(output_result),
+      tree_(tree) {
+  filters_.resize(table_->get_num_blocks());
 }
 
-arrow::Datum Select::get_filter(const std::shared_ptr<Node> &node,
-                                const std::shared_ptr<Block> &block) {
-  arrow::Status status;
+void Select::execute(Task *ctx) {
+  ctx->spawnTask(CreateTaskChain(
+      // Task 1: perform selection on all blocks
+      CreateLambdaTask([this](Task *internal) {
+        table_->ForEachBatch([&](auto batch_index, auto batch_size) {
+          internal->spawnLambdaTask([this, batch_index, batch_size]() {
+            size_t base_index = batch_index * batch_size;
+            size_t batch_limit =
+                std::min((base_index + batch_size), table_->get_num_blocks());
+            for (size_t block_index = base_index; block_index < batch_limit;
+                 block_index++) {
+              this->ExecuteBlock(block_index);
+            }
+          });
+        });
+      }),
+      // Task 2: create the output result
+      CreateLambdaTask([this](Task *internal) {
+        auto chunked_filter = std::make_shared<arrow::ChunkedArray>(filters_);
+        auto lazy_table = std::make_shared<LazyTable>(
+            table_, chunked_filter, arrow::Datum(), arrow::Datum());
+        output_result_->append(lazy_table);
+      })));
+}
 
+void Select::ExecuteBlock(int block_index) {
+  auto block = table_->get_block(block_index);
+
+  std::shared_ptr<arrow::Buffer> filter_buffer;
+  auto status =
+      arrow::AllocateBitmap(block->get_num_rows()).Value(&filter_buffer);
+  evaluate_status(status, __FUNCTION__, __LINE__);
+
+  auto block_filter = this->Filter(block, tree_->root_);
+  filters_[block_index] = block_filter.make_array();
+}
+
+arrow::Datum Select::Filter(const std::shared_ptr<Block> &block,
+                            const std::shared_ptr<Node> &node) {
+  arrow::Status status;
   if (node->is_leaf()) {
-    return get_filter(node->predicate_, block);
+    return Filter(block, node->predicate_);
   }
 
-  auto left_child_filter = get_filter(node->left_child_, block);
-  auto right_child_filter = get_filter(node->right_child_, block);
+  auto left_child_filter = Filter(block, node->left_child_);
+  auto right_child_filter = Filter(block, node->right_child_);
   arrow::Datum block_filter;
 
   auto left_data = left_child_filter.array()->GetMutableValues<uint8_t>(1);
   auto right_data = right_child_filter.array()->GetValues<uint8_t>(1);
 
-  auto num_bits = left_child_filter.length();
-  auto num_bytes = num_bits / 8;
-  if (num_bits % 8 > 0) ++num_bytes;
-
+  auto num_bytes = 1 + ((left_child_filter.length() - 1) / CHAR_BIT);
   switch (node->connective_) {
     case AND: {
-      for (int i = 0; i < num_bytes; ++i)
+      for (int i = 0; i < num_bytes; ++i) {
         left_data[i] = left_data[i] & right_data[i];
+      }
       break;
     }
     case OR: {
-      for (int i = 0; i < num_bytes; ++i)
+      for (int i = 0; i < num_bytes; ++i) {
         left_data[i] = left_data[i] | right_data[i];
+      }
       break;
     }
     case NONE: {
@@ -123,73 +115,8 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Node> &node,
   return left_child_filter;
 }
 
-template <typename Functor>
-void Select::for_each_batch(int batch_size, int num_batches,
-                            std::shared_ptr<arrow::ArrayVector> filter_vector,
-                            const Functor &functor) {
-  for (int batch_i = 0; batch_i < num_batches; batch_i++) {
-    functor(filter_vector, batch_i, batch_size);
-  }
-}
-
-void Select::execute(Task *ctx) {
-  auto filter_vector = std::make_shared<arrow::ArrayVector>();
-  filter_vector->resize(table_->get_num_blocks());
-  filters_.resize(table_->get_num_blocks());
-  filter_exists_.resize(table_->get_num_blocks());
-
-  ctx->spawnTask(CreateTaskChain(
-      // Task 1: perform selection on all blocks
-      CreateLambdaTask([this, filter_vector](Task *internal) {
-        int batch_size =
-            table_->get_num_blocks() / std::thread::hardware_concurrency();
-        if (batch_size == 0) batch_size = table_->get_num_blocks();
-        int num_batches = table_->get_num_blocks() / batch_size +
-                          1;  // if num_chunks is a multiple of batch_size, we
-                              // don't actually want the +1
-        if (num_batches == 0) num_batches = 1;
-
-        auto batch_functor = [&](auto filter_vector, auto batch_i,
-                                 auto batch_size) {
-          internal->spawnLambdaTask([this, filter_vector, batch_i,
-                                     batch_size]() {
-            int base_i = batch_i * batch_size;
-            for (int i = base_i;
-                 i < base_i + batch_size && i < table_->get_num_blocks(); i++) {
-              execute_block(*filter_vector, i);
-            }
-          });
-        };
-
-        for_each_batch(batch_size, num_batches, filter_vector, batch_functor);
-      }),
-      // Task 2: create the output result
-      CreateLambdaTask([this, filter_vector](Task *internal) {
-        finish(filter_vector, internal);
-      })));
-}
-
-void Select::execute_block(arrow::ArrayVector &filter_vector, int i) {
-  auto block = table_->get_block(i);
-
-  std::shared_ptr<arrow::Buffer> filter_buffer;
-  auto status =
-      arrow::AllocateBitmap(block->get_num_rows()).Value(&filter_buffer);
-  evaluate_status(status, __FUNCTION__, __LINE__);
-
-  auto block_filter = this->get_filter(tree_->root_, block);
-  filters_[i] = block_filter.make_array();
-}
-
-void Select::finish(std::shared_ptr<arrow::ArrayVector> filter_vector,
-                    Task *ctx) {
-  auto chunked_filter = std::make_shared<arrow::ChunkedArray>(filters_);
-  LazyTable lazy_table(table_, chunked_filter, arrow::Datum(), arrow::Datum());
-  output_result_->append(lazy_table);
-}
-
-arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
-                                const std::shared_ptr<Block> &block) {
+arrow::Datum Select::Filter(const std::shared_ptr<Block> &block,
+                            const std::shared_ptr<Predicate> &predicate) {
   switch (predicate->value_.type()->id()) {
     case arrow::Type::UINT8: {
       uint8_t val = std::static_pointer_cast<arrow::UInt8Scalar>(
@@ -198,24 +125,23 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
 
       switch (predicate->comparator_) {
         case arrow::compute::CompareOperator::LESS: {
-          auto f = [](uint8_t x, uint8_t y) -> bool { return x < y; };
-          return get_filter<uint8_t>(predicate->col_ref_, f, val, block);
+          return Filter<uint8_t>(block, predicate->col_ref_, val, std::less());
         }
         case arrow::compute::CompareOperator::LESS_EQUAL: {
-          auto f = [](uint8_t x, uint8_t y) -> bool { return x <= y; };
-          return get_filter<uint8_t>(predicate->col_ref_, f, val, block);
+          return Filter<uint8_t>(block, predicate->col_ref_, val,
+                                 std::less_equal());
         }
         case arrow::compute::CompareOperator::GREATER: {
-          auto f = [](uint8_t x, uint8_t y) -> bool { return x > y; };
-          return get_filter<uint8_t>(predicate->col_ref_, f, val, block);
+          return Filter<uint8_t>(block, predicate->col_ref_, val,
+                                 std::greater());
         }
         case arrow::compute::CompareOperator::GREATER_EQUAL: {
-          auto f = [](uint8_t x, uint8_t y) -> bool { return x >= y; };
-          return get_filter<uint8_t>(predicate->col_ref_, f, val, block);
+          return Filter<uint8_t>(block, predicate->col_ref_, val,
+                                 std::greater_equal());
         }
         case arrow::compute::CompareOperator::EQUAL: {
-          auto f = [](uint8_t x, uint8_t y) -> bool { return x == y; };
-          return get_filter<uint8_t>(predicate->col_ref_, f, val, block);
+          return Filter<uint8_t>(block, predicate->col_ref_, val,
+                                 std::equal_to());
         }
         // TODO(nicholas): placeholder for BETWEEN
         case arrow::compute::CompareOperator::NOT_EQUAL: {
@@ -241,17 +167,13 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
           auto f = [](uint8_t val, uint8_t diff) -> bool {
             return val <= diff;
           };
-
           for (uint32_t i = 0; i < num_rows; ++i) {
             bytemap[i] = f(col_data[i] - lo, diff);
           }
 
           std::shared_ptr<arrow::BooleanArray> out_filter;
-          pack(num_rows, bytemap, &out_filter);
+          utils::pack(num_rows, bytemap, &out_filter);
           return out_filter;
-          //                    return
-          //                    arrow::Datum(arrow::MakeArray(arrow::ArrayData::Make(arrow::uint8(),
-          //                    num_rows, {nullptr, buffer})));
         }
         default: {
           std::cerr << "No support for comparator" << std::endl;
@@ -266,23 +188,27 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
 
       switch (predicate->comparator_) {
         case arrow::compute::CompareOperator::LESS: {
-          return get_filter<int64_t>(predicate->col_ref_, std::less(), val,
-                                     block);
+          return Filter<int64_t>(block, predicate->col_ref_, val, std::less());
           break;
         }
         case arrow::compute::CompareOperator::LESS_EQUAL: {
-          std::less_equal op;
-          return get_filter<int64_t>(predicate->col_ref_, op, val, block);
+          return Filter<int64_t>(block, predicate->col_ref_, val,
+                                 std::less_equal());
+          break;
+        }
+        case arrow::compute::CompareOperator::GREATER: {
+          return Filter<int64_t>(block, predicate->col_ref_, val,
+                                 std::greater());
           break;
         }
         case arrow::compute::CompareOperator::GREATER_EQUAL: {
-          std::greater_equal op;
-          return get_filter<int64_t>(predicate->col_ref_, op, val, block);
+          return Filter<int64_t>(block, predicate->col_ref_, val,
+                                 std::greater_equal());
           break;
         }
         case arrow::compute::CompareOperator::EQUAL: {
-          std::equal_to op;
-          return get_filter<int64_t>(predicate->col_ref_, op, val, block);
+          return Filter<int64_t>(block, predicate->col_ref_, val,
+                                 std::equal_to());
           break;
         }
         case arrow::compute::CompareOperator::NOT_EQUAL: {
@@ -303,22 +229,19 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
           std::shared_ptr<arrow::Buffer> buffer;
           auto status = arrow::AllocateBuffer(num_rows).Value(&buffer);
           evaluate_status(status, __FUNCTION__, __LINE__);
-          auto bytemap = buffer->mutable_data();
 
           auto f = [](int64_t val, int64_t diff) -> bool {
             return val <= diff;
           };
 
+          auto bytemap = buffer->mutable_data();
           for (uint32_t i = 0; i < num_rows; ++i) {
             bytemap[i] = f(col_data[i] - lo, diff);
           }
 
           std::shared_ptr<arrow::BooleanArray> out_filter;
-          pack(num_rows, bytemap, &out_filter);
+          utils::pack(num_rows, bytemap, &out_filter);
           return out_filter;
-          //                    return
-          //                    arrow::Datum(arrow::MakeArray(arrow::ArrayData::Make(arrow::uint8(),
-          //                    num_rows, {nullptr, buffer})));
         }
         default: {
           std::cerr << "No supprt for comparator" << std::endl;
@@ -328,17 +251,6 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
     }
 
     default: {
-      //            auto val =
-      //            std::static_pointer_cast<arrow::StringScalar>(predicate->value_.scalar())->value->ToString();
-      //
-      //            auto f = [](uint8_t* x, uint8_t y, uint32_t num_bytes) {
-      //                for (int i=0; i<num_bytes; ++i) {
-      //
-      //                }
-      //            };
-      //
-      //            return get_filter_str(predicate->col_ref_, f, val, block);
-
       arrow::Status status;
       arrow::compute::CompareOptions compare_options(predicate->comparator_);
       arrow::Datum block_filter;
@@ -357,9 +269,9 @@ arrow::Datum Select::get_filter(const std::shared_ptr<Predicate> &predicate,
 }
 
 template <typename T, typename Op>
-arrow::Datum Select::get_filter(const ColumnReference &col_ref, Op comparator,
-                                const T &value,
-                                const std::shared_ptr<Block> &block) {
+arrow::Datum Select::Filter(const std::shared_ptr<Block> &block,
+                            const ColumnReference &col_ref, const T &value,
+                            Op comparator) {
   arrow::Datum block_filter;
   auto num_rows = block->get_num_rows();
   auto col_data =
@@ -368,51 +280,15 @@ arrow::Datum Select::get_filter(const ColumnReference &col_ref, Op comparator,
   std::shared_ptr<arrow::Buffer> buffer;
   auto status = arrow::AllocateBuffer(num_rows).Value(&buffer);
   evaluate_status(status, __FUNCTION__, __LINE__);
-  auto bytemap = buffer->mutable_data();
 
+  auto bytemap = buffer->mutable_data();
   for (uint32_t i = 0; i < num_rows; ++i) {
     bytemap[i] = comparator(col_data[i], value);
   }
 
   std::shared_ptr<arrow::BooleanArray> out_filter;
-  pack(num_rows, bytemap, &out_filter);
+  utils::pack(num_rows, bytemap, &out_filter);
   return out_filter;
-  //    return
-  //    arrow::Datum(arrow::MakeArray(arrow::ArrayData::Make(arrow::uint8(),
-  //    num_rows, {nullptr, buffer})));
-}
-
-template <typename Op>
-arrow::Datum Select::get_filter_str(const ColumnReference &col_ref,
-                                    Op comparator, const std::string &value,
-                                    const std::shared_ptr<Block> &block) {
-  arrow::Datum block_filter;
-  auto num_rows = block->get_num_rows();
-  auto col_data = block->get_column_by_name(col_ref.col_name)
-                      ->data()
-                      ->GetValues<uint8_t>(2);
-  auto col_offsets = block->get_column_by_name(col_ref.col_name)
-                         ->data()
-                         ->GetValues<uint32_t>(1);
-
-  auto col_data_str = std::static_pointer_cast<arrow::StringArray>(
-      block->get_column_by_name(col_ref.col_name));
-
-  std::shared_ptr<arrow::Buffer> buffer;
-  auto status = arrow::AllocateBuffer(num_rows).Value(&buffer);
-  evaluate_status(status, __FUNCTION__, __LINE__);
-  auto bytemap = buffer->mutable_data();
-  for (uint32_t i = 0; i < num_rows; ++i) {
-    //        bytemap[i] = std::memcmp(value.c_str(), &col_data[col_offsets[i]],
-    //        value.length()); bytemap[i] = std::memcmp(value.c_str(),
-    //        &col_data[col_offsets[i]], value.length());
-    auto y = col_data_str->GetString(i);
-    auto out = std::strcmp(value.c_str(), col_data_str->GetString(i).c_str());
-    bytemap[i] = value == y;
-  }
-
-  return arrow::Datum(arrow::MakeArray(
-      arrow::ArrayData::Make(arrow::uint8(), num_rows, {nullptr, buffer})));
 }
 
 }  // namespace operators

--- a/src/operators/select.h
+++ b/src/operators/select.h
@@ -30,9 +30,6 @@
 #include "storage/block.h"
 #include "storage/table.h"
 
-// Bitmask selecting the k-th bit in a byte
-static constexpr uint8_t kBitmask[] = {1, 2, 4, 8, 16, 32, 64, 128};
-
 namespace hustle::operators {
 
 /**
@@ -51,7 +48,7 @@ class Select : public Operator {
    * @param prev_result OperatorResult from an upstream operator
    * @param tree predicate tree
    */
-  Select(const std::size_t query_id,
+  Select(const std::size_t query_id, std::shared_ptr<Table> table,
          std::shared_ptr<OperatorResult> prev_result,
          std::shared_ptr<OperatorResult> output_result,
          std::shared_ptr<PredicateTree> tree);
@@ -65,63 +62,47 @@ class Select : public Operator {
   void execute(Task *ctx) override;
 
  private:
-  std::shared_ptr<PredicateTree> tree_;
-  std::shared_ptr<OperatorResult> output_result_;
   std::shared_ptr<Table> table_;
+  std::shared_ptr<OperatorResult> output_result_;
+  std::shared_ptr<PredicateTree> tree_;
   arrow::ArrayVector filters_;
-  std::vector<bool> filter_exists_;
 
-  std::unordered_map<std::string, arrow::ArrayVector> select_col_map;
+  void ExecuteBlock(int block_index);
+
   /**
    * Perform the selection specified by a node in the predicate tree on
    * one block of the table. If the node is a not a leaf node, this
    * function will be recursively called on its children. The nodes of the
    * predicate tree are visited using inorder traversal.
    *
-   * @param node A node of the predicate tree.
    * @param block A block of the table
+   * @param node A node of the predicate tree.
    *
    * @return A filter corresponding to values that satisfy the node's
    * selection predicate(s)
    */
-  arrow::Datum get_filter(const std::shared_ptr<Node> &node,
-                          const std::shared_ptr<Block> &block);
+  arrow::Datum Filter(const std::shared_ptr<Block> &block,
+                      const std::shared_ptr<Node> &node);
 
   /**
    * Perform the selection specified by a predicate (i.e. leaf node) in the
    * predicate tree on one block of the table. This is the base function
    * call of the other get_filter() function.
    *
+   * @param block A block of the table
    * @param predicate A predicate from one of the leaf nodes of the
    * predicate tree.
-   * @param block A block of the table
    *
    * @return A filter corresponding to values that satisfy the node's
    * selection predicate(s)
    */
-  arrow::Datum get_filter(const std::shared_ptr<Predicate> &predicate,
-                          const std::shared_ptr<Block> &block);
-
-  /**
-   * Create the output result from the raw data computed during execution.
-   */
-  void finish(std::shared_ptr<arrow::ArrayVector> filter_vector, Task *ctx);
-
-  void execute_block(arrow::ArrayVector &filter_vector, int i);
-
-  template <typename Functor>
-  void for_each_batch(int batch_size, int num_batches,
-                      std::shared_ptr<arrow::ArrayVector> filter_vector,
-                      const Functor &functor);
+  arrow::Datum Filter(const std::shared_ptr<Block> &block,
+                      const std::shared_ptr<Predicate> &predicate);
 
   template <typename T, typename Op>
-  arrow::Datum get_filter(const ColumnReference &col_ref, Op comparator,
-                          const T &value, const std::shared_ptr<Block> &block);
-
-  template <typename Op>
-  arrow::Datum get_filter_str(const ColumnReference &col_ref, Op comparator,
-                              const std::string &value,
-                              const std::shared_ptr<Block> &block);
+  arrow::Datum Filter(const std::shared_ptr<Block> &block,
+                      const ColumnReference &col_ref, const T &value,
+                      Op comparator);
 };
 
 }  // namespace hustle::operators

--- a/src/operators/tests/select_test.cc
+++ b/src/operators/tests/select_test.cc
@@ -108,7 +108,7 @@ TEST_F(SelectTestFixture, SingleSelectTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  Select select_op(0, result, out_result, select_pred_tree);
+  Select select_op(0, R, result, out_result, select_pred_tree);
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
 
@@ -178,7 +178,7 @@ TEST_F(SelectTestFixture, AndSelectTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  Select select_op(0, result, out_result, select_pred_tree);
+  Select select_op(0, R, result, out_result, select_pred_tree);
   Scheduler &scheduler = Scheduler::GlobalInstance();
 
   scheduler.addTask(select_op.createTask());
@@ -247,7 +247,7 @@ TEST_F(SelectTestFixture, OrSelectTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  Select select_op(0, result, out_result, select_pred_tree);
+  Select select_op(0, R, result, out_result, select_pred_tree);
   Scheduler &scheduler = Scheduler::GlobalInstance();
 
   scheduler.addTask(select_op.createTask());
@@ -301,7 +301,7 @@ TEST_F(SelectTestFixture, SingleSelectManyBlocksTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  Select select_op(0, result, out_result, select_pred_tree);
+  Select select_op(0, R, result, out_result, select_pred_tree);
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
 
@@ -371,7 +371,7 @@ TEST_F(SelectTestFixture, AndSelectManyBlocksTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  Select select_op(0, result, out_result, select_pred_tree);
+  Select select_op(0, R, result, out_result, select_pred_tree);
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
 

--- a/src/operators/utils/operator_result.cc
+++ b/src/operators/utils/operator_result.cc
@@ -45,6 +45,10 @@ void OperatorResult::append(LazyTable lazy_table) {
   lazy_tables_.insert(lazy_tables_.begin(), lazy_table);
 }
 
+void OperatorResult::append(std::shared_ptr<LazyTable> lazy_table) {
+  lazy_tables_.insert(lazy_tables_.begin(), *lazy_table);
+}
+
 void OperatorResult::append(const std::shared_ptr<OperatorResult>& result) {
   for (auto& lazy_table : result->lazy_tables_) {
     lazy_tables_.push_back(lazy_table);

--- a/src/operators/utils/operator_result.h
+++ b/src/operators/utils/operator_result.h
@@ -67,6 +67,12 @@ class OperatorResult {
   void append(LazyTable lazy_table);
 
   /**
+   * Append a new lazy table to the OperatorResult.
+   * @param table Shared pointer to the lazy table to append
+   */
+  void append(std::shared_ptr<LazyTable> lazy_table);
+
+  /**
    * Append another OperatorResult to this OperatorResult.
    *
    * @param result Another OperatorResult

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -130,7 +130,7 @@ void Table::mark_block_for_insert(const std::shared_ptr<Block> &block) {
 
 std::shared_ptr<arrow::Schema> Table::get_schema() const { return schema; }
 
-int Table::get_num_blocks() const { return blocks.size(); }
+size_t Table::get_num_blocks() const { return blocks.size(); }
 
 void Table::print() {
   if (blocks.empty()) {

--- a/src/storage/util.cc
+++ b/src/storage/util.cc
@@ -27,8 +27,8 @@
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
-#include "storage/block.h"
 #include "scheduler/scheduler.h"
+#include "storage/block.h"
 #include "storage/table.h"
 
 void evaluate_status(const arrow::Status& status, const char* function_name,

--- a/src/utils/bit_utils.h
+++ b/src/utils/bit_utils.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_BIT_UTILS_H
+#define HUSTLE_BIT_UTILS_H
+
+#include <arrow/api.h>
+
+#include <memory>
+
+namespace hustle {
+namespace utils {
+
+void pack(int64_t length, const uint8_t *arr,
+          std::shared_ptr<arrow::BooleanArray> *out) {
+  auto packed = std::static_pointer_cast<arrow::BooleanArray>(
+      arrow::MakeArrayFromScalar(arrow::BooleanScalar(false), length)
+          .ValueOrDie());
+
+  uint8_t *packed_arr = packed->values()->mutable_data();
+  uint8_t current_byte;
+
+  const uint8_t *src_byte = arr;
+  uint8_t *dst_byte = packed_arr;
+
+  int64_t remaining_bytes = length / 8;
+  while (remaining_bytes-- > 0) {
+    current_byte = 0u;
+    current_byte = *src_byte++ ? current_byte | 0x01u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x02u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x04u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x08u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x10u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x20u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x40u : current_byte;
+    current_byte = *src_byte++ ? current_byte | 0x80u : current_byte;
+    *dst_byte++ = current_byte;
+  }
+
+  int64_t remaining_bits = length % 8;
+  if (remaining_bits) {
+    current_byte = 0;
+    uint8_t bit_mask = 0x01;
+    while (remaining_bits-- > 0) {
+      current_byte = *src_byte++ ? current_byte | bit_mask : current_byte;
+      bit_mask = bit_mask << 1u;
+    }
+    *dst_byte++ = current_byte;
+  }
+
+  *out = packed;
+}
+
+}  // namespace utils
+}  // namespace hustle
+
+#endif  // HUSTLE_BIT_UTILS_H


### PR DESCRIPTION
### Summary

In this PR re-organized the select operator by moving some functionalities to other modules, simplified some logic and some refactoring and re-organization.


### Change Details
* Simple Select operator interface - earlier the select operator infers the table based on the predicate tree. In this PR, made the table as explicit in input to the operators, as the inference of the table should be handled outside the operator.
* Moved some functionalities to storage and util modules.
* Improved the naming of the functions to C++ style guide.
* Removed unused variables and code sections.
* Updated Readme to build the release version.

Main changes can be found in this file: **src/operators/select.cc**

### Test
* Ran the unit tests - `ctest --output-on-failure`
* Ran the SSB benchmark for the scale factor 1 input and cross-checked the performance and the aggregated output for correctness.

