### PR TITLE
Aggregate Operator - simplification and re-organization

### DIFF
--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -213,7 +213,7 @@ void SSB::q11() {
   JoinGraph graph({{join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////
@@ -294,7 +294,7 @@ void SSB::q12() {
 
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////
@@ -385,7 +385,7 @@ void SSB::q13() {
 
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////
@@ -455,7 +455,7 @@ void SSB::q21() {
   JoinGraph graph({{s_join_pred, p_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
 
@@ -551,7 +551,7 @@ void SSB::q22() {
   JoinGraph graph({{s_join_pred, p_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
 
@@ -623,7 +623,7 @@ void SSB::q23() {
   JoinGraph graph({{s_join_pred, p_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
 
@@ -707,7 +707,7 @@ void SSB::q31() {
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_nation_ref, s_nation_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -795,7 +795,7 @@ void SSB::q32() {
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -907,7 +907,7 @@ void SSB::q33() {
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -1017,7 +1017,7 @@ void SSB::q34() {
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -1114,7 +1114,7 @@ void SSB::q41() {
   JoinGraph graph({{s_join_pred, c_join_pred, p_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_nation_ref}, {d_year_ref, c_nation_ref});
 
@@ -1222,7 +1222,7 @@ void SSB::q42() {
   JoinGraph graph({{s_join_pred, c_join_pred, p_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, s_nation_ref, p_category_ref},
                    {d_year_ref, s_nation_ref, p_category_ref});
@@ -1325,7 +1325,7 @@ void SSB::q43() {
   JoinGraph graph({{s_join_pred, c_join_pred, p_join_pred, d_join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, s_city_ref, p_brand1_ref},
                    {d_year_ref, s_city_ref, p_brand1_ref});

--- a/src/benchmark/ssb_workload_lip.cc
+++ b/src/benchmark/ssb_workload_lip.cc
@@ -80,7 +80,7 @@ void SSB::q11_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////
@@ -186,7 +186,7 @@ void SSB::q12_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////
@@ -302,7 +302,7 @@ void SSB::q13_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////
@@ -376,7 +376,7 @@ void SSB::q21_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
 
@@ -462,7 +462,7 @@ void SSB::q22_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
 
@@ -538,7 +538,7 @@ void SSB::q23_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
 
@@ -633,7 +633,7 @@ void SSB::q31_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_nation_ref, s_nation_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -734,7 +734,7 @@ void SSB::q32_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -859,7 +859,7 @@ void SSB::q33_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -975,7 +975,7 @@ void SSB::q34_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
                    {d_year_ref, {nullptr, "revenue"}});
@@ -1076,7 +1076,7 @@ void SSB::q41_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_nation_ref}, {d_year_ref, c_nation_ref});
 
@@ -1195,7 +1195,7 @@ void SSB::q42_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, s_nation_ref, p_category_ref},
                    {d_year_ref, s_nation_ref, p_category_ref});
@@ -1307,7 +1307,7 @@ void SSB::q43_lip() {
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
   Join join_op(0, {lip_result_out}, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, s_city_ref, p_brand1_ref},
                    {d_year_ref, s_city_ref, p_brand1_ref});

--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -25,28 +25,161 @@
 
 #include "storage/util.h"
 
+#define AGGREGATE_OUTPUT_TABLE "aggregate"
+
 namespace hustle::operators {
 
 Aggregate::Aggregate(const std::size_t query_id,
                      std::shared_ptr<OperatorResult> prev_result,
                      std::shared_ptr<OperatorResult> output_result,
                      std::vector<AggregateReference> aggregate_refs,
-                     std::vector<ColumnReference> group_refs,
+                     std::vector<ColumnReference> group_by_refs,
                      std::vector<ColumnReference> order_by_refs)
-    : Operator(query_id) {
-  prev_result_ = std::move(prev_result);
-  output_result_ = std::move(output_result);
-  aggregate_refs_ = std::move(aggregate_refs);
+    : Operator(query_id),
+      prev_result_(prev_result),
+      output_result_(output_result),
+      aggregate_refs_(aggregate_refs),
+      group_by_refs_(group_by_refs),
+      order_by_refs_(order_by_refs) {}
 
-  group_by_refs_ = std::move(group_refs);
-  order_by_refs_ = std::move(order_by_refs);
+void Aggregate::execute(Task* ctx) {
+  ctx->spawnTask(CreateTaskChain(
+      CreateLambdaTask([this](Task* internal) { Initialize(internal); }),
+      CreateLambdaTask([this](Task* internal) { ComputeAggregates(internal); }),
+      CreateLambdaTask([this](Task* internal) { Finish(); })));
+}
+
+void Aggregate::Initialize(Task* ctx) {
+  std::vector<std::shared_ptr<Context>> contexts;
+  contexts.reserve(group_by_refs_.size());
+  for (std::size_t i = 0; i < group_by_refs_.size(); ++i) {
+    contexts.push_back(std::make_shared<Context>());
+  }
+
+  ctx->spawnTask(CreateTaskChain(
+      CreateLambdaTask(
+          [this](Task* internal) { InitializeVariables(internal); }),
+      CreateLambdaTask([this, contexts](Task* internal) {
+        // Fetch unique values for all Group By columns.
+        for (std::size_t group_index = 0; group_index < group_by_refs_.size();
+             group_index++) {
+          internal->spawnTask(CreateTaskChain(
+              CreateLambdaTask([this, group_index](Task* internal) {
+                InitializeGroupByColumn(internal, group_index);
+              }),
+              CreateLambdaTask([this, group_index] {
+                unique_values_[group_index] =
+                    ComputeUniqueValues(group_by_refs_[group_index])
+                        .make_array();
+              }),
+              CreateLambdaTask([this, group_index, contexts](Task* internal) {
+                contexts[group_index]->match(internal,
+                                             group_by_cols_[group_index],
+                                             unique_values_[group_index]);
+              }),
+              CreateLambdaTask([this, contexts, group_index] {
+                unique_values_map_[group_index] =
+                    contexts[group_index]->out_.chunked_array();
+              })));
+        }
+      })));
+}
+
+void Aggregate::InitializeVariables(Task* ctx) {
+  // Fetch the fields associated with each groupby column.
+  std::vector<std::shared_ptr<arrow::Field>> group_by_fields;
+  group_by_fields.reserve(group_by_refs_.size());
+  for (auto& group_by : group_by_refs_) {
+    group_by_fields.push_back(
+        group_by.table->get_schema()->GetFieldByName(group_by.col_name));
+  }
+
+  // Initialize a StructBuilder containing one builder for each group
+  // by column.
+  group_type_ = arrow::struct_(group_by_fields);
+  group_builder_ = std::make_shared<arrow::StructBuilder>(
+      group_type_, arrow::default_memory_pool(), CreateGroupBuilderVector());
+
+  // Initialize aggregate builder
+  aggregate_builder_ = CreateAggregateBuilder(aggregate_refs_[0].kernel);
+
+  // Initialize output table and its schema. group_type_ must be initialized
+  // beforehand.
+  std::shared_ptr<arrow::Schema> out_schema =
+      OutputSchema(aggregate_refs_[0].kernel, aggregate_refs_[0].agg_name);
+  output_table_ =
+      std::make_shared<Table>(AGGREGATE_OUTPUT_TABLE, out_schema, BLOCK_SIZE);
+
+  unique_values_.resize(group_by_refs_.size());
+  group_by_cols_.resize(group_by_refs_.size());
+
+  for (auto& group_by : group_by_refs_) {
+    group_by_tables_.push_back(prev_result_->get_table(group_by.table));
+  }
+  unique_values_map_.resize(group_by_refs_.size());
+}
+
+void Aggregate::InitializeGroupByColumn(Task* ctx, std::size_t group_index) {
+  std::scoped_lock<std::mutex> lock(mutex_);
+  group_by_index_map_.emplace(group_by_refs_[group_index].col_name,
+                              group_index);
+  group_by_tables_[group_index].get_column_by_name(
+      ctx, group_by_refs_[group_index].col_name, group_by_cols_[group_index]);
+}
+
+void Aggregate::InitializeGroupFilters(Task* ctx) {
+  if (group_type_->num_fields() == 0) {
+    return;
+  }
+
+  ctx->spawnLambdaTask([this](Task* internal) {
+    auto num_fields = group_by_cols_.size();
+
+    std::vector<arrow::Type::type> field_types;
+    field_types.reserve(num_fields);
+
+    for (std::size_t field_index = 0; field_index < num_fields; ++field_index) {
+      auto field_unique_values = unique_values_[field_index]->data();
+      field_types.push_back(field_unique_values->type->id());
+    }
+
+    auto agg_col = agg_col_.chunked_array();
+    auto num_chunks = agg_col->num_chunks();
+    aggregate_col_data_.resize(num_chunks);
+
+    for (std::size_t chunk_index = 0; chunk_index < num_chunks; ++chunk_index) {
+      aggregate_col_data_[chunk_index] =
+          agg_col->chunk(chunk_index)->data()->GetValues<int64_t>(1, 0);
+    }
+
+    std::size_t batch_size =
+        num_chunks / std::thread::hardware_concurrency() / 2;
+    if (batch_size == 0) batch_size = num_chunks;
+    std::size_t num_batches = 1 + ((num_aggs_ - 1) / batch_size);
+
+    for (std::size_t batch_index = 0; batch_index < num_batches;
+         batch_index++) {
+      // Each task gets the filter for one block and stores it in filter_vector
+      internal->spawnLambdaTask([this, num_chunks, num_fields, batch_index,
+                                 batch_size](Task* internal) {
+        std::vector<const uint32_t*> group_map;
+        group_map.resize(num_fields);
+
+        int base_index = batch_index * batch_size;
+        for (std::size_t block_index = base_index;
+             block_index < base_index + batch_size && block_index < num_chunks;
+             ++block_index) {
+          BlockScan(group_map, block_index);
+        }
+      });
+    }
+  });
 }
 
 std::vector<std::shared_ptr<arrow::ArrayBuilder>>
-Aggregate::get_group_builders() {
-  arrow::Status status;
+Aggregate::CreateGroupBuilderVector() {
   std::vector<std::shared_ptr<arrow::ArrayBuilder>> group_builders;
-  for (auto& field : group_type_->children()) {
+  for (auto& field : group_type_->fields()) {
     switch (field->type()->id()) {
       case arrow::Type::STRING: {
         group_builders.push_back(std::make_shared<arrow::StringBuilder>());
@@ -68,39 +201,35 @@ Aggregate::get_group_builders() {
       }
     }
   }
-
   return group_builders;
 }
 
-std::shared_ptr<arrow::ArrayBuilder> Aggregate::get_aggregate_builder(
-    AggregateKernels kernel) {
-  arrow::Status status;
-  std::shared_ptr<arrow::ArrayBuilder> aggreagte_builder;
-
+std::shared_ptr<arrow::ArrayBuilder> Aggregate::CreateAggregateBuilder(
+    AggregateKernel kernel) {
+  std::shared_ptr<arrow::ArrayBuilder> aggregate_builder;
   switch (kernel) {
     case SUM: {
-      aggreagte_builder = std::make_shared<arrow::Int64Builder>();
+      aggregate_builder = std::make_shared<arrow::Int64Builder>();
       break;
     }
     case MEAN: {
-      aggreagte_builder = std::make_shared<arrow::DoubleBuilder>();
+      aggregate_builder = std::make_shared<arrow::DoubleBuilder>();
       break;
     }
     case COUNT: {
       throw std::runtime_error("Count aggregate not supported.");
     }
   }
-
-  return aggreagte_builder;
+  return aggregate_builder;
 }
 
-std::shared_ptr<arrow::Schema> Aggregate::get_output_schema(
-    AggregateKernels kernel, const std::string& agg_col_name) {
+std::shared_ptr<arrow::Schema> Aggregate::OutputSchema(
+    AggregateKernel kernel, const std::string& agg_col_name) {
   arrow::Status status;
   arrow::SchemaBuilder schema_builder;
 
   if (group_type_ != nullptr) {
-    status = schema_builder.AddFields(group_type_->children());
+    status = schema_builder.AddFields(group_type_->fields());
     evaluate_status(status, __FUNCTION__, __LINE__);
   }
   switch (kernel) {
@@ -123,95 +252,48 @@ std::shared_ptr<arrow::Schema> Aggregate::get_output_schema(
 
   auto result = schema_builder.Finish();
   evaluate_status(result.status(), __FUNCTION__, __LINE__);
-
   return result.ValueOrDie();
 }
 
-void Aggregate::scan_block(std::vector<const uint32_t*>& group_map, int chunk_i,
-                           std::vector<arrow::ArrayVector>& filter_vectors) {
-  auto chunk_length = agg_col_.chunked_array()->chunk(chunk_i)->length();
-  auto num_children = group_by_refs_.size();
-  auto agg_col_chunk_data = agg_col_data_[chunk_i];
+void Aggregate::BlockScan(std::vector<const uint32_t*>& group_map,
+                          int chunk_index) {
+  auto chunk_length = agg_col_.chunked_array()->chunk(chunk_index)->length();
+  auto num_fields = group_by_refs_.size();
+  auto agg_col_chunk_data = aggregate_col_data_[chunk_index];
 
-  for (int field_i = 0; field_i < num_children; ++field_i) {
-    group_map[field_i] = uniq_val_maps_[field_i]
-                             .chunked_array()
-                             ->chunk(chunk_i)
-                             ->data()
-                             ->GetValues<uint32_t>(1, 0);
+  for (std::size_t field_index = 0; field_index < num_fields; ++field_index) {
+    group_map[field_index] = unique_values_map_[field_index]
+                                 .chunked_array()
+                                 ->chunk(chunk_index)
+                                 ->data()
+                                 ->GetValues<uint32_t>(1, 0);
   }
 
-  for (int row_j = 0; row_j < chunk_length; ++row_j) {
+  for (std::size_t row_index = 0; row_index < chunk_length; ++row_index) {
     auto key = 0;
-    for (int group_k = 0; group_k < num_children; ++group_k) {
+    for (std::size_t group_id = 0; group_id < num_fields; ++group_id) {
       // @TODO(nicholas): save time by precomputing 10^(k+1)
-      key += group_map[group_k][row_j] * pow(10, group_k);
+      key += group_map[group_id][row_index] * pow(10, group_id);
     }
 
-    auto agg_index = group_id_to_agg_index_map_[key];
-    aggregates_vec_[agg_index] += agg_col_chunk_data[row_j];
+    auto agg_index = group_agg_index_map_[key];
+    aggregate_data_[agg_index] += agg_col_chunk_data[row_index];
   }
 }
 
-void Aggregate::initialize_group_filters(Task* ctx) {
-  if (group_type_->num_children() == 0) {
-    return;
-  }
-
-  ctx->spawnLambdaTask([this](Task* internal) {
-    auto num_children = group_by_cols_.size();
-
-    std::vector<arrow::Type::type> field_types;
-    std::vector<const uint32_t*> uniq_index_maps;
-
-    for (int field_i = 0; field_i < num_children; field_i++) {
-      auto data = all_unique_values_[field_i]->data();
-      field_types.push_back(data->type->id());
-    }
-
-    auto agg_col = agg_col_.chunked_array();
-    auto num_chunks = agg_col->num_chunks();
-    agg_col_data_.resize(num_chunks);
-    for (int i = 0; i < num_chunks; ++i) {
-      agg_col_data_[i] = agg_col->chunk(i)->data()->GetValues<int64_t>(1, 0);
-    }
-
-    int batch_size = num_chunks / std::thread::hardware_concurrency() / 2;
-    if (batch_size == 0) batch_size = num_chunks;
-    int num_batches = num_chunks / batch_size +
-                      1;  // if num_chunks is a multiple of batch_size, we don't
-                          // actually want the +1
-    if (num_batches == 0) num_batches = 1;
-
-    for (int batch_i = 0; batch_i < num_batches; batch_i++) {
-      // Each task gets the filter for one block and stores it in filter_vector
-      internal->spawnLambdaTask([this, num_chunks, num_children, batch_i,
-                                 batch_size](Task* internal) {
-        std::vector<const uint32_t*> group_map;
-        group_map.resize(num_children);
-
-        int base_i = batch_i * batch_size;
-        for (int i = base_i; i < base_i + batch_size && i < num_chunks; i++) {
-          scan_block(group_map, i, filter_vectors);
-        }
-      });
-    }
-  });
-}
-
-void Aggregate::insert_group(std::vector<int> group_id, int agg_index) {
+void Aggregate::InsertGroupColumns(std::vector<int> group_id, int agg_index) {
   arrow::Status status;
   // Loop over columns in group builder, and append one of its unique values to
   // its builder.
-  for (int i = 0; i < group_type_->num_children(); ++i) {
-    switch (group_type_->child(i)->type()->id()) {
+  for (std::size_t i = 0; i < group_type_->num_fields(); ++i) {
+    switch (group_type_->field(i)->type()->id()) {
       case arrow::Type::STRING: {
         // Downcast the column's builder
         auto col_group_builder =
             (arrow::StringBuilder*)(group_builder_->child(i));
         // Downcast the column's unique_values
         auto col_unique_values =
-            std::static_pointer_cast<arrow::StringArray>(all_unique_values_[i]);
+            std::static_pointer_cast<arrow::StringArray>(unique_values_[i]);
 
         // Append one of the unique values to the column's builder.
         status = col_group_builder->Append(
@@ -225,7 +307,7 @@ void Aggregate::insert_group(std::vector<int> group_id, int agg_index) {
             (arrow::Int64Builder*)(group_builder_->child(i));
         // Downcast the column's unique_values
         auto col_unique_values =
-            std::static_pointer_cast<arrow::Int64Array>(all_unique_values_[i]);
+            std::static_pointer_cast<arrow::Int64Array>(unique_values_[i]);
 
         // Append one of the unique values to the column's builder.
         status =
@@ -235,7 +317,7 @@ void Aggregate::insert_group(std::vector<int> group_id, int agg_index) {
       }
       default: {
         std::cerr << "Cannot insert unsupported aggregate type: " +
-                         group_type_->child(i)->type()->ToString()
+                         group_type_->field(i)->type()->ToString()
                   << std::endl;
       }
     }
@@ -246,97 +328,28 @@ void Aggregate::insert_group(std::vector<int> group_id, int agg_index) {
   evaluate_status(status, __FUNCTION__, __LINE__);
 }
 
-void Aggregate::insert_group_aggregate(const arrow::Datum& aggregate,
-                                       int agg_index) {
-  arrow::Status status;
-
+void Aggregate::InsertGroupAggregate(int agg_index) {
   auto aggregate_builder_casted =
       std::static_pointer_cast<arrow::Int64Builder>(aggregate_builder_);
-  status = aggregate_builder_casted->Append(aggregates_vec_[agg_index]);
+  arrow::Status status =
+      aggregate_builder_casted->Append(aggregate_data_[agg_index]);
   evaluate_status(status, __FUNCTION__, __LINE__);
   return;
-  // Append a group's aggregate to its builder.
-  switch (aggregate.type()->id()) {
-    case arrow::Type::INT64: {
-      // Downcast the aggregate builder
-
-      //            // Downcast the group aggregate
-      //            auto aggregate_casted =
-      //                std::static_pointer_cast<arrow::Int64Scalar>
-      //                    (aggregate.scalar());
-      // Append the group's aggregate to its builder.
-
-      break;
-    }
-    case arrow::Type::DOUBLE: {
-      // Downcast the aggregate builder
-      auto aggregate_builder_casted =
-          std::static_pointer_cast<arrow::DoubleBuilder>(aggregate_builder_);
-      // Downcast the group aggregate
-      auto aggregate_casted =
-          std::static_pointer_cast<arrow::DoubleScalar>(aggregate.scalar());
-      // Append the group's aggregate to its builder.
-      status = aggregate_builder_casted->Append(aggregate_casted->value);
-      evaluate_status(status, __FUNCTION__, __LINE__);
-      break;
-    }
-    default: {
-      std::cerr << "Aggregate does not support aggregations of "
-                   "type " +
-                       aggregate.type()->ToString()
-                << std::endl;
-    }
-  }
 }
 
-arrow::Datum Aggregate::get_unique_values(const ColumnReference& group_ref) {
-  arrow::Status status;
-  auto group_by_col =
-      group_by_cols_[group_by_col_names_to_index_[group_ref.col_name]];
-
+arrow::Datum Aggregate::ComputeUniqueValues(const ColumnReference& group_ref) {
+  auto group_by_col = group_by_cols_[group_by_index_map_[group_ref.col_name]];
   // Get the unique values in group_by_col
   arrow::Datum unique_values;
-  status = arrow::compute::Unique(group_by_col).Value(&unique_values);
-
+  arrow::Status status =
+      arrow::compute::Unique(group_by_col).Value(&unique_values);
   evaluate_status(status, __FUNCTION__, __LINE__);
 
   return unique_values;
 }
 
-void Aggregate::finish() {
-  arrow::Status status;
-
-  // Create Arrow Arrays from the ArrayBuilders
-  std::shared_ptr<arrow::StructArray> groups_temp;
-  status = group_builder_->Finish(&groups_temp);
-  evaluate_status(status, __FUNCTION__, __LINE__);
-
-  for (int i = 0; i < groups_temp->num_fields(); ++i) {
-    groups_.emplace_back(groups_temp->field(i));
-  }
-  std::shared_ptr<arrow::Array> agg_temp;
-  status = aggregate_builder_->Finish(&agg_temp);
-  evaluate_status(status, __FUNCTION__, __LINE__);
-  aggregates_.value = agg_temp->data();
-
-  // Sort the output according to the ORDER BY clause
-  sort();
-
-  // Add the sorted data to the output table, and wrap the output table in
-  // the output OperatorResult.
-  for (auto& group_values : groups_) {
-    output_table_data_.push_back(group_values.make_array()->data());
-  }
-  output_table_data_.push_back(aggregates_.make_array()->data());
-
-  output_table_->insert_records(output_table_data_);
-  output_result_->append(output_table_);
-
-  free(aggregates_vec_);
-}
-
-arrow::Datum Aggregate::compute_aggregate(AggregateKernels kernel,
-                                          const arrow::Datum& aggregate_col) {
+arrow::Datum Aggregate::ComputeAggregate(AggregateKernel kernel,
+                                         const arrow::Datum& aggregate_col) {
   arrow::Status status;
   arrow::Datum out_aggregate;
 
@@ -359,109 +372,26 @@ arrow::Datum Aggregate::compute_aggregate(AggregateKernels kernel,
   return out_aggregate;
 }
 
-void Aggregate::initialize_variables(Task* ctx) {
-  // Fetch the fields associated with each groupby column.
-  std::vector<std::shared_ptr<arrow::Field>> group_by_fields;
-  for (auto& group_by : group_by_refs_) {
-    group_by_fields.push_back(
-        group_by.table->get_schema()->GetFieldByName(group_by.col_name));
-  }
-
-  sort_aggregate_col_ = false;
-  for (auto& order_by : order_by_refs_) {
-    if (order_by.table == nullptr) {
-      sort_aggregate_col_ = true;
-    }
-  }
-
-  // Initialize a StructBuilder containing one builder for each group
-  // by column.
-  group_type_ = arrow::struct_(group_by_fields);
-  group_builder_ = std::make_shared<arrow::StructBuilder>(
-      group_type_, arrow::default_memory_pool(), get_group_builders());
-
-  // Initialize aggregate builder
-  aggregate_builder_ = get_aggregate_builder(aggregate_refs_[0].kernel);
-
-  // Initialize output table schema. group_type_ must be initialized beforehand.
-  out_schema_ =
-      get_output_schema(aggregate_refs_[0].kernel, aggregate_refs_[0].agg_name);
-  // Initialize output table.
-  output_table_ = std::make_shared<Table>("aggregate", out_schema_, BLOCK_SIZE);
-
-  all_unique_values_.resize(group_by_refs_.size());
-  unique_value_filters_.resize(group_by_refs_.size());
-  group_by_cols_.resize(group_by_refs_.size());
-
-  for (auto& group_by : group_by_refs_) {
-    group_by_tables_.push_back(prev_result_->get_table(group_by.table));
-  }
-
-  auto num_children = group_by_refs_.size();
-  uniq_val_maps_.resize(num_children);
-}
-
-void Aggregate::initialize_group_by_column(Task* ctx, int i) {
-  std::scoped_lock<std::mutex> lock(mutex_);
-  group_by_col_names_to_index_.emplace(group_by_refs_[i].col_name, i);
-  group_by_tables_[i].get_column_by_name(ctx, group_by_refs_[i].col_name,
-                                         group_by_cols_[i]);
-}
-
-void Aggregate::initialize(Task* ctx) {
-  std::vector<std::shared_ptr<Context>> contexts;
-  for (int i = 0; i < group_by_refs_.size(); ++i) {
-    contexts.push_back(std::make_shared<Context>());
-  }
-
-  ctx->spawnTask(CreateTaskChain(
-      CreateLambdaTask(
-          [this](Task* internal) { initialize_variables(internal); }),
-      CreateLambdaTask([this, contexts](Task* internal) {
-        // Fetch unique values for all Group By columns.
-        for (int i = 0; i < group_by_refs_.size(); i++) {
-          // TODO(nicholas): No need for a TaskChain here
-          internal->spawnTask(CreateTaskChain(
-              CreateLambdaTask([this, i](Task* internal) {
-                initialize_group_by_column(internal, i);
-              }),
-              CreateLambdaTask([this, i] {
-                all_unique_values_[i] =
-                    get_unique_values(group_by_refs_[i]).make_array();
-              }),
-              CreateLambdaTask([this, i, contexts](Task* internal) {
-                arrow::Datum out;
-                contexts[i]->match(internal, group_by_cols_[i],
-                                   all_unique_values_[i], out);
-              }),
-              CreateLambdaTask([this, contexts, i] {
-                uniq_val_maps_[i] = contexts[i]->out_.chunked_array();
-              })));
-        }
-      })));
-}
-
-void Aggregate::compute_group_aggregate(Task* ctx, int agg_index,
-                                        const std::vector<int>& group_id,
-                                        const arrow::Datum agg_col) {
+void Aggregate::ComputeGroupAggregate(Task* ctx, std::size_t agg_index,
+                                      const std::vector<int>& group_id,
+                                      const arrow::Datum agg_col) {
   if (num_aggs_ == 1) {
     auto aggregate =
-        compute_aggregate(aggregate_refs_[0].kernel, agg_col.chunked_array());
-    aggregates_vec_[agg_index] =
+        ComputeAggregate(aggregate_refs_[0].kernel, agg_col.chunked_array());
+    aggregate_data_[agg_index] =
         std::static_pointer_cast<arrow::Int64Scalar>(aggregate.scalar())->value;
   }
-  if (aggregates_vec_[agg_index] > 0) {
-    arrow::Datum dummy;
+  if (aggregate_data_[agg_index] > 0) {
     // Compute the aggregate over the filtered agg_col
-    // Acquire builder_mutex_ so that groups are correctly associated with
+    // Acquire mutex_ so that groups are correctly associated with
     // their corresponding aggregates
-    std::unique_lock<std::mutex> lock(builder_mutex_);
-    insert_group_aggregate(dummy, agg_index);
-    insert_group(group_id, agg_index);
+    std::unique_lock<std::mutex> lock(mutex_);
+    InsertGroupAggregate(agg_index);
+    InsertGroupColumns(group_id, agg_index);
   }
 }
 
-void Aggregate::compute_aggregates(Task* ctx) {
+void Aggregate::ComputeAggregates(Task* ctx) {
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([this](Task* internal) {
         // TODO(nicholas): For now, we only perform one aggregate.
@@ -473,9 +403,9 @@ void Aggregate::compute_aggregates(Task* ctx) {
       CreateLambdaTask([this](Task* internal) {
         // Initialize the slots to hold the current iteration value for each
         // depth
-        int n = group_type_->num_children();
-        int maxes[n];
-        std::vector<int> group_id(n);
+        int num_group_columns = group_type_->num_fields();
+        int max_unique_values[num_group_columns];
+        std::vector<int> group_id(num_group_columns);
 
         // DYNAMIC DEPTH NESTED LOOP:
         // We must handle an arbitrary number of GROUP BY columns. We need a
@@ -491,57 +421,41 @@ void Aggregate::compute_aggregates(Task* ctx) {
         // {1, 1}
         // {1, 2}
 
-        num_aggs_ = 1;
-
         // initialize group_id = {0, 0, ..., 0} and initialize maxes[i] to the
         // number of unique values in group by column i.
-        for (int i = 0; i < n; i++) {
+        num_aggs_ = 1;
+        for (std::size_t i = 0; i < num_group_columns; ++i) {
           group_id[i] = 0;
-          maxes[i] = all_unique_values_[i]->length();
-          unique_value_filters_[i].resize(maxes[i]);
-          num_aggs_ *= maxes[i];
+          max_unique_values[i] = unique_values_[i]->length();
+          num_aggs_ *= max_unique_values[i];
         }
 
-        group_id_to_agg_index_map_.reserve(num_aggs_);
-        group_filters_.resize(num_aggs_);
-        filtered_agg_cols_.resize(num_aggs_);
-        contexts_.resize(num_aggs_);
-        unique_value_filter_contexts_.resize(num_aggs_);
-
-        aggregates_vec_ = (std::atomic<int64_t>*)malloc(
-            sizeof(std::atomic<int64_t>) * num_aggs_);
-        for (int i = 0; i < num_aggs_; ++i) {
-          aggregates_vec_[i] = 0;
-        }
-
-        for (auto& vec : unique_value_filter_contexts_) {
-          vec.resize(group_by_refs_.size());
-        }
+        group_agg_index_map_.reserve(num_aggs_);
+        group_id_vec_.resize(num_aggs_);
+        aggregate_data_ = (std::atomic<int64_t>*)calloc(
+            num_aggs_, sizeof(std::atomic<int64_t>));
 
         int agg_index = 0;
-        group_id_vec_.resize(num_aggs_);
+        int index = num_group_columns - 1;  // loop index
 
-        int index = n - 1;  // loop index
         bool exit = false;
         while (!exit) {
           // LOOP BODY START
           group_id_vec_[agg_index] = group_id;
           auto key = 0;
-          for (int k = 0; k < group_id.size(); ++k) {
+          for (std::size_t k = 0; k < group_id.size(); ++k) {
             key += group_id[k] * pow(10, k);
           }
-          group_id_to_agg_index_map_[key] = agg_index;
-          ++agg_index;
+          group_agg_index_map_[key] = agg_index++;
           // LOOP BODY END
 
-          if (n == 0)
+          if (num_group_columns == 0) {
             break;  // Only execute the loop once if there are no group bys
+          }
 
           // INCREMENT group_id
-          group_id[n - 1]++;
-          while (group_id[index] == maxes[index]) {
-            // if n == 0, we have no Group By clause and should exit after one
-            // iteration.
+          group_id[num_group_columns - 1]++;
+          while (group_id[index] == max_unique_values[index]) {
             if (index == 0) {
               exit = true;
               break;
@@ -549,48 +463,36 @@ void Aggregate::compute_aggregates(Task* ctx) {
             group_id[index--] = 0;
             ++group_id[index];
           }
-          index = n - 1;
+          index = num_group_columns - 1;
         }
-        initialize_group_filters(internal);
+        InitializeGroupFilters(internal);
       }),
       CreateLambdaTask([this](Task* internal) {
-        int batch_size = num_aggs_ / std::thread::hardware_concurrency() / 2;
+        std::size_t batch_size =
+            num_aggs_ / std::thread::hardware_concurrency() / 2;
         if (batch_size == 0) batch_size = num_aggs_;
-        int num_batches = num_aggs_ / batch_size +
-                          1;  // if num_chunks is a multiple of batch_size, we
-                              // don't actually want the +1
-        if (num_batches == 0) num_batches = 1;
+        std::size_t num_batches = 1 + ((num_aggs_ - 1) / batch_size);
 
-        for (int batch_i = 0; batch_i < num_batches; batch_i++) {
+        for (std::size_t batch_index = 0; batch_index < num_batches;
+             ++batch_index) {
           // Each task gets the filter for one block and stores it in
           // filter_vector
-          internal->spawnLambdaTask([this, batch_i,
+          internal->spawnLambdaTask([this, batch_index,
                                      batch_size](Task* internal) {
-            int base_i = batch_i * batch_size;
-            for (int i = base_i; i < base_i + batch_size && i < num_aggs_;
-                 i++) {
-              // i = agg_index
-              compute_group_aggregate(internal, i, group_id_vec_[i], agg_col_);
+            int base_index = batch_index * batch_size;
+            for (std::size_t agg_index = base_index;
+                 agg_index < base_index + batch_size && agg_index < num_aggs_;
+                 ++agg_index) {
+              ComputeGroupAggregate(internal, agg_index,
+                                    group_id_vec_[agg_index], agg_col_);
             }
           });
         }
       })));
 }
 
-void Aggregate::execute(Task* ctx) {
-  ctx->spawnTask(CreateTaskChain(
-      // Task 1 = Compute all aggregates
-      CreateLambdaTask([this](Task* internal) { initialize(internal); }),
-      CreateLambdaTask(
-          [this](Task* internal) { compute_aggregates(internal); }),
-      CreateLambdaTask([this](Task* internal) {
-        //            initialize_group_filters(internal);
-      }),
-      // Task 2 = Create the output result
-      CreateLambdaTask([this](Task* internal) { finish(); })));
-}
-
-void Aggregate::sort() {
+void Aggregate::SortResult(std::vector<arrow::Datum>& groups,
+                           arrow::Datum& aggregates) {
   // The columns in the GROUP BY and ORDER BY clause may not directly correspond
   // to the same column, e.g we may have
   // GROUP BY R.a, R.b
@@ -600,7 +502,7 @@ void Aggregate::sort() {
   std::vector<int> order_to_group;
 
   for (auto& order_by_ref : order_by_refs_) {
-    for (int j = 0; j < group_by_refs_.size(); j++) {
+    for (std::size_t j = 0; j < group_by_refs_.size(); ++j) {
       if (order_by_ref.table == group_by_refs_[j].table) {
         order_to_group.push_back(j);
       }
@@ -618,28 +520,66 @@ void Aggregate::sort() {
   // clause in reverse order.
   for (int i = order_by_refs_.size() - 1; i >= 0; i--) {
     auto order_ref = order_by_refs_[i];
-
     // A nullptr indicates that we are sorting by the aggregate column
     // TODO(nicholas): better way to indicate we want to sort the aggregate?
     if (order_ref.table == nullptr) {
-      status = arrow::compute::SortToIndices(*aggregates_.make_array())
+      status = arrow::compute::SortToIndices(*aggregates.make_array())
                    .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);
     } else {
-      auto group = groups_[order_to_group[i]];
+      auto group = groups[order_to_group[i]];
       status = arrow::compute::SortToIndices(*group.make_array())
                    .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);
     }
-    status = arrow::compute::Take(aggregates_, sorted_indices, take_options)
-                 .Value(&aggregates_);
+    status = arrow::compute::Take(aggregates, sorted_indices, take_options)
+                 .Value(&aggregates);
     evaluate_status(status, __FUNCTION__, __LINE__);
 
-    for (auto& group : groups_) {
+    for (auto& group : groups) {
       status = arrow::compute::Take(group, sorted_indices, take_options)
                    .Value(&group);
       evaluate_status(status, __FUNCTION__, __LINE__);
     }
   }
 }
+
+void Aggregate::Finish() {
+  arrow::Status status;
+
+  // Create Arrow Arrays from the ArrayBuilders
+  std::shared_ptr<arrow::StructArray> groups_temp;
+  status = group_builder_->Finish(&groups_temp);
+  evaluate_status(status, __FUNCTION__, __LINE__);
+
+  std::vector<arrow::Datum> groups;
+  arrow::Datum aggregates;
+
+  groups.reserve(groups_temp->num_fields());
+  for (std::size_t field_index = 0; field_index < groups_temp->num_fields();
+       ++field_index) {
+    groups.emplace_back(groups_temp->field(field_index));
+  }
+  std::shared_ptr<arrow::Array> agg_temp;
+  status = aggregate_builder_->Finish(&agg_temp);
+  evaluate_status(status, __FUNCTION__, __LINE__);
+  aggregates.value = agg_temp->data();
+
+  // Sort the output according to the ORDER BY clause
+  SortResult(groups, aggregates);
+
+  // Add the sorted data to the output table, and wrap the output table in
+  // the output OperatorResult.
+  std::vector<std::shared_ptr<arrow::ArrayData>> output_table_data;
+  for (auto& group_values : groups) {
+    output_table_data.push_back(group_values.make_array()->data());
+  }
+  output_table_data.push_back(aggregates.make_array()->data());
+
+  output_table_->insert_records(output_table_data);
+  output_result_->append(output_table_);
+
+  free(aggregate_data_);
+}
+
 }  // namespace hustle::operators

--- a/src/operators/tests/aggregate_test.cc
+++ b/src/operators/tests/aggregate_test.cc
@@ -102,7 +102,7 @@ TEST_F(AggregateTestFixture, MeanTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  AggregateReference agg_ref = {AggregateKernels::MEAN, "data_mean", R, "data"};
+  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
@@ -136,7 +136,7 @@ TEST_F(AggregateTestFixture, SumTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "data_sum", R, "data"};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
@@ -228,7 +228,7 @@ TEST_F(AggregateTestFixture, SumWithGroupByTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "data_sum", R, "data"};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
                    {R_group_ref});
   Scheduler &scheduler = Scheduler::GlobalInstance();
@@ -283,7 +283,7 @@ TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
   auto out_result = std::make_shared<OperatorResult>();
   result->append(R);
 
-  AggregateReference agg_ref = {AggregateKernels::SUM, "data_sum", R, "data"};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
                    {R_group_ref});
   Scheduler &scheduler = Scheduler::GlobalInstance();

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -361,9 +361,9 @@ void Context::apply_indices(Task* ctx, const arrow::Datum values,
 void Context::clear_data() { array_vec_.clear(); }
 
 void Context::match(Task* ctx, const arrow::Datum& values,
-                    const arrow::Datum& keys, arrow::Datum& out) {
+                    const arrow::Datum& keys) {
   ctx->spawnTask(CreateTaskChain(
-      CreateLambdaTask([this, values, keys, &out](Task* internal) {
+      CreateLambdaTask([this, values, keys](Task* internal) {
         clear_data();
 
         auto vals = values.chunked_array();
@@ -380,9 +380,7 @@ void Context::match(Task* ctx, const arrow::Datum& values,
           });
         }
       }),
-      CreateLambdaTask([this, &out](Task* internal) {
-        //            out.value =
-        //            std::make_shared<arrow::ChunkedArray>(array_vec_);
+      CreateLambdaTask([this](Task* internal) {
         out_.value = std::make_shared<arrow::ChunkedArray>(array_vec_);
       })));
 }

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -33,8 +33,7 @@ class Context {
 
   void apply_indices(Task *ctx, arrow::Datum values, arrow::Datum indices,
                      arrow::Datum index_chunks, arrow::Datum &out);
-  void match(Task *ctx, const arrow::Datum &values, const arrow::Datum &keys,
-             arrow::Datum &out);
+  void match(Task *ctx, const arrow::Datum &values, const arrow::Datum &keys);
   void apply_filter(Task *ctx, const arrow::Datum &values,
                     const arrow::Datum &filter, arrow::Datum &out);
 


### PR DESCRIPTION
### Summary
In this PR, simplified and reorganized the aggregate operator by some refactoring and re-organization and minor simplification of logics.

### Change Details
* Refactored some functionalities to use message passing between functions instead of the data members.
* Simplified some minor logics.
* Removed unused data members, functions and function parameters
* Improved the naming of the functions to C++ style guide.
* Moved from deprecated arrow APIs to the suggested APIs.

Main changes can be found in this file: src/operators/aggregate.cc and src/operators/aggregate.h

### Test
Ran the unit tests - ctest --output-on-failure
Ran the SSB benchmark for the scale factor 1 input and cross-checked the performance and the aggregated output for correctness.