### PR TITLE
Add count operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ debug
 Brewfile.lock.json
 arrow/
 ssb/
-.vscode/settings.json
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ debug
 Brewfile.lock.json
 arrow/
 ssb/
+.vscode/settings.json

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -190,7 +190,7 @@ void SSB::q11() {
   JoinGraph graph({{join_pred}});
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::COUNT, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -193,7 +193,7 @@ void SSB::q11() {
 
   Join join_op(0, join_result_in, join_result_out, graph);
 
-  AggregateReference agg_ref = {AggregateKernel::COUNT, "revenue", lo_rev_ref};
+  AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -217,7 +217,8 @@ std::shared_ptr<arrow::ArrayBuilder> Aggregate::CreateAggregateBuilder(
       break;
     }
     case COUNT: {
-      throw std::runtime_error("Count aggregate not supported.");
+      aggregate_builder = std::make_shared<arrow::Int64Builder>();
+      break;
     }
   }
   return aggregate_builder;
@@ -246,7 +247,10 @@ std::shared_ptr<arrow::Schema> Aggregate::OutputSchema(
       break;
     }
     case COUNT: {
-      throw std::runtime_error("Count aggregate not supported.");
+      status =
+          schema_builder.AddField(arrow::field(agg_col_name, arrow::int64()));
+      evaluate_status(status, __FUNCTION__, __LINE__);
+      break;
     }
   }
 
@@ -359,7 +363,7 @@ arrow::Datum Aggregate::ComputeAggregate(AggregateKernel kernel,
       break;
     }
     case COUNT: {
-      throw std::runtime_error("Count aggregate not supported.");
+      status = arrow::compute::Count(aggregate_col).Value(&out_aggregate);
       break;
     }
       // Note that Mean outputs a DOUBLE

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -19,6 +19,7 @@
 #define HUSTLE_AGGREGATE_H
 
 #include <arrow/compute/api.h>
+#include <arrow/compute/api_aggregate.h>
 
 #include <string>
 


### PR DESCRIPTION
(warm-up project) Implement the `COUNT` operator.


**Example Query**:
```
SELECT count(R.data) as data_count
FROM R;
```

**Changes**:

- Add the `COUNT` operator for the aggregate.
- Add the operator test cases.

**Future issues**
- [ ] `COUNT` should be implemented as fast as possible. Postgres keeps the count of table somewhere (haven't done enough research yet!) and do look-up on the statistics if possible. Since it's not in the SSB, it's not urgent; but in reality, it's definitely a must.