### PR TITLE
Configurable operators

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "cmake"
 brew "pkgconfig"
 brew "google-benchmark"
+brew "libconfig"

--- a/hustle.cfg
+++ b/hustle.cfg
@@ -1,3 +1,3 @@
-join-parallel-factor = 10.00
-filter_join-parallel-factor = 10.00
+join-parallel-factor = 6.0
+filter_join-parallel-factor = 12.00
 aggregate-parallel-factor = 0.15

--- a/hustle.cfg
+++ b/hustle.cfg
@@ -1,0 +1,3 @@
+join-parallel-factor = 10.00
+filter_join-parallel-factor = 10.00
+aggregate-parallel-factor = 0.15

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -29,6 +29,9 @@ elif [[ `uname` == "Linux" ]]; then
     sudo apt-get install gcc-9 g++-9 --yes
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
     
+    sudo apt-get update -y
+    sudo apt-get install -y libconfig-dev
+
     if [ ! -d "benchmark" ]
     then
       git clone https://github.com/google/benchmark.git

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -30,7 +30,7 @@ elif [[ `uname` == "Linux" ]]; then
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
     
     sudo apt-get update -y
-    sudo apt-get install -y libconfig-dev
+    sudo apt-get install -y libconfig++-dev
 
     if [ ! -d "benchmark" ]
     then

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(hustle_src_benchmark PUBLIC
         hustle_src_optimizer_ExecutionPlan
         hustle_src_utils_EventProfiler
         hustle_src_utils_skew
+        hustle_src_utils_Config
         ${ARROW_SHARED_LIB}
         )
 

--- a/src/benchmark/ssb_workload.h
+++ b/src/benchmark/ssb_workload.h
@@ -19,6 +19,7 @@
 #define HUSTLE_SSB_WORKLOAD_H
 
 #include "execution/execution_plan.h"
+#include "operators/operator_options.h"
 #include "operators/predicate.h"
 #include "scheduler/scheduler.h"
 #include "storage/table.h"
@@ -92,6 +93,11 @@ class SSB {
   std::shared_ptr<OperatorResult> lip_result_out;
   std::shared_ptr<OperatorResult> join_result_out;
   std::shared_ptr<OperatorResult> agg_result_out;
+
+  std::shared_ptr<OperatorOptions> select_options;
+  std::shared_ptr<OperatorOptions> join_options;
+  std::shared_ptr<OperatorOptions> filter_join_options;
+  std::shared_ptr<OperatorOptions> aggregate_options;
 
   std::shared_ptr<Table> out_table;
 

--- a/src/benchmark/ssb_workload_lip.cc
+++ b/src/benchmark/ssb_workload_lip.cc
@@ -80,10 +80,11 @@ void SSB::q11_lip() {
   JoinPredicate join_pred = {lo_d_ref, arrow::compute::EQUAL, d_ref};
   JoinGraph graph({{join_pred}});
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
-  Join join_op(0, {lip_result_out}, join_result_out, graph);
+  Join join_op(0, {lip_result_out}, join_result_out, graph, join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
-  Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
+  Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {},
+                   aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -185,10 +186,11 @@ void SSB::q12_lip() {
   join_result_in = {lo_select_result_out, d_select_result_out};
 
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
-  Join join_op(0, {lip_result_out}, join_result_out, graph);
+  Join join_op(0, {lip_result_out}, join_result_out, graph, join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
-  Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
+  Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {},
+                   aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -300,10 +302,11 @@ void SSB::q13_lip() {
   lip_result_in = {lo_select_result_out, d_select_result_out};
 
   LIP lip_op(0, lip_result_in, lip_result_out, graph);
-  Join join_op(0, {lip_result_out}, join_result_out, graph);
+  Join join_op(0, {lip_result_out}, join_result_out, graph, join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
-  Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {});
+  Aggregate agg_op(0, join_result_out, agg_result_out, {agg_ref}, {}, {},
+                   aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -375,11 +378,13 @@ void SSB::q21_lip() {
                    p_select_result_out, s_select_result_out};
 
   JoinGraph graph({{s_join_pred, p_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
-                   {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
+                   {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}},
+                   aggregate_options);
 
   ExecutionPlan plan(0);
   auto p_select_id = plan.addOperator(&p_select_op);
@@ -462,11 +467,13 @@ void SSB::q22_lip() {
                    p_select_result_out, s_select_result_out};
 
   JoinGraph graph({{s_join_pred, p_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
-                   {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
+                   {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}},
+                   aggregate_options);
 
   ExecutionPlan plan(0);
   auto p_select_id = plan.addOperator(&p_select_op);
@@ -538,11 +545,13 @@ void SSB::q23_lip() {
                    p_select_result_out, s_select_result_out};
 
   JoinGraph graph({{s_join_pred, p_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
-                   {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}});
+                   {{d, "year"}, {p, "brand1"}}, {{d, "year"}, {p, "brand1"}},
+                   aggregate_options);
 
   ExecutionPlan plan(0);
   auto p_select_id = plan.addOperator(&p_select_op);
@@ -633,12 +642,13 @@ void SSB::q31_lip() {
                    s_select_result_out, c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_nation_ref, s_nation_ref},
-                   {d_year_ref, {nullptr, "revenue"}});
+                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -732,12 +742,13 @@ void SSB::q32_lip() {
                    s_select_result_out, c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
-                   {d_year_ref, {nullptr, "revenue"}});
+                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -855,12 +866,13 @@ void SSB::q33_lip() {
                    s_select_result_out, c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
-                   {d_year_ref, {nullptr, "revenue"}});
+                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -969,12 +981,13 @@ void SSB::q34_lip() {
                    s_select_result_out, c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
-                   {d_year_ref, {nullptr, "revenue"}});
+                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
 
   ExecutionPlan plan(0);
   auto s_select_id = plan.addOperator(&s_select_op);
@@ -1069,11 +1082,13 @@ void SSB::q41_lip() {
                    c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, p_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
-                   {d_year_ref, c_nation_ref}, {d_year_ref, c_nation_ref});
+                   {d_year_ref, c_nation_ref}, {d_year_ref, c_nation_ref},
+                   aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -1191,12 +1206,14 @@ void SSB::q42_lip() {
                    c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, p_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, {lip_result_out}, agg_result_out, {agg_ref},
                    {d_year_ref, s_nation_ref, p_category_ref},
-                   {d_year_ref, s_nation_ref, p_category_ref});
+                   {d_year_ref, s_nation_ref, p_category_ref},
+                   aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -1304,12 +1321,13 @@ void SSB::q43_lip() {
                    c_select_result_out};
 
   JoinGraph graph({{s_join_pred, c_join_pred, p_join_pred, d_join_pred}});
-  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph);
+  FilterJoin lip_op(0, lip_result_in, lip_result_out, graph,
+                    filter_join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   Aggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, s_city_ref, p_brand1_ref},
-                   {d_year_ref, s_city_ref, p_brand1_ref});
+                   {d_year_ref, s_city_ref, p_brand1_ref}, aggregate_options);
 
   ExecutionPlan plan(0);
   auto p_select_id = plan.addOperator(&p_select_op);

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
         join_graph.cc join_graph.h
         predicate.cc predicate.h
         operator.h
+        operator_options.h
         fused/select_build_hash.cc fused/select_build_hash.h
         fused/filter_join.cc fused/filter_join.h
         utils/lazy_table.cc utils/lazy_table.h
@@ -20,6 +21,7 @@ target_link_libraries(hustle_src_operators PUBLIC
         hustle_src_storage
         hustle_src_utils_EventProfiler
         hustle_src_utils_ArrowComputeWrappers
+        hustle_src_utils_Config
         hustle_src_utils_ParallelHashmap
         ${ARROW_SHARED_LIB}
         )

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -129,6 +129,14 @@ class Aggregate : public Operator {
             std::vector<ColumnReference> group_by_refs,
             std::vector<ColumnReference> order_by_refs);
 
+  Aggregate(const std::size_t query_id,
+            std::shared_ptr<OperatorResult> prev_result,
+            std::shared_ptr<OperatorResult> output_result,
+            std::vector<AggregateReference> aggregate_units,
+            std::vector<ColumnReference> group_by_refs,
+            std::vector<ColumnReference> order_by_refs,
+            std::shared_ptr<OperatorOptions> options);
+
   /**
    * Compute the aggregate(s) specified by the parameters passed into the
    * constructor.

--- a/src/operators/fused/filter_join.h
+++ b/src/operators/fused/filter_join.h
@@ -69,6 +69,12 @@ class FilterJoin : public Operator {
              std::shared_ptr<OperatorResult> output_result,
              hustle::operators::JoinGraph graph);
 
+  FilterJoin(const std::size_t query_id,
+             std::vector<std::shared_ptr<OperatorResult>> prev_result_vec,
+             std::shared_ptr<OperatorResult> output_result,
+             hustle::operators::JoinGraph graph,
+             std::shared_ptr<OperatorOptions> options);
+
   /**
    * Perform LIP and JOIN on a left-deep join plan.
    *

--- a/src/operators/fused/select_build_hash.cc
+++ b/src/operators/fused/select_build_hash.cc
@@ -38,7 +38,17 @@ SelectBuildHash::SelectBuildHash(const std::size_t query_id,
                                  std::shared_ptr<OperatorResult> output_result,
                                  std::shared_ptr<PredicateTree> tree,
                                  ColumnReference join_column)
-    : Select(query_id, table, prev_result, output_result, tree),
+    : SelectBuildHash(query_id, table, prev_result, output_result, tree,
+                      join_column, std::make_shared<OperatorOptions>()) {}
+
+SelectBuildHash::SelectBuildHash(const std::size_t query_id,
+                                 std::shared_ptr<Table> table,
+                                 std::shared_ptr<OperatorResult> prev_result,
+                                 std::shared_ptr<OperatorResult> output_result,
+                                 std::shared_ptr<PredicateTree> tree,
+                                 ColumnReference join_column,
+                                 std::shared_ptr<OperatorOptions> options)
+    : Select(query_id, table, prev_result, output_result, tree, options),
       join_column_(join_column) {
   filters_.resize(table_->get_num_blocks());
   hash_table_ = std::make_shared<phmap::flat_hash_map<int64_t, RecordID>>();

--- a/src/operators/fused/select_build_hash.h
+++ b/src/operators/fused/select_build_hash.h
@@ -55,6 +55,13 @@ class SelectBuildHash : public Select {
                   std::shared_ptr<PredicateTree> tree,
                   ColumnReference join_column);
 
+  SelectBuildHash(const std::size_t query_id, std::shared_ptr<Table> table,
+                  std::shared_ptr<OperatorResult> prev_result,
+                  std::shared_ptr<OperatorResult> output_result,
+                  std::shared_ptr<PredicateTree> tree,
+                  ColumnReference join_column,
+                  std::shared_ptr<OperatorOptions> options);
+
   /**
    * Perform the selection specified by the predicate tree passed into the
    * constructor.

--- a/src/operators/join.h
+++ b/src/operators/join.h
@@ -52,6 +52,11 @@ class Join : public Operator {
        std::vector<std::shared_ptr<OperatorResult>> prev_result,
        std::shared_ptr<OperatorResult> output_result, JoinGraph graph);
 
+  Join(const std::size_t query_id,
+       std::vector<std::shared_ptr<OperatorResult>> prev_result,
+       std::shared_ptr<OperatorResult> output_result, JoinGraph graph,
+       std::shared_ptr<OperatorOptions> options);
+
   /**
    * Perform a natural join on two tables using hash join.
    *

--- a/src/operators/operator.h
+++ b/src/operators/operator.h
@@ -20,8 +20,10 @@
 
 #include <cstdlib>
 
+#include "operators/operator_options.h"
 #include "operators/utils/operator_result.h"
 #include "scheduler/task.h"
+#include "utils/config.h"
 #include "utils/event_profiler.h"
 
 namespace hustle::operators {
@@ -50,8 +52,15 @@ class Operator {
   }
 
  protected:
-  explicit Operator(const std::size_t query_id) : query_id_(query_id) {}
+  explicit Operator(const std::size_t query_id) : query_id_(query_id) {
+    options_ = std::make_shared<OperatorOptions>();
+  }
 
+  explicit Operator(const std::size_t query_id,
+                    std::shared_ptr<OperatorOptions> options)
+      : query_id_(query_id), options_(options) {}
+
+  std::shared_ptr<OperatorOptions> options_;
   const std::size_t query_id_;
 
  private:

--- a/src/operators/operator_options.h
+++ b/src/operators/operator_options.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_OPERATOR_OPTIONS_H
+#define HUSTLE_OPERATOR_OPTIONS_H
+
+namespace hustle::operators {
+
+class OperatorOptions {
+ public:
+  /**
+   * This class contains set of options or configurable parameters
+   * that we need to pass to the Operator to tune/configure
+   * its execution.
+   */
+  explicit OperatorOptions() : parallel_factor_(1.0) {}
+  double get_parallel_factor() const { return parallel_factor_; }
+
+  OperatorOptions set_parallel_factor(double parallel_factor) {
+    parallel_factor_ = parallel_factor;
+    return *this;
+  }
+
+ protected:
+  double parallel_factor_;
+};
+};  // namespace hustle::operators
+
+#endif  // HUSTLE_OPERATOR_OPTIONS_H

--- a/src/operators/select.cc
+++ b/src/operators/select.cc
@@ -36,7 +36,15 @@ Select::Select(const std::size_t query_id, std::shared_ptr<Table> table,
                std::shared_ptr<OperatorResult> prev_result,
                std::shared_ptr<OperatorResult> output_result,
                std::shared_ptr<PredicateTree> tree)
-    : Operator(query_id),
+    : Select(query_id, table, prev_result, output_result, tree,
+             std::make_shared<OperatorOptions>()) {}
+
+Select::Select(const std::size_t query_id, std::shared_ptr<Table> table,
+               std::shared_ptr<OperatorResult> prev_result,
+               std::shared_ptr<OperatorResult> output_result,
+               std::shared_ptr<PredicateTree> tree,
+               std::shared_ptr<OperatorOptions> options)
+    : Operator(query_id, options),
       table_(table),
       output_result_(output_result),
       tree_(tree) {

--- a/src/operators/select.h
+++ b/src/operators/select.h
@@ -53,6 +53,12 @@ class Select : public Operator {
          std::shared_ptr<OperatorResult> output_result,
          std::shared_ptr<PredicateTree> tree);
 
+  Select(const std::size_t query_id, std::shared_ptr<Table> table,
+         std::shared_ptr<OperatorResult> prev_result,
+         std::shared_ptr<OperatorResult> output_result,
+         std::shared_ptr<PredicateTree> tree,
+         std::shared_ptr<OperatorOptions> options);
+
   /**
    * Perform the selection specified by the predicate tree passed into the
    * constructor.

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -29,14 +29,19 @@ add_library(hustle_src_utils_ThreadSafeQueue ../empty_src.cc thread_safe_queue.h
 add_library(hustle_src_utils_ArrowComputeWrappers arrow_compute_wrappers.cc arrow_compute_wrappers.h)
 #add_library(hustle_src_utils_ContextPool context_pool.cc context_pool.h)
 add_library(hustle_src_utils_ParallelHashmap ../empty_src.cc parallel_hashmap/phmap.h)
+add_library(hustle_src_utils_Config ../empty_src.cc config.h)
 add_library(hustle_src_utils_skew ../empty_src.cc skew.h)
 
 
 add_library(hustle_src_utils_BloomFilter ../empty_src.cc bloom_filter.h histogram.h)
 
+find_path(LIB_CONFIG_DIR NAMES libconfig.h++)
+find_library(LIB_CONFIG_LIB NAMES config++)
+
 # Include Arrow
 target_include_directories(hustle_src_utils_BloomFilter PUBLIC ${ARROW_INCLUDE_DIR})
 target_include_directories(hustle_src_utils_ArrowComputeWrappers PUBLIC ${ARROW_INCLUDE_DIR})
+target_include_directories(hustle_src_utils_Config PUBLIC ${LIB_CONFIG_DIR})
 #target_include_directories(hustle_src_utils_ContextPool PUBLIC ${ARROW_INCLUDE_DIR})
 
 
@@ -52,6 +57,9 @@ target_link_libraries(hustle_src_utils_ThreadSafeQueue
 target_link_libraries(hustle_src_utils_ArrowComputeWrappers
         absl::hash
         ${ARROW_SHARED_LIB})
+target_link_libraries(hustle_src_utils_Config PUBLIC
+        ${LIB_CONFIG_LIB}
+        )
 #target_link_libraries(hustle_src_utils_BloomFilter PUBLIC
 #        ${ARROW_SHARED_LIB}
 #        )

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_CONFIG_H
+#define HUSTLE_CONFIG_H
+
+#include <stdlib.h>
+
+#include <libconfig.h++>
+#include <string>
+
+class Config {
+ public:
+  static void Init(const char* filename) { GetInstance(filename); }
+
+  static Config& GetInstance(const char* filename = nullptr) {
+    static Config instance(filename);
+    return instance;
+  }
+
+  double GetDoubleValue(const char* name) {
+    double value;
+    cfg.lookupValue(name, value);
+    return value;
+  }
+
+ private:
+  libconfig::Config cfg;
+  const char* filename_;
+
+  Config(const char* filename) : filename_(filename) {
+    try {
+      cfg.readFile(filename);
+    } catch (const libconfig::FileIOException& io) {
+      std::cerr << "[FileIOException] Error in reading this file:" << filename
+                << std::endl;
+    } catch (const libconfig::ParseException& pe) {
+      std::cerr << "[ParseException] error in file" << pe.getFile() << ":"
+                << pe.getLine() << std::endl;
+    }
+  }
+};
+
+#endif  // HUSTLE_CONFIG_H


### PR DESCRIPTION
### Summary

In this pull request, made the operators' execution configurable/tunable through the config file. Currently, the parallelism inside the operator is made configurable, i.e deciding the number of threads to spawn for execution.

By having this easy way to configure this will help in an easy way to fine-tune the database for the given workload, scale factor, and type of machine on which we do the evaluation so that the maximum performance can be achieved. From the current experiment-setup, by fine-tuning, the parallelism got an improvement over 20% for some of the queries.


### Change Details
* Config file reader using libconfig++
* OperatorOptions class to provide configurable parameters as input to the operators
* Fine-tuned the number of threads/parallelism to improve the performance.

Main changes are in these files, **src/operators/operator_options.h** and **src/utils/config.h**
Current config can be found in this .cfg file: **hustle.cfg**

### Performance evaluation

Ran the SSB benchmark on the workload with Scale Factor=10 (i.e Lineorder file with around 6GB) in the cloudlab machine. (CPU(s): 40 - Intel(R) Xeon(R) CPU E5-2660 v3 @ 2.60GHz, L1d cache: 32K, L1i cache: 32K, L2 cache: 256K, L3 cache: 25600K, main memory around : 158 GB)

The performance improvement comes from fine-tuning of the number of threads that need to be spawned for the given number of chunks. 

Query | Improvement Percentage (%)
-- | --
query 1.1 |+5.30%
query 1.2 | +6.54%
query 1.3 | +6.51%
query 2.1 | +14.85%
query 2.2 | +8.80%
query 2.3 | +11.64%
query 3.1 | +21.99%
query 3.2 | +14.08%
query 3.3 | +17.96%
query 3.4 | +20.57%
query 4.1 |  +9.57%
query 4.2 | +13.03%
query 4.3 | +10.63%

You can find the detailed information of the performance in these files and the table above,
[BasePerformance.txt](https://github.com/UWHustle/hustle/files/5338075/BasePerformance.txt)
[ChangePerformance.txt](https://github.com/UWHustle/hustle/files/5338078/ChangePerformance.txt)
