### PR TITLE
HashAggregate - First iteration (for suggestions and review)

### DIFF
--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -58,6 +58,20 @@ target_link_libraries(hustle_aggregate_test
         )
 add_test(HustleAggregate_test hustle_aggregate_test)
 
+add_executable(hustle_hash_aggregate_test "tests/hash_aggregate_test.cc")
+target_link_libraries(hustle_hash_aggregate_test
+        gtest
+        gtest_main
+        gmock
+        #        glog
+        ${GFLAGS_LIB_NAME}
+        hustle_src_storage
+        hustle_src_operators
+        hustle_src_optimizer_ExecutionPlan
+        hustle_src_scheduler_Scheduler
+        )
+add_test(HustleHashAggregate_test hustle_hash_aggregate_test)
+
 add_executable(hustle_select_test "tests/select_test.cc")
 target_link_libraries(hustle_select_test
         gtest

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(
         hustle_src_operators
         join.h join.cc
+        aggregate_const.h
         aggregate.h aggregate.cc
+        hash_aggregate.h hash_aggregate.cc
         select.h select.cc
         join_graph.cc join_graph.h
         predicate.cc predicate.h

--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -84,9 +84,10 @@ void Aggregate::Initialize(Task* ctx) {
                         .make_array();
               }),
               CreateLambdaTask([this, group_index, contexts](Task* internal) {
-                contexts[group_index]->match(internal,
-                                             group_by_cols_[group_index],
-                                             unique_values_[group_index]);
+                contexts[group_index]->match(
+                  internal,
+                  group_by_cols_[group_index],
+                  unique_values_[group_index]);
               }),
               CreateLambdaTask([this, contexts, group_index] {
                 unique_values_map_[group_index] =
@@ -455,12 +456,22 @@ void Aggregate::ComputeAggregates(Task* ctx) {
 
         bool exit = false;
         while (!exit) {
+          /*
+           * 1. COPY the current group_id to group_id_vec_[agg_index]
+           * 2. CREATE hash key of the group_id
+           * 3. INSERT the (key, agg_index) pair into group_agg_index_map_.
+           * 4. INCREMENT the group_id using dynamic nested depth loop.
+           * */
+
+          // 1. COPY group_id
           // LOOP BODY START
           group_id_vec_[agg_index] = group_id;
+          // 2. CREATE hash key
           auto key = 0;
           for (std::size_t k = 0; k < group_id.size(); ++k) {
             key += group_id[k] * pow(10, k);
           }
+          // 3. INSERT hash key map to agg_index
           group_agg_index_map_[key] = agg_index++;
           // LOOP BODY END
 
@@ -468,7 +479,7 @@ void Aggregate::ComputeAggregates(Task* ctx) {
             break;  // Only execute the loop once if there are no group bys
           }
 
-          // INCREMENT group_id
+          // 4. INCREMENT group_id
           group_id[num_group_columns - 1]++;
           while (group_id[index] == max_unique_values[index]) {
             if (index == 0) {

--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -37,7 +37,7 @@ Aggregate::Aggregate(const std::size_t query_id,
                      std::vector<ColumnReference> order_by_refs)
     : Aggregate(query_id, prev_result, output_result, aggregate_refs,
                 group_by_refs, order_by_refs,
-                std::make_shared<OperatorOptions>()) {}
+                std::make_shared<OperatorOptions>(), NESTED_DEPTH) {}
 
 Aggregate::Aggregate(const std::size_t query_id,
                      std::shared_ptr<OperatorResult> prev_result,
@@ -46,12 +46,25 @@ Aggregate::Aggregate(const std::size_t query_id,
                      std::vector<ColumnReference> group_by_refs,
                      std::vector<ColumnReference> order_by_refs,
                      std::shared_ptr<OperatorOptions> options)
+  : Aggregate(query_id, prev_result, output_result, aggregate_refs,
+            group_by_refs, order_by_refs,
+            std::make_shared<OperatorOptions>(), NESTED_DEPTH) {}
+
+Aggregate::Aggregate(const std::size_t query_id,
+                     std::shared_ptr<OperatorResult> prev_result,
+                     std::shared_ptr<OperatorResult> output_result,
+                     std::vector<AggregateReference> aggregate_refs,
+                     std::vector<ColumnReference> group_by_refs,
+                     std::vector<ColumnReference> order_by_refs,
+                     std::shared_ptr<OperatorOptions> options,
+                     AggregateStrategy strategy)
     : Operator(query_id, options),
       prev_result_(prev_result),
       output_result_(output_result),
       aggregate_refs_(aggregate_refs),
       group_by_refs_(group_by_refs),
-      order_by_refs_(order_by_refs) {}
+      order_by_refs_(order_by_refs),
+      strategy_(strategy) {}
 
 void Aggregate::execute(Task* ctx) {
   ctx->spawnTask(CreateTaskChain(
@@ -60,7 +73,68 @@ void Aggregate::execute(Task* ctx) {
       CreateLambdaTask([this](Task* internal) { Finish(); })));
 }
 
+// TODO: Refactor this function
+void Aggregate::setStrategy(AggregateStrategy strategy){
+  if (strategy != AggregateStrategy::COMPOSIT_HASH &&
+      strategy != AggregateStrategy::NESTED_DEPTH){
+    std::cerr << "[DVAR] Not supported AggregateStrategy: " << strategy << std::endl;
+    exit(1);
+  }
+  this->strategy_ = strategy;
+  std::cout << "[DVAR] Aggregate set to strategy: " << strategy << std::endl;
+}
+
 void Aggregate::Initialize(Task* ctx) {
+  // Initialize variable based on the aggregate strategy.
+  switch (strategy_) {
+    case NESTED_DEPTH:
+      InitializeNestedDepth(ctx);
+      break;
+    case COMPOSIT_HASH:
+      InitializeCompositeHash(ctx);
+      break;
+  }
+}
+
+void Aggregate::InitializeNestedDepth(Task* ctx) {
+    std::vector<std::shared_ptr<Context>> contexts;
+    contexts.reserve(group_by_refs_.size());
+    for (std::size_t i = 0; i < group_by_refs_.size(); ++i) {
+      contexts.push_back(std::make_shared<Context>());
+    }
+
+    ctx->spawnTask(CreateTaskChain(
+      CreateLambdaTask(
+        [this](Task* internal) { InitializeVariables(internal); }),
+      CreateLambdaTask([this, contexts](Task* internal) {
+        // Fetch unique values for all Group By columns.
+        for (std::size_t group_index = 0; group_index < group_by_refs_.size();
+             group_index++) {
+          internal->spawnTask(CreateTaskChain(
+            CreateLambdaTask([this, group_index](Task* internal) {
+              InitializeGroupByColumn(internal, group_index);
+            }),
+            // TODO: Bring the unique value calculation earlier in the section
+            CreateLambdaTask([this, group_index] {
+              unique_values_[group_index] =
+                ComputeUniqueValues(group_by_refs_[group_index])
+                  .make_array();
+            }),
+            CreateLambdaTask([this, group_index, contexts](Task* internal) {
+              contexts[group_index]->match(internal,
+                                           group_by_cols_[group_index],
+                                           unique_values_[group_index]);
+            }),
+            CreateLambdaTask([this, contexts, group_index] {
+              unique_values_map_[group_index] =
+                contexts[group_index]->out_.chunked_array();
+            })));
+        }
+      })));
+  }
+
+
+void Aggregate::InitializeCompositeHash(Task *ctx) {
   std::vector<std::shared_ptr<Context>> contexts;
   contexts.reserve(group_by_refs_.size());
   for (std::size_t i = 0; i < group_by_refs_.size(); ++i) {
@@ -68,33 +142,36 @@ void Aggregate::Initialize(Task* ctx) {
   }
 
   ctx->spawnTask(CreateTaskChain(
-      CreateLambdaTask(
-          [this](Task* internal) { InitializeVariables(internal); }),
-      CreateLambdaTask([this, contexts](Task* internal) {
-        // Fetch unique values for all Group By columns.
-        for (std::size_t group_index = 0; group_index < group_by_refs_.size();
-             group_index++) {
-          internal->spawnTask(CreateTaskChain(
-              CreateLambdaTask([this, group_index](Task* internal) {
-                InitializeGroupByColumn(internal, group_index);
-              }),
-              CreateLambdaTask([this, group_index] {
-                unique_values_[group_index] =
-                    ComputeUniqueValues(group_by_refs_[group_index])
-                        .make_array();
-              }),
-              CreateLambdaTask([this, group_index, contexts](Task* internal) {
-                contexts[group_index]->match(internal,
-                                             group_by_cols_[group_index],
-                                             unique_values_[group_index]);
-              }),
-              CreateLambdaTask([this, contexts, group_index] {
-                unique_values_map_[group_index] =
-                    contexts[group_index]->out_.chunked_array();
-              })));
-        }
-      })));
+    CreateLambdaTask(
+      [this](Task* internal) { InitializeVariables(internal); }),
+    CreateLambdaTask([this, contexts](Task* internal) {
+      // Fetch unique values for all Group By columns.
+      for (std::size_t group_index = 0; group_index < group_by_refs_.size();
+           group_index++) {
+        internal->spawnTask(CreateTaskChain(
+          CreateLambdaTask([this, group_index](Task* internal) {
+            InitializeGroupByColumn(internal, group_index);
+          }),
+          // TODO: Bring the unique value calculation earlier in the section
+          CreateLambdaTask([this, group_index] {
+            unique_values_[group_index] =
+              ComputeUniqueValues(group_by_refs_[group_index])
+                .make_array();
+          }),
+          CreateLambdaTask([this, group_index, contexts](Task* internal) {
+            contexts[group_index]->match(internal,
+                                         group_by_cols_[group_index],
+                                         unique_values_[group_index]);
+          }),
+          CreateLambdaTask([this, contexts, group_index] {
+            unique_values_map_[group_index] =
+              contexts[group_index]->out_.chunked_array();
+          })));
+      }
+    })));
+
 }
+
 
 void Aggregate::InitializeVariables(Task* ctx) {
   // Fetch the fields associated with each groupby column.
@@ -406,105 +483,238 @@ void Aggregate::ComputeGroupAggregate(Task* ctx, std::size_t agg_index,
   }
 }
 
-void Aggregate::ComputeAggregates(Task* ctx) {
-  ctx->spawnTask(CreateTaskChain(
-      CreateLambdaTask([this](Task* internal) {
-        // TODO(nicholas): For now, we only perform one aggregate.
-        auto table = aggregate_refs_[0].col_ref.table;
-        auto col_name = aggregate_refs_[0].col_ref.col_name;
-        agg_lazy_table_ = prev_result_->get_table(table);
-        agg_lazy_table_.get_column_by_name(internal, col_name, agg_col_);
-      }),
-      CreateLambdaTask([this](Task* internal) {
-        // Initialize the slots to hold the current iteration value for each
-        // depth
-        int num_group_columns = group_type_->num_fields();
-        int max_unique_values[num_group_columns];
-        std::vector<int> group_id(num_group_columns);
-
-        // DYNAMIC DEPTH NESTED LOOP:
-        // We must handle an arbitrary number of GROUP BY columns. We need a
-        // dynamic nested loop to iterate over all possible groups. If maxes =
-        // {2, 3} (i.e. we have two group by columns which have 2 and 3 unique
-        // values, respectively), then group_id takes on the following values at
-        // each iteration:
-        //
-        // {0, 0}
-        // {0, 1}
-        // {0, 2}
-        // {1, 0}
-        // {1, 1}
-        // {1, 2}
-
-        // initialize group_id = {0, 0, ..., 0} and initialize maxes[i] to the
-        // number of unique values in group by column i.
-        num_aggs_ = 1;
-        for (std::size_t i = 0; i < num_group_columns; ++i) {
-          group_id[i] = 0;
-          max_unique_values[i] = unique_values_[i]->length();
-          num_aggs_ *= max_unique_values[i];
-        }
-
-        group_agg_index_map_.reserve(num_aggs_);
-        group_id_vec_.resize(num_aggs_);
-        aggregate_data_ = (std::atomic<int64_t>*)calloc(
-            num_aggs_, sizeof(std::atomic<int64_t>));
-
-        int agg_index = 0;
-        int index = num_group_columns - 1;  // loop index
-
-        bool exit = false;
-        while (!exit) {
-          // LOOP BODY START
-          group_id_vec_[agg_index] = group_id;
-          auto key = 0;
-          for (std::size_t k = 0; k < group_id.size(); ++k) {
-            key += group_id[k] * pow(10, k);
-          }
-          group_agg_index_map_[key] = agg_index++;
-          // LOOP BODY END
-
-          if (num_group_columns == 0) {
-            break;  // Only execute the loop once if there are no group bys
-          }
-
-          // INCREMENT group_id
-          group_id[num_group_columns - 1]++;
-          while (group_id[index] == max_unique_values[index]) {
-            if (index == 0) {
-              exit = true;
-              break;
-            }
-            group_id[index--] = 0;
-            ++group_id[index];
-          }
-          index = num_group_columns - 1;
-        }
-        InitializeGroupFilters(internal);
-      }),
-      CreateLambdaTask([this](Task* internal) {
-        std::size_t batch_size =
-            num_aggs_ / std::thread::hardware_concurrency() / 2;
-        if (batch_size == 0) batch_size = num_aggs_;
-        std::size_t num_batches = 1 + ((num_aggs_ - 1) / batch_size);
-
-        for (std::size_t batch_index = 0; batch_index < num_batches;
-             ++batch_index) {
-          // Each task gets the filter for one block and stores it in
-          // filter_vector
-          internal->spawnLambdaTask([this, batch_index,
-                                     batch_size](Task* internal) {
-            int base_index = batch_index * batch_size;
-            for (std::size_t agg_index = base_index;
-                 agg_index < base_index + batch_size && agg_index < num_aggs_;
-                 ++agg_index) {
-              ComputeGroupAggregate(internal, agg_index,
-                                    group_id_vec_[agg_index], agg_col_);
-            }
-          });
-        }
-      })));
+void Aggregate::ComputeGroupAggregate(Task* ctx, std::size_t agg_index,
+                                      const std::vector<int>& group_id,
+                                      const arrow::Datum agg_col) {
+  if (num_aggs_ == 1) {
+    auto aggregate =
+      ComputeAggregate(aggregate_refs_[0].kernel, agg_col.chunked_array());
+    aggregate_data_[agg_index] =
+      std::static_pointer_cast<arrow::Int64Scalar>(aggregate.scalar())->value;
+  }
+  if (aggregate_data_[agg_index] > 0) {
+    // Compute the aggregate over the filtered agg_col
+    // Acquire mutex_ so that groups are correctly associated with
+    // their corresponding aggregates
+    std::unique_lock<std::mutex> lock(mutex_);
+    InsertGroupAggregate(agg_index);
+    InsertGroupColumns(group_id, agg_index);
+  }
 }
+
+void Aggregate::ComputeAggregates(Task* ctx) {
+  switch (this->strategy_) {
+    case NESTED_DEPTH:
+      ComputeNestedDepthAggregates(ctx);
+      break;
+    case COMPOSIT_HASH:
+      ComputeCompositeHashAggregates(ctx);
+      break;
+  }
+}
+
+void Aggregate::ComputeNestedDepthAggregates(Task* ctx) {
+  ctx->spawnTask(CreateTaskChain(
+    CreateLambdaTask([this](Task* internal) {
+      // TODO(nicholas): For now, we only perform one aggregate.
+      auto table = aggregate_refs_[0].col_ref.table;
+      auto col_name = aggregate_refs_[0].col_ref.col_name;
+      agg_lazy_table_ = prev_result_->get_table(table);
+      agg_lazy_table_.get_column_by_name(internal, col_name, agg_col_);
+    }),
+    CreateLambdaTask([this](Task* internal) {
+      // Initialize the slots to hold the current iteration value for each
+      // depth
+      int num_group_columns = group_type_->num_fields();
+      int max_unique_values[num_group_columns];
+      std::vector<int> group_id(num_group_columns);
+
+      // DYNAMIC DEPTH NESTED LOOP:
+      // We must handle an arbitrary number of GROUP BY columns. We need a
+      // dynamic nested loop to iterate over all possible groups. If maxes =
+      // {2, 3} (i.e. we have two group by columns which have 2 and 3 unique
+      // values, respectively), then group_id takes on the following values at
+      // each iteration:
+      //
+      // {0, 0}
+      // {0, 1}
+      // {0, 2}
+      // {1, 0}
+      // {1, 1}
+      // {1, 2}
+
+      // initialize group_id = {0, 0, ..., 0} and initialize maxes[i] to the
+      // number of unique values in group by column i.
+      num_aggs_ = 1;
+      for (std::size_t i = 0; i < num_group_columns; ++i) {
+        group_id[i] = 0;
+        max_unique_values[i] = unique_values_[i]->length();
+        num_aggs_ *= max_unique_values[i];
+      }
+
+      group_agg_index_map_.reserve(num_aggs_);
+      group_id_vec_.resize(num_aggs_);
+      aggregate_data_ = (std::atomic<int64_t>*)calloc(
+        num_aggs_, sizeof(std::atomic<int64_t>));
+
+      int agg_index = 0;
+      int index = num_group_columns - 1;  // loop index
+
+      bool exit = false;
+      while (!exit) {
+        // LOOP BODY START
+        group_id_vec_[agg_index] = group_id;
+        auto key = 0;
+        for (std::size_t k = 0; k < group_id.size(); ++k) {
+          key += group_id[k] * pow(10, k);
+        }
+        group_agg_index_map_[key] = agg_index++;
+        // LOOP BODY END
+
+        if (num_group_columns == 0) {
+          break;  // Only execute the loop once if there are no group bys
+        }
+
+        // INCREMENT group_id
+        group_id[num_group_columns - 1]++;
+        while (group_id[index] == max_unique_values[index]) {
+          if (index == 0) {
+            exit = true;
+            break;
+          }
+          group_id[index--] = 0;
+          ++group_id[index];
+        }
+        index = num_group_columns - 1;
+      }
+      InitializeGroupFilters(internal);
+    }),
+    CreateLambdaTask([this](Task* internal) {
+      std::size_t batch_size =
+        num_aggs_ / std::thread::hardware_concurrency() / 2;
+      if (batch_size == 0) batch_size = num_aggs_;
+      std::size_t num_batches = 1 + ((num_aggs_ - 1) / batch_size);
+
+      for (std::size_t batch_index = 0; batch_index < num_batches;
+           ++batch_index) {
+        // Each task gets the filter for one block and stores it in
+        // filter_vector
+        internal->spawnLambdaTask([this, batch_index,
+                                    batch_size](Task* internal) {
+          int base_index = batch_index * batch_size;
+          for (std::size_t agg_index = base_index;
+               agg_index < base_index + batch_size && agg_index < num_aggs_;
+               ++agg_index) {
+            ComputeGroupAggregate(internal, agg_index,
+                                  group_id_vec_[agg_index], agg_col_);
+          }
+        });
+      }
+    })));
+}
+
+void Aggregate::ComputeCompositeHashAggregates(Task* ctx) {
+  ctx->spawnTask(CreateTaskChain(
+    CreateLambdaTask([this](Task* internal) {
+      // TODO(nicholas): For now, we only perform one aggregate.
+      auto table = aggregate_refs_[0].col_ref.table;
+      auto col_name = aggregate_refs_[0].col_ref.col_name;
+      agg_lazy_table_ = prev_result_->get_table(table);
+      agg_lazy_table_.get_column_by_name(internal, col_name, agg_col_);
+    }),
+    CreateLambdaTask([this](Task* internal) {
+      // Build hash functions
+
+      // Initialize the slots to hold the current iteration value for each
+      // depth
+      int num_group_columns = group_type_->num_fields();
+      int max_unique_values[num_group_columns];
+      std::vector<int> group_id(num_group_columns);
+
+      // DYNAMIC DEPTH NESTED LOOP:
+      // We must handle an arbitrary number of GROUP BY columns. We need a
+      // dynamic nested loop to iterate over all possible groups. If maxes =
+      // {2, 3} (i.e. we have two group by columns which have 2 and 3 unique
+      // values, respectively), then group_id takes on the following values at
+      // each iteration:
+      //
+      // {0, 0}
+      // {0, 1}
+      // {0, 2}
+      // {1, 0}
+      // {1, 1}
+      // {1, 2}
+
+      // initialize group_id = {0, 0, ..., 0} and initialize maxes[i] to the
+      // number of unique values in group by column i.
+      num_aggs_ = 1;
+      for (std::size_t i = 0; i < num_group_columns; ++i) {
+        group_id[i] = 0;
+        max_unique_values[i] = unique_values_[i]->length();
+        num_aggs_ *= max_unique_values[i];
+      }
+
+      group_agg_index_map_.reserve(num_aggs_);
+      group_id_vec_.resize(num_aggs_);
+      aggregate_data_ = (std::atomic<int64_t>*)calloc(
+        num_aggs_, sizeof(std::atomic<int64_t>));
+
+      int agg_index = 0;
+      int index = num_group_columns - 1;  // loop index
+
+      bool exit = false;
+      while (!exit) {
+        // LOOP BODY START
+        group_id_vec_[agg_index] = group_id;
+        auto key = 0;
+        for (std::size_t k = 0; k < group_id.size(); ++k) {
+          key += group_id[k] * pow(10, k);
+        }
+        group_agg_index_map_[key] = agg_index++;
+        // LOOP BODY END
+
+        if (num_group_columns == 0) {
+          break;  // Only execute the loop once if there are no group bys
+        }
+
+        // INCREMENT group_id
+        group_id[num_group_columns - 1]++;
+        while (group_id[index] == max_unique_values[index]) {
+          if (index == 0) {
+            exit = true;
+            break;
+          }
+          group_id[index--] = 0;
+          ++group_id[index];
+        }
+        index = num_group_columns - 1;
+      }
+      InitializeGroupFilters(internal);
+    }),
+    CreateLambdaTask([this](Task* internal) {
+      std::size_t batch_size =
+        num_aggs_ / std::thread::hardware_concurrency() / 2;
+      if (batch_size == 0) batch_size = num_aggs_;
+      std::size_t num_batches = 1 + ((num_aggs_ - 1) / batch_size);
+
+      for (std::size_t batch_index = 0; batch_index < num_batches;
+           ++batch_index) {
+        // Each task gets the filter for one block and stores it in
+        // filter_vector
+        internal->spawnLambdaTask([this, batch_index,
+                                    batch_size](Task* internal) {
+          int base_index = batch_index * batch_size;
+          for (std::size_t agg_index = base_index;
+               agg_index < base_index + batch_size && agg_index < num_aggs_;
+               ++agg_index) {
+            ComputeGroupAggregate(internal, agg_index,
+                                  group_id_vec_[agg_index], agg_col_);
+          }
+        });
+      }
+    })));
+}
+
 
 void Aggregate::SortResult(std::vector<arrow::Datum>& groups,
                            arrow::Datum& aggregates) {

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -32,14 +32,8 @@
 namespace hustle {
 namespace operators {
 
-// Types of aggregates we can perform.
+// Types of aggregates we can perform. COUNT is currently not supported.
 enum AggregateKernel { SUM, COUNT, MEAN };
-
-// Strategy of aggregation.
-// TODO: The usage is not healthy
-enum AggregateStrategy{
-  NESTED_DEPTH, COMPOSIT_HASH
-};
 
 /**
  * A reference structure containing all the information needed to perform an
@@ -143,15 +137,6 @@ class Aggregate : public Operator {
             std::vector<ColumnReference> order_by_refs,
             std::shared_ptr<OperatorOptions> options);
 
-  Aggregate(const std::size_t query_id,
-            std::shared_ptr<OperatorResult> prev_result,
-            std::shared_ptr<OperatorResult> output_result,
-            std::vector<AggregateReference> aggregate_units,
-            std::vector<ColumnReference> group_by_refs,
-            std::vector<ColumnReference> order_by_refs,
-            std::shared_ptr<OperatorOptions> options,
-            AggregateStrategy strategy);
-
   /**
    * Compute the aggregate(s) specified by the parameters passed into the
    * constructor.
@@ -164,16 +149,10 @@ class Aggregate : public Operator {
    */
   void execute(Task* ctx) override;
 
-  // TODO: Refactor this function
-  void setStrategy(AggregateStrategy strategy);
-
  private:
-  // The product of unique values in all group-by columns.
   std::size_t num_aggs_;
   // Operator result from an upstream operator and output result will be stored
   std::shared_ptr<OperatorResult> prev_result_, output_result_;
-  // Aggregate strategy
-  AggregateStrategy strategy_;
 
   // The new output table containing the group columns and aggregate columns.
   std::shared_ptr<Table> output_table_;
@@ -220,11 +199,6 @@ class Aggregate : public Operator {
    * Initialize or pre-compute data members.
    */
   void Initialize(Task* ctx);
-
-  // Initialize for nested depth strategy.
-  void InitializeNestedDepth(Task *ctx);
-
-  void InitializeCompositeHash(Task *ctx);
 
   void InitializeGroupByColumn(Task* ctx, std::size_t group_index);
 
@@ -301,8 +275,6 @@ class Aggregate : public Operator {
    * @param ctx scheduler task
    */
   void ComputeAggregates(Task* ctx);
-  void ComputeNestedDepthAggregates(Task* ctx);
-  void ComputeCompositeHashAggregates(Task* ctx);
 
   /**
    * Sort the output data with respect to each column in the ORDER BY clause.
@@ -323,15 +295,6 @@ class Aggregate : public Operator {
    * Create the output result from data computed during operator execution.
    */
   void Finish();
-
-
-  void ComputeGroupAggregateCompositeHash(
-    Task *ctx, size_t agg_index, const std::vector<int> &group_id,
-    arrow::Datum agg_col);
-
-  void ComputeGroupAggregateNestedDepth(
-    Task *ctx, size_t agg_index, const std::vector<int> &group_id,
-    arrow::Datum agg_col);
 };
 
 }  // namespace operators

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -170,7 +170,7 @@ class Aggregate : public Operator {
 
   // Map group by column names to the actual group column
   std::vector<arrow::Datum> group_by_cols_;
-  // Hash the group to the agg_index (see BlockScan)
+  // Hash the group-by key to the agg_index (initialized in ComputeAggregates)
   phmap::flat_hash_map<int, int> group_agg_index_map_;
   // Number of unique values in each group by column.
   std::vector<arrow::Datum> unique_values_map_;
@@ -178,6 +178,7 @@ class Aggregate : public Operator {
   // by columns.
   std::vector<std::shared_ptr<arrow::Array>> unique_values_;
 
+  arrow::Datum agg_col_;
   // A StructType containing the types of all group by columns
   std::shared_ptr<arrow::DataType> group_type_;
   // We append each aggregate to this after it is computed.
@@ -185,11 +186,10 @@ class Aggregate : public Operator {
   // We append each group to this after we compute the aggregate for that
   // group.
   std::shared_ptr<arrow::StructBuilder> group_builder_;
-  arrow::Datum agg_col_;
   // Construct the group-by key. Initialized in Dynamic Depth Nested Loop.
   std::vector<std::vector<int>> group_id_vec_;
 
-  //
+  // Map group-by column name to group_index in the group_by_refs_ table.
   std::unordered_map<std::string, int> group_by_index_map_;
   std::vector<LazyTable> group_by_tables_;
   LazyTable agg_lazy_table_;

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -28,27 +28,10 @@
 #include "parallel_hashmap/phmap.h"
 #include "storage/block.h"
 #include "storage/table.h"
+#include "aggregate_const.h"
 
 namespace hustle {
 namespace operators {
-
-// Types of aggregates we can perform. COUNT is currently not supported.
-enum AggregateKernel { SUM, COUNT, MEAN };
-
-/**
- * A reference structure containing all the information needed to perform an
- * aggregate over a column.
- *
- * @param kernel The type of aggregate we want to compute
- * @param agg_name Name of the new aggregate column
- * @param col_ref A reference to the column over which we want to compute the
- * aggregate
- */
-struct AggregateReference {
-  AggregateKernel kernel;
-  std::string agg_name;
-  ColumnReference col_ref;
-};
 
 /**
  * Group = a set of column values, one for each column in the GROUP BY clause

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -150,14 +150,16 @@ class Aggregate : public Operator {
   void execute(Task* ctx) override;
 
  private:
+  // Number of groups to aggregate.
   std::size_t num_aggs_;
   // Operator result from an upstream operator and output result will be stored
   std::shared_ptr<OperatorResult> prev_result_, output_result_;
 
   // The new output table containing the group columns and aggregate columns.
   std::shared_ptr<Table> output_table_;
-
+  // The output result of each aggregate group (length = num_aggs_)
   std::atomic<int64_t>* aggregate_data_;
+  // Hold the aggregate column data (in chunks)
   std::vector<const int64_t*> aggregate_col_data_;
 
   // References denoting which columns we want to perform an aggregate on
@@ -168,8 +170,9 @@ class Aggregate : public Operator {
 
   // Map group by column names to the actual group column
   std::vector<arrow::Datum> group_by_cols_;
-
+  // Hash the group to the agg_index (see BlockScan)
   phmap::flat_hash_map<int, int> group_agg_index_map_;
+  // Number of unique values in each group by column.
   std::vector<arrow::Datum> unique_values_map_;
   // A vector of Arrays containing the unique values of each of the group
   // by columns.
@@ -183,9 +186,10 @@ class Aggregate : public Operator {
   // group.
   std::shared_ptr<arrow::StructBuilder> group_builder_;
   arrow::Datum agg_col_;
-
+  // Construct the group-by key. Initialized in Dynamic Depth Nested Loop.
   std::vector<std::vector<int>> group_id_vec_;
 
+  //
   std::unordered_map<std::string, int> group_by_index_map_;
   std::vector<LazyTable> group_by_tables_;
   LazyTable agg_lazy_table_;

--- a/src/operators/aggregate_const.h
+++ b/src/operators/aggregate_const.h
@@ -1,0 +1,33 @@
+//
+// Created by Ginda on 10/14/20.
+//
+
+#ifndef HUSTLE_AGGREGATE_CONST_H
+#define HUSTLE_AGGREGATE_CONST_H
+
+#include "operators/operator.h"
+
+namespace hustle::operators {
+
+
+// Types of aggregates we can perform. COUNT is currently not supported.
+enum AggregateKernel { SUM, COUNT, MEAN };
+
+/**
+ * A reference structure containing all the information needed to perform an
+ * aggregate over a column.
+ *
+ * @param kernel The type of aggregate we want to compute
+ * @param agg_name Name of the new aggregate column
+ * @param col_ref A reference to the column over which we want to compute the
+ * aggregate
+ */
+struct AggregateReference {
+  AggregateKernel kernel;
+  std::string agg_name;
+  ColumnReference col_ref;
+};
+
+}
+
+#endif //HUSTLE_AGGREGATE_CONST_H

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -235,6 +235,32 @@ std::shared_ptr<arrow::Schema> HashAggregate::OutputSchema(
   return result.ValueOrDie();
 }
 
+void HashAggregate::InitializeLocalHashTables() {
+  auto num_tasks = strategy.suggestedNumTasks();
+  auto kernel = aggregate_refs_[0].kernel;
+  switch (kernel) {
+    case SUM:
+    case COUNT: {
+      for (size_t tid = 0; tid < num_tasks; ++tid) {
+        auto map = new HashMap();
+        value_maps.push_back(map);
+      }
+      break;
+    }
+
+    case MEAN: {
+      // Need 2 maps to hold the float values accountable.
+      for (size_t tid = 0; tid < num_tasks; ++tid) {
+        auto value_map = new HashMap();
+        auto count_map = new HashMap();
+        value_maps.push_back(value_map);
+        count_maps.push_back(count_map);
+      }
+      break;
+    }
+  }
+}
+
 
 
 }

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -235,6 +235,13 @@ std::shared_ptr<arrow::Schema> HashAggregate::OutputSchema(
   return result.ValueOrDie();
 }
 
+// TODO: Refactor HashCombine function as a part of the strategy.
+// TODO: Verify if this hash function works.
+HashAggregate::hash_t HashAggregate::HashCombine(hash_t seed, hash_t val){
+  seed ^= val + 0x9e3779b9 + (seed<<6) + (seed>>2);
+  return seed;
+}
+
 void HashAggregate::FirstPhaseAggregateChunks(size_t tid, int st, int ed) {
   for(int i = st; i < ed; i++){
     FirstPhaseAggregateChunk_(tid, i);

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -235,6 +235,12 @@ std::shared_ptr<arrow::Schema> HashAggregate::OutputSchema(
   return result.ValueOrDie();
 }
 
+void HashAggregate::FirstPhaseAggregateChunks(size_t tid, int st, int ed) {
+  for(int i = st; i < ed; i++){
+    FirstPhaseAggregateChunk_(tid, i);
+  }
+}
+
 void HashAggregate::FirstPhaseAggregateChunk_(size_t tid, int chunk_index) {
   auto agg_chunk = agg_col_.chunked_array()->chunk(chunk_index);
   auto chunk_size = agg_chunk->length();

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "hash_aggregate.h"
+
+// TODO: Merge this reference with the one in aggregate.cc.
+//  Maybe put this in aggregate.h?
+#define AGGREGATE_OUTPUT_TABLE "aggregate"
+
+namespace hustle::operators {
+
+
+HashAggregate::HashAggregate(const std::size_t query_id,
+                             std::shared_ptr<OperatorResult> prev_result,
+                             std::shared_ptr<OperatorResult> output_result,
+                             std::vector<AggregateReference> aggregate_refs,
+                             std::vector<ColumnReference> group_by_refs,
+                             std::vector<ColumnReference> order_by_refs)
+  : HashAggregate(
+        query_id, prev_result, output_result, aggregate_refs,
+        group_by_refs, order_by_refs,
+        std::make_shared<OperatorOptions>()) {}
+
+HashAggregate::HashAggregate(const std::size_t query_id,
+                             std::shared_ptr<OperatorResult> prev_result,
+                             std::shared_ptr<OperatorResult> output_result,
+                             std::vector<AggregateReference> aggregate_refs,
+                             std::vector<ColumnReference> group_by_refs,
+                             std::vector<ColumnReference> order_by_refs,
+                             std::shared_ptr<OperatorOptions> options)
+  : Operator(query_id, options),
+    prev_result_(prev_result),
+    output_result_(output_result),
+    aggregate_refs_(aggregate_refs),
+    group_by_refs_(group_by_refs),
+    order_by_refs_(order_by_refs) {}
+
+void HashAggregate::execute(Task *ctx) {
+  ctx->spawnTask(CreateTaskChain(
+    CreateLambdaTask([this](Task* internal){
+      Initialize(internal);
+    }),
+    CreateLambdaTask([this](Task* internal){
+      ComputeAggregates(internal);
+    }),
+    CreateLambdaTask([this](Task* internal){
+      Finish();
+    })
+    ));
+}
+
+void HashAggregate::Initialize(Task *ctx) {
+
+  // Fetch the fields associated with each groupby column.
+  std::vector<std::shared_ptr<arrow::Field>> group_by_fields;
+  group_by_fields.reserve(group_by_refs_.size());
+  for (auto& group_by : group_by_refs_) {
+    group_by_fields.push_back(
+      group_by.table->get_schema()->GetFieldByName(group_by.col_name));
+  }
+
+  // Initialize a StructBuilder containing one builder for each group
+  // by column.
+  group_type_ = arrow::struct_(group_by_fields);
+  group_builder_ = std::make_shared<arrow::StructBuilder>(
+    group_type_, arrow::default_memory_pool(), CreateGroupBuilderVector());
+
+  // Initialize aggregate builder
+  aggregate_builder_ = CreateAggregateBuilder(aggregate_refs_[0].kernel);
+
+  // Initialize output table and its schema. group_type_ must be initialized
+  // beforehand.
+  std::shared_ptr<arrow::Schema> out_schema =
+    OutputSchema(aggregate_refs_[0].kernel, aggregate_refs_[0].agg_name);
+  output_table_ =
+    std::make_shared<Table>(AGGREGATE_OUTPUT_TABLE, out_schema, BLOCK_SIZE);
+
+  group_by_cols_.resize(group_by_refs_.size());
+  for (auto& group_by : group_by_refs_) {
+    group_by_tables_.push_back(prev_result_->get_table(group_by.table));
+  }
+
+
+
+}
+
+void HashAggregate::ComputeAggregates(Task *internal) {
+
+}
+
+void HashAggregate::Finish() {
+
+}
+
+std::vector<std::shared_ptr<arrow::ArrayBuilder>>
+HashAggregate::CreateGroupBuilderVector() {
+  std::vector<std::shared_ptr<arrow::ArrayBuilder>> group_builders;
+  for (auto& field : group_type_->fields()) {
+    switch (field->type()->id()) {
+      case arrow::Type::STRING: {
+        group_builders.push_back(std::make_shared<arrow::StringBuilder>());
+        break;
+      }
+      case arrow::Type::FIXED_SIZE_BINARY: {
+        group_builders.push_back(
+          std::make_shared<arrow::FixedSizeBinaryBuilder>(field->type()));
+        break;
+      }
+      case arrow::Type::INT64: {
+        group_builders.push_back(std::make_shared<arrow::Int64Builder>());
+        break;
+      }
+      default: {
+        std::cerr << "Aggregate does not support group bys of type " +
+                     field->type()->ToString()
+                  << std::endl;
+      }
+    }
+  }
+  return group_builders;
+}
+
+
+}

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -21,6 +21,7 @@
 // TODO: Merge this reference with the one in aggregate.cc.
 //  Maybe put this in aggregate.h?
 #define AGGREGATE_OUTPUT_TABLE "aggregate"
+#define debugmsg(arg) {std::cout << __FILE_NAME__ << ":" << __LINE__ << " " << arg << std::endl;}
 
 namespace hustle::operators {
 
@@ -513,8 +514,8 @@ void HashAggregate::FirstPhaseAggregateChunk_(size_t tid, int chunk_index) {
     switch (kernel) {
       case SUM:{
         auto it = value_map->find(agg_item_key);
-        if (it != value_map->end()){
-          it->second = agg_item_value;
+        if (it == value_map->end()){
+          value_map->insert(std::make_pair(agg_item_key, agg_item_value));
         }else{
           it->second = agg_item_value + it->second;
         }
@@ -523,8 +524,8 @@ void HashAggregate::FirstPhaseAggregateChunk_(size_t tid, int chunk_index) {
 
       case COUNT:{
         auto it = value_map->find(agg_item_key);
-        if (it != value_map->end()){
-          it->second = 1;
+        if (it == value_map->end()){
+          value_map->insert(std::make_pair(agg_item_key, 1));
         }else{
           it->second = 1 + it->second;
         }
@@ -535,12 +536,12 @@ void HashAggregate::FirstPhaseAggregateChunk_(size_t tid, int chunk_index) {
         auto it = value_map->find(agg_item_key);
         auto jt = count_map->find(agg_item_key);
         if (it != value_map->end()){
-          it->second = agg_item_value;
+          value_map->insert(std::make_pair(agg_item_key, agg_item_value));
         }else{
           it->second = agg_item_value + it->second;
         }
         if (jt != count_map->end()){
-          jt->second = 1;
+          value_map->insert(std::make_pair(agg_item_key, 1));
         }else{
           jt->second = 1 + jt->second;
         }

--- a/src/operators/hash_aggregate.h
+++ b/src/operators/hash_aggregate.h
@@ -154,7 +154,7 @@ private:
 
   void ComputeAggregates(Task* internal);
 
-  void Finish();
+  void Finish(Task* internal);
 
   /**
    * @return A vector of ArrayBuilders, one for each of the group by columns.

--- a/src/operators/hash_aggregate.h
+++ b/src/operators/hash_aggregate.h
@@ -223,6 +223,8 @@ private:
 
 
   hash_t HashCombine(hash_t seed, hash_t val);
+
+  void SortResult(std::vector<arrow::Datum> &groups, arrow::Datum &aggregates);
 };
 
 }

--- a/src/operators/hash_aggregate.h
+++ b/src/operators/hash_aggregate.h
@@ -98,7 +98,32 @@ private:
 
   void Finish();
 
+  /**
+   * @return A vector of ArrayBuilders, one for each of the group by columns.
+   */
   std::vector<std::shared_ptr<arrow::ArrayBuilder>> CreateGroupBuilderVector();
+
+  /**
+   * Construct an ArrayBuilder for the aggregate values.
+   *
+   * @param kernel The type of aggregate we want to compute
+   * @return An ArrayBuilder of the correct type for the aggregate we want
+   * to compute.
+   */
+  std::shared_ptr<arrow::ArrayBuilder> CreateAggregateBuilder(
+    AggregateKernel kernel);
+
+  /**
+   * Construct the schema for the output table.
+   *
+   * @param kernel The type of aggregate we want to compute
+   * @param agg_col_name The column over which we want to compute the
+   * aggregate.
+   *
+   * @return The schema for the output table.
+   */
+  std::shared_ptr<arrow::Schema> OutputSchema(AggregateKernel kernel,
+                                              const std::string& agg_col_name);
 };
 
 }

--- a/src/operators/hash_aggregate.h
+++ b/src/operators/hash_aggregate.h
@@ -127,8 +127,7 @@ private:
   // The (temporary) type for key.
   typedef size_t hash_t;
   // The (temporary) type for value.
-  // Used long long in case we hit int64_t.
-  typedef long long value_t;
+  typedef int64_t value_t;
   // TODO: Refactor the unordered_maps to use phmap::flat_hash_map.
   //  It seems to have great optimization over the hash phrasing.
   typedef std::unordered_map<hash_t, value_t> HashMap;
@@ -141,6 +140,8 @@ private:
   // TODO: Construct a mapping from hash key to group-by column tuples
 
   // Global hash table handles the second phase of hashing.
+  // - HashMap if the aggregate kernel is SUM, COUNT
+  // - MeanHashMap if the aggregate kernel is MEAN
   // TODO: Depending on the strategy, the global_map should be polymorphic.
   void * global_map;
 

--- a/src/operators/hash_aggregate.h
+++ b/src/operators/hash_aggregate.h
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_HASH_AGGREGATE_H
+#define HUSTLE_HASH_AGGREGATE_H
+
+#include "operator.h"
+#include "aggregate_const.h"
+
+namespace hustle{
+namespace operators{
+
+class HashAggregate : public Operator {
+
+public:
+  HashAggregate(const std::size_t query_id,
+            std::shared_ptr<OperatorResult> prev_result,
+            std::shared_ptr<OperatorResult> output_result,
+            std::vector<AggregateReference> aggregate_units,
+            std::vector<ColumnReference> group_by_refs,
+            std::vector<ColumnReference> order_by_refs);
+
+  HashAggregate(const std::size_t query_id,
+            std::shared_ptr<OperatorResult> prev_result,
+            std::shared_ptr<OperatorResult> output_result,
+            std::vector<AggregateReference> aggregate_units,
+            std::vector<ColumnReference> group_by_refs,
+            std::vector<ColumnReference> order_by_refs,
+            std::shared_ptr<OperatorOptions> options);
+
+  void execute(Task* ctx) override;
+
+private:
+  // Operator result from an upstream operator and output result will be stored
+  std::shared_ptr<OperatorResult> prev_result_, output_result_;
+  // The new output table containing the group columns and aggregate columns.
+  std::shared_ptr<Table> output_table_;
+  // The output result of each aggregate group (length = num_aggs_)
+  std::atomic<int64_t>* aggregate_data_;
+  // Hold the aggregate column data (in chunks)
+  std::vector<const int64_t*> aggregate_col_data_;
+
+  // References denoting which columns we want to perform an aggregate on
+  // and which aggregate to perform.
+  std::vector<AggregateReference> aggregate_refs_;
+  // References denoting which columns we want to group by and order by
+  std::vector<ColumnReference> group_by_refs_, order_by_refs_;
+
+  // Map group by column names to the actual group column
+  std::vector<arrow::Datum> group_by_cols_;
+  //  // Number of unique values in each group by column.
+  //  std::vector<arrow::Datum> unique_values_map_;
+  //  // A vector of Arrays containing the unique values of each of the group
+  //  // by columns.
+  //  std::vector<std::shared_ptr<arrow::Array>> unique_values_;
+
+
+
+  arrow::Datum agg_col_;
+  // A StructType containing the types of all group by columns
+  std::shared_ptr<arrow::DataType> group_type_;
+  // We append each aggregate to this after it is computed.
+  std::shared_ptr<arrow::ArrayBuilder> aggregate_builder_;
+  // We append each group to this after we compute the aggregate for that
+  // group.
+  std::shared_ptr<arrow::StructBuilder> group_builder_;
+  // Construct the group-by key. Initialized in Dynamic Depth Nested Loop.
+  std::vector<std::vector<int>> group_id_vec_;
+
+  // Map group-by column name to group_index in the group_by_refs_ table.
+  std::unordered_map<std::string, int> group_by_index_map_;
+  std::vector<LazyTable> group_by_tables_;
+  LazyTable agg_lazy_table_;
+
+  // If a thread wants to insert a group and its aggregate into group_builder_
+  // and aggregate_builder_, then it must grab this mutex to ensure that the
+  // groups and its aggregates are inserted at the same row.
+  std::mutex mutex_;
+
+
+  void Initialize(Task* internal);
+
+  void ComputeAggregates(Task* internal);
+
+  void Finish();
+
+  std::vector<std::shared_ptr<arrow::ArrayBuilder>> CreateGroupBuilderVector();
+};
+
+}
+}
+
+
+
+#endif //HUSTLE_HASH_AGGREGATE_H

--- a/src/operators/tests/aggregate_test.cc
+++ b/src/operators/tests/aggregate_test.cc
@@ -88,106 +88,106 @@ class AggregateTestFixture : public testing::Test {
   }
 };
 
-///*
-// * SELECT avg(R.data) as data_mean
-// * FROM R
-// */
-//TEST_F(AggregateTestFixture, MeanTest) {
-//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-//
-//  ColumnReference R_key_ref = {R, "key"};
-//  ColumnReference R_group_ref = {R, "data"};
-//
-//  auto result = std::make_shared<OperatorResult>();
-//  auto out_result = std::make_shared<OperatorResult>();
-//  result->append(R);
-//
-//  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
-//  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-//
-//  Scheduler &scheduler = Scheduler::GlobalInstance();
-//  scheduler.addTask(agg_op.createTask());
-//
-//  scheduler.start();
-//  scheduler.join();
-//
-//  auto out_table = out_result->materialize({{nullptr, "data_mean"}});
-//  //    out_table->print();
-//
-//  // Construct expected results
-//  arrow::Status status;
-//  status = double_builder.Append(((double)150) / 6);
-//  status = double_builder.Finish(&expected_agg_col_1);
-//
-//  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-//}
-//
-///*
-// * SELECT sum(R.data) as data_sum
-// * FROM R
-// */
-//TEST_F(AggregateTestFixture, SumTest) {
-//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-//
-//  ColumnReference R_key_ref = {R, "key"};
-//  ColumnReference R_group_ref = {R, "data"};
-//
-//  auto result = std::make_shared<OperatorResult>();
-//  auto out_result = std::make_shared<OperatorResult>();
-//  result->append(R);
-//
-//  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
-//  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-//  Scheduler &scheduler = Scheduler::GlobalInstance();
-//  scheduler.addTask(agg_op.createTask());
-//
-//  scheduler.start();
-//  scheduler.join();
-//
-//  auto out_table = out_result->materialize({{nullptr, "data_sum"}});
-//  //    out_table->print();
-//
-//  // Construct expected results
-//  arrow::Status status;
-//  status = int_builder.Append(150);
-//  status = int_builder.Finish(&expected_agg_col_1);
-//
-//  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-//}
-//
-///*
-// * SELECT count(R.data) as data_count
-// * FROM R
-// */
-//TEST_F(AggregateTestFixture, CountTest) {
-//    R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-//
-//    ColumnReference R_key_ref = {R, "key"};
-//    ColumnReference R_group_ref = {R, "data"};
-//
-//    auto result = std::make_shared<OperatorResult>();
-//    auto out_result = std::make_shared<OperatorResult>();
-//    result->append(R);
-//
-//    AggregateReference agg_ref = {AggregateKernel::COUNT, "data_count", R, "data"};
-//    Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-//
-//    Scheduler &scheduler = Scheduler::GlobalInstance();
-//    scheduler.addTask(agg_op.createTask());
-//
-//    scheduler.start();
-//    scheduler.join();
-//
-//    auto out_table = out_result->materialize({{nullptr, "data_count"}});
-//    //    out_table->print();
-//
-//    // Construct expected results
-//    arrow::Status status;
-//    status = int_builder.Append(6);
-//    status = int_builder.Finish(&expected_agg_col_1);
-//
-//    EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-//}
+/*
+ * SELECT avg(R.data) as data_mean
+ * FROM R
+ */
+TEST_F(AggregateTestFixture, MeanTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "data"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
+  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table = out_result->materialize({{nullptr, "data_mean"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = double_builder.Append(((double)150) / 6);
+  status = double_builder.Finish(&expected_agg_col_1);
+
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+}
+
+/*
+ * SELECT sum(R.data) as data_sum
+ * FROM R
+ */
+TEST_F(AggregateTestFixture, SumTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "data"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table = out_result->materialize({{nullptr, "data_sum"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = int_builder.Append(150);
+  status = int_builder.Finish(&expected_agg_col_1);
+
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+}
+
+/*
+ * SELECT count(R.data) as data_count
+ * FROM R
+ */
+TEST_F(AggregateTestFixture, CountTest) {
+    R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+    ColumnReference R_key_ref = {R, "key"};
+    ColumnReference R_group_ref = {R, "data"};
+
+    auto result = std::make_shared<OperatorResult>();
+    auto out_result = std::make_shared<OperatorResult>();
+    result->append(R);
+
+    AggregateReference agg_ref = {AggregateKernel::COUNT, "data_count", R, "data"};
+    Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+
+    Scheduler &scheduler = Scheduler::GlobalInstance();
+    scheduler.addTask(agg_op.createTask());
+
+    scheduler.start();
+    scheduler.join();
+
+    auto out_table = out_result->materialize({{nullptr, "data_count"}});
+    //    out_table->print();
+
+    // Construct expected results
+    arrow::Status status;
+    status = int_builder.Append(6);
+    status = int_builder.Finish(&expected_agg_col_1);
+
+    EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+}
 
 /*
  * SELECT sum(R.data) as data_sum
@@ -252,56 +252,7 @@ class AggregateTestFixture : public testing::Test {
  * FROM R
  * GROUP BY R.group
  */
-//TEST_F(AggregateTestFixture, SumWithGroupByTest) {
-//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-//
-//  ColumnReference R_key_ref = {R, "key"};
-//  ColumnReference R_group_ref = {R, "group"};
-//
-//  auto result = std::make_shared<OperatorResult>();
-//  auto out_result = std::make_shared<OperatorResult>();
-//  result->append(R);
-//
-//  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
-//  Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-//                   {R_group_ref});
-//  Scheduler &scheduler = Scheduler::GlobalInstance();
-//  scheduler.addTask(agg_op.createTask());
-//
-//  scheduler.start();
-//  scheduler.join();
-//
-//  auto out_table =
-//      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
-//  //    out_table->print();
-//
-//  // Construct expected results
-//  arrow::Status status;
-//  status = str_builder.AppendValues({"R2", "R1", "R0"});
-//  status = str_builder.Finish(&expected_agg_col_1);
-//
-//  status = int_builder.AppendValues({10, 50, 90});
-//  status = int_builder.Finish(&expected_agg_col_2);
-//
-//  auto group_col = std::static_pointer_cast<arrow::StringArray>(
-//      out_table->get_column(0)->chunk(0));
-//  auto agg_col = std::static_pointer_cast<arrow::Int64Array>(
-//      out_table->get_column(1)->chunk(0));
-//
-//  for (int i = 0; i < group_col->length(); i++) {
-//    if (group_col->GetString(i) == "R0") {
-//      ASSERT_EQ(agg_col->Value(i), 90);
-//    } else if (group_col->GetString(i) == "R1") {
-//      ASSERT_EQ(agg_col->Value(i), 50);
-//    } else if (group_col->GetString(i) == "R2") {
-//      ASSERT_EQ(agg_col->Value(i), 10);
-//    } else {
-//      FAIL();
-//    }
-//  }
-//}
-
-TEST_F(AggregateTestFixture, SumWithGroupByCompositeHashTest) {
+TEST_F(AggregateTestFixture, SumWithGroupByTest) {
   R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
 
   ColumnReference R_key_ref = {R, "key"};
@@ -314,9 +265,6 @@ TEST_F(AggregateTestFixture, SumWithGroupByCompositeHashTest) {
   AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
                    {R_group_ref});
-  // Set the strategy to composite hash keys.
-  agg_op.setStrategy(AggregateStrategy::COMPOSIT_HASH);
-
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
 
@@ -324,7 +272,7 @@ TEST_F(AggregateTestFixture, SumWithGroupByCompositeHashTest) {
   scheduler.join();
 
   auto out_table =
-    out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
   //    out_table->print();
 
   // Construct expected results
@@ -336,9 +284,9 @@ TEST_F(AggregateTestFixture, SumWithGroupByCompositeHashTest) {
   status = int_builder.Finish(&expected_agg_col_2);
 
   auto group_col = std::static_pointer_cast<arrow::StringArray>(
-    out_table->get_column(0)->chunk(0));
+      out_table->get_column(0)->chunk(0));
   auto agg_col = std::static_pointer_cast<arrow::Int64Array>(
-    out_table->get_column(1)->chunk(0));
+      out_table->get_column(1)->chunk(0));
 
   for (int i = 0; i < group_col->length(); i++) {
     if (group_col->GetString(i) == "R0") {
@@ -353,43 +301,43 @@ TEST_F(AggregateTestFixture, SumWithGroupByCompositeHashTest) {
   }
 }
 
-///*
-// * SELECT sum(R.data) as data_sum
-// * FROM R
-// * GROUP BY R.group
-// * ORDER BY R.group
-// */
-//TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
-//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-//
-//  ColumnReference R_key_ref = {R, "key"};
-//  ColumnReference R_group_ref = {R, "group"};
-//
-//  auto result = std::make_shared<OperatorResult>();
-//  auto out_result = std::make_shared<OperatorResult>();
-//  result->append(R);
-//
-//  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
-//  Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-//                   {R_group_ref});
-//  Scheduler &scheduler = Scheduler::GlobalInstance();
-//  scheduler.addTask(agg_op.createTask());
-//
-//  scheduler.start();
-//  scheduler.join();
-//
-//  auto out_table =
-//      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
-//  //    out_table->print();
-//
-//  // Construct expected results
-//  arrow::Status status;
-//  status = str_builder.AppendValues({"R0", "R1", "R2"});
-//  status = str_builder.Finish(&expected_agg_col_1);
-//
-//  status = int_builder.AppendValues({90, 50, 10});
-//  status = int_builder.Finish(&expected_agg_col_2);
-//
-//  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-//  EXPECT_TRUE(out_table->get_column(1)->chunk(0)->Equals(expected_agg_col_2));
-//}
+/*
+ * SELECT sum(R.data) as data_sum
+ * FROM R
+ * GROUP BY R.group
+ * ORDER BY R.group
+ */
+TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "group"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+  Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
+                   {R_group_ref});
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table =
+      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = str_builder.AppendValues({"R0", "R1", "R2"});
+  status = str_builder.Finish(&expected_agg_col_1);
+
+  status = int_builder.AppendValues({90, 50, 10});
+  status = int_builder.Finish(&expected_agg_col_2);
+
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+  EXPECT_TRUE(out_table->get_column(1)->chunk(0)->Equals(expected_agg_col_2));
+}

--- a/src/operators/tests/aggregate_test.cc
+++ b/src/operators/tests/aggregate_test.cc
@@ -88,106 +88,106 @@ class AggregateTestFixture : public testing::Test {
   }
 };
 
-/*
- * SELECT avg(R.data) as data_mean
- * FROM R
- */
-TEST_F(AggregateTestFixture, MeanTest) {
-  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-
-  ColumnReference R_key_ref = {R, "key"};
-  ColumnReference R_group_ref = {R, "data"};
-
-  auto result = std::make_shared<OperatorResult>();
-  auto out_result = std::make_shared<OperatorResult>();
-  result->append(R);
-
-  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
-  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-
-  Scheduler &scheduler = Scheduler::GlobalInstance();
-  scheduler.addTask(agg_op.createTask());
-
-  scheduler.start();
-  scheduler.join();
-
-  auto out_table = out_result->materialize({{nullptr, "data_mean"}});
-  //    out_table->print();
-
-  // Construct expected results
-  arrow::Status status;
-  status = double_builder.Append(((double)150) / 6);
-  status = double_builder.Finish(&expected_agg_col_1);
-
-  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-}
-
-/*
- * SELECT sum(R.data) as data_sum
- * FROM R
- */
-TEST_F(AggregateTestFixture, SumTest) {
-  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-
-  ColumnReference R_key_ref = {R, "key"};
-  ColumnReference R_group_ref = {R, "data"};
-
-  auto result = std::make_shared<OperatorResult>();
-  auto out_result = std::make_shared<OperatorResult>();
-  result->append(R);
-
-  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
-  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-  Scheduler &scheduler = Scheduler::GlobalInstance();
-  scheduler.addTask(agg_op.createTask());
-
-  scheduler.start();
-  scheduler.join();
-
-  auto out_table = out_result->materialize({{nullptr, "data_sum"}});
-  //    out_table->print();
-
-  // Construct expected results
-  arrow::Status status;
-  status = int_builder.Append(150);
-  status = int_builder.Finish(&expected_agg_col_1);
-
-  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-}
-
-/*
- * SELECT count(R.data) as data_count
- * FROM R
- */
-TEST_F(AggregateTestFixture, CountTest) {
-    R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-
-    ColumnReference R_key_ref = {R, "key"};
-    ColumnReference R_group_ref = {R, "data"};
-
-    auto result = std::make_shared<OperatorResult>();
-    auto out_result = std::make_shared<OperatorResult>();
-    result->append(R);
-
-    AggregateReference agg_ref = {AggregateKernel::COUNT, "data_count", R, "data"};
-    Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-
-    Scheduler &scheduler = Scheduler::GlobalInstance();
-    scheduler.addTask(agg_op.createTask());
-
-    scheduler.start();
-    scheduler.join();
-
-    auto out_table = out_result->materialize({{nullptr, "data_count"}});
-    //    out_table->print();
-
-    // Construct expected results
-    arrow::Status status;
-    status = int_builder.Append(6);
-    status = int_builder.Finish(&expected_agg_col_1);
-
-    EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-}
+///*
+// * SELECT avg(R.data) as data_mean
+// * FROM R
+// */
+//TEST_F(AggregateTestFixture, MeanTest) {
+//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+//
+//  ColumnReference R_key_ref = {R, "key"};
+//  ColumnReference R_group_ref = {R, "data"};
+//
+//  auto result = std::make_shared<OperatorResult>();
+//  auto out_result = std::make_shared<OperatorResult>();
+//  result->append(R);
+//
+//  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
+//  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+//
+//  Scheduler &scheduler = Scheduler::GlobalInstance();
+//  scheduler.addTask(agg_op.createTask());
+//
+//  scheduler.start();
+//  scheduler.join();
+//
+//  auto out_table = out_result->materialize({{nullptr, "data_mean"}});
+//  //    out_table->print();
+//
+//  // Construct expected results
+//  arrow::Status status;
+//  status = double_builder.Append(((double)150) / 6);
+//  status = double_builder.Finish(&expected_agg_col_1);
+//
+//  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+//}
+//
+///*
+// * SELECT sum(R.data) as data_sum
+// * FROM R
+// */
+//TEST_F(AggregateTestFixture, SumTest) {
+//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+//
+//  ColumnReference R_key_ref = {R, "key"};
+//  ColumnReference R_group_ref = {R, "data"};
+//
+//  auto result = std::make_shared<OperatorResult>();
+//  auto out_result = std::make_shared<OperatorResult>();
+//  result->append(R);
+//
+//  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+//  Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+//  Scheduler &scheduler = Scheduler::GlobalInstance();
+//  scheduler.addTask(agg_op.createTask());
+//
+//  scheduler.start();
+//  scheduler.join();
+//
+//  auto out_table = out_result->materialize({{nullptr, "data_sum"}});
+//  //    out_table->print();
+//
+//  // Construct expected results
+//  arrow::Status status;
+//  status = int_builder.Append(150);
+//  status = int_builder.Finish(&expected_agg_col_1);
+//
+//  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+//}
+//
+///*
+// * SELECT count(R.data) as data_count
+// * FROM R
+// */
+//TEST_F(AggregateTestFixture, CountTest) {
+//    R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+//
+//    ColumnReference R_key_ref = {R, "key"};
+//    ColumnReference R_group_ref = {R, "data"};
+//
+//    auto result = std::make_shared<OperatorResult>();
+//    auto out_result = std::make_shared<OperatorResult>();
+//    result->append(R);
+//
+//    AggregateReference agg_ref = {AggregateKernel::COUNT, "data_count", R, "data"};
+//    Aggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+//
+//    Scheduler &scheduler = Scheduler::GlobalInstance();
+//    scheduler.addTask(agg_op.createTask());
+//
+//    scheduler.start();
+//    scheduler.join();
+//
+//    auto out_table = out_result->materialize({{nullptr, "data_count"}});
+//    //    out_table->print();
+//
+//    // Construct expected results
+//    arrow::Status status;
+//    status = int_builder.Append(6);
+//    status = int_builder.Finish(&expected_agg_col_1);
+//
+//    EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+//}
 
 /*
  * SELECT sum(R.data) as data_sum
@@ -252,7 +252,56 @@ TEST_F(AggregateTestFixture, CountTest) {
  * FROM R
  * GROUP BY R.group
  */
-TEST_F(AggregateTestFixture, SumWithGroupByTest) {
+//TEST_F(AggregateTestFixture, SumWithGroupByTest) {
+//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+//
+//  ColumnReference R_key_ref = {R, "key"};
+//  ColumnReference R_group_ref = {R, "group"};
+//
+//  auto result = std::make_shared<OperatorResult>();
+//  auto out_result = std::make_shared<OperatorResult>();
+//  result->append(R);
+//
+//  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+//  Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
+//                   {R_group_ref});
+//  Scheduler &scheduler = Scheduler::GlobalInstance();
+//  scheduler.addTask(agg_op.createTask());
+//
+//  scheduler.start();
+//  scheduler.join();
+//
+//  auto out_table =
+//      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+//  //    out_table->print();
+//
+//  // Construct expected results
+//  arrow::Status status;
+//  status = str_builder.AppendValues({"R2", "R1", "R0"});
+//  status = str_builder.Finish(&expected_agg_col_1);
+//
+//  status = int_builder.AppendValues({10, 50, 90});
+//  status = int_builder.Finish(&expected_agg_col_2);
+//
+//  auto group_col = std::static_pointer_cast<arrow::StringArray>(
+//      out_table->get_column(0)->chunk(0));
+//  auto agg_col = std::static_pointer_cast<arrow::Int64Array>(
+//      out_table->get_column(1)->chunk(0));
+//
+//  for (int i = 0; i < group_col->length(); i++) {
+//    if (group_col->GetString(i) == "R0") {
+//      ASSERT_EQ(agg_col->Value(i), 90);
+//    } else if (group_col->GetString(i) == "R1") {
+//      ASSERT_EQ(agg_col->Value(i), 50);
+//    } else if (group_col->GetString(i) == "R2") {
+//      ASSERT_EQ(agg_col->Value(i), 10);
+//    } else {
+//      FAIL();
+//    }
+//  }
+//}
+
+TEST_F(AggregateTestFixture, SumWithGroupByCompositeHashTest) {
   R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
 
   ColumnReference R_key_ref = {R, "key"};
@@ -265,6 +314,9 @@ TEST_F(AggregateTestFixture, SumWithGroupByTest) {
   AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
                    {R_group_ref});
+  // Set the strategy to composite hash keys.
+  agg_op.setStrategy(AggregateStrategy::COMPOSIT_HASH);
+
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
 
@@ -272,7 +324,7 @@ TEST_F(AggregateTestFixture, SumWithGroupByTest) {
   scheduler.join();
 
   auto out_table =
-      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+    out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
   //    out_table->print();
 
   // Construct expected results
@@ -284,9 +336,9 @@ TEST_F(AggregateTestFixture, SumWithGroupByTest) {
   status = int_builder.Finish(&expected_agg_col_2);
 
   auto group_col = std::static_pointer_cast<arrow::StringArray>(
-      out_table->get_column(0)->chunk(0));
+    out_table->get_column(0)->chunk(0));
   auto agg_col = std::static_pointer_cast<arrow::Int64Array>(
-      out_table->get_column(1)->chunk(0));
+    out_table->get_column(1)->chunk(0));
 
   for (int i = 0; i < group_col->length(); i++) {
     if (group_col->GetString(i) == "R0") {
@@ -301,43 +353,43 @@ TEST_F(AggregateTestFixture, SumWithGroupByTest) {
   }
 }
 
-/*
- * SELECT sum(R.data) as data_sum
- * FROM R
- * GROUP BY R.group
- * ORDER BY R.group
- */
-TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
-  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-
-  ColumnReference R_key_ref = {R, "key"};
-  ColumnReference R_group_ref = {R, "group"};
-
-  auto result = std::make_shared<OperatorResult>();
-  auto out_result = std::make_shared<OperatorResult>();
-  result->append(R);
-
-  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
-  Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-                   {R_group_ref});
-  Scheduler &scheduler = Scheduler::GlobalInstance();
-  scheduler.addTask(agg_op.createTask());
-
-  scheduler.start();
-  scheduler.join();
-
-  auto out_table =
-      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
-  //    out_table->print();
-
-  // Construct expected results
-  arrow::Status status;
-  status = str_builder.AppendValues({"R0", "R1", "R2"});
-  status = str_builder.Finish(&expected_agg_col_1);
-
-  status = int_builder.AppendValues({90, 50, 10});
-  status = int_builder.Finish(&expected_agg_col_2);
-
-  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-  EXPECT_TRUE(out_table->get_column(1)->chunk(0)->Equals(expected_agg_col_2));
-}
+///*
+// * SELECT sum(R.data) as data_sum
+// * FROM R
+// * GROUP BY R.group
+// * ORDER BY R.group
+// */
+//TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
+//  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+//
+//  ColumnReference R_key_ref = {R, "key"};
+//  ColumnReference R_group_ref = {R, "group"};
+//
+//  auto result = std::make_shared<OperatorResult>();
+//  auto out_result = std::make_shared<OperatorResult>();
+//  result->append(R);
+//
+//  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+//  Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
+//                   {R_group_ref});
+//  Scheduler &scheduler = Scheduler::GlobalInstance();
+//  scheduler.addTask(agg_op.createTask());
+//
+//  scheduler.start();
+//  scheduler.join();
+//
+//  auto out_table =
+//      out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+//  //    out_table->print();
+//
+//  // Construct expected results
+//  arrow::Status status;
+//  status = str_builder.AppendValues({"R0", "R1", "R2"});
+//  status = str_builder.Finish(&expected_agg_col_1);
+//
+//  status = int_builder.AppendValues({90, 50, 10});
+//  status = int_builder.Finish(&expected_agg_col_2);
+//
+//  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+//  EXPECT_TRUE(out_table->get_column(1)->chunk(0)->Equals(expected_agg_col_2));
+//}

--- a/src/operators/tests/aggregate_test.cc
+++ b/src/operators/tests/aggregate_test.cc
@@ -343,36 +343,3 @@ TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
   EXPECT_TRUE(out_table->get_column(1)->chunk(0)->Equals(expected_agg_col_2));
 }
 
-/*
- * SELECT avg(R.data) as data_mean
- * FROM R
- */
-TEST_F(AggregateTestFixture, MeanTestHashAgg){
-  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
-
-  ColumnReference R_key_ref = {R, "key"};
-  ColumnReference R_group_ref = {R, "data"};
-
-  auto result = std::make_shared<OperatorResult>();
-  auto out_result = std::make_shared<OperatorResult>();
-  result->append(R);
-
-  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
-  HashAggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
-
-  Scheduler &scheduler = Scheduler::GlobalInstance();
-  scheduler.addTask(agg_op.createTask());
-
-  scheduler.start();
-  scheduler.join();
-
-  auto out_table = out_result->materialize({{nullptr, "data_mean"}});
-  //    out_table->print();
-
-  // Construct expected results
-  arrow::Status status;
-  status = double_builder.Append(((double)150) / 6);
-  status = double_builder.Finish(&expected_agg_col_1);
-
-  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
-}

--- a/src/operators/tests/hash_aggregate_test.cc
+++ b/src/operators/tests/hash_aggregate_test.cc
@@ -1,0 +1,344 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "operators/aggregate.h"
+
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+
+#include <fstream>
+#include <operators/hash_aggregate.h>
+
+#include "execution/execution_plan.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "operators/join.h"
+#include "operators/select.h"
+#include "scheduler/scheduler.h"
+#include "storage/block.h"
+#include "storage/util.h"
+
+using namespace testing;
+using namespace hustle::operators;
+using namespace hustle;
+
+class HashAggregateTestFixture : public testing::Test {
+protected:
+  std::shared_ptr<arrow::Schema> schema;
+
+  arrow::Int64Builder int_builder;
+  arrow::DoubleBuilder double_builder;
+  arrow::StringBuilder str_builder;
+  std::shared_ptr<arrow::Array> expected_agg_col_1;
+  std::shared_ptr<arrow::Array> expected_agg_col_2;
+  std::shared_ptr<arrow::Array> expected_S_col_1;
+  std::shared_ptr<arrow::Array> expected_S_col_2;
+  std::shared_ptr<arrow::Array> expected_T_col_1;
+  std::shared_ptr<arrow::Array> expected_T_col_2;
+
+  std::shared_ptr<Table> R, S, T;
+
+  void SetUp() override {
+    arrow::Status status;
+
+    auto field_1 = arrow::field("key", arrow::int64());
+    auto field_2 = arrow::field("group", arrow::utf8());
+    auto field_3 = arrow::field("data", arrow::int64());
+
+    schema = arrow::schema({field_1, field_2, field_3});
+
+    std::ofstream R_csv;
+    std::ofstream S_csv;
+    std::ofstream T_csv;
+    R_csv.open("R.csv");
+    S_csv.open("S.csv");
+    T_csv.open("T.csv");
+
+    for (int i = 0; i < 6; i++) {
+      R_csv << std::to_string(i) << "|";
+      R_csv << "R" << std::to_string((5 - i) / 2) << "|";
+      R_csv << std::to_string(i * 10) << std::endl;
+    }
+    R_csv.close();
+
+    for (int i = 0; i < 4; i++) {
+      S_csv << std::to_string(3 - i) << "|";
+      S_csv << "S" << std::to_string(3 - i) << std::endl;
+    }
+    S_csv.close();
+
+    for (int i = 0; i < 5; i++) {
+      T_csv << std::to_string(i) << "|";
+      T_csv << "T" << std::to_string(i) << std::endl;
+    }
+    T_csv.close();
+  }
+};
+
+/*
+ * SELECT avg(R.data) as data_mean
+ * FROM R
+ */
+TEST_F(HashAggregateTestFixture, MeanTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "data"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::MEAN, "data_mean", R, "data"};
+  HashAggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table = out_result->materialize({{nullptr, "data_mean"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = double_builder.Append(((double)150) / 6);
+  status = double_builder.Finish(&expected_agg_col_1);
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+}
+
+/*
+ * SELECT sum(R.data) as data_sum
+ * FROM R
+ */
+TEST_F(HashAggregateTestFixture, SumTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "data"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+  HashAggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table = out_result->materialize({{nullptr, "data_sum"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = int_builder.Append(150);
+  status = int_builder.Finish(&expected_agg_col_1);
+
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+}
+
+/*
+ * SELECT count(R.data) as data_count
+ * FROM R
+ */
+TEST_F(HashAggregateTestFixture, CountTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "data"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::COUNT, "data_count", R, "data"};
+  HashAggregate agg_op(0, result, out_result, {agg_ref}, {}, {});
+
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table = out_result->materialize({{nullptr, "data_count"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = int_builder.Append(6);
+  status = int_builder.Finish(&expected_agg_col_1);
+
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+}
+
+/*
+ * SELECT sum(R.data) as data_sum
+ * FROM R
+ * WHERE R.group == "R0"
+ */
+// TEST_F(AggregateTestFixture, SumWithSelectTest) {
+//
+//    R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+//
+//    ColumnReference R_key_ref = {R, "key"};
+//    ColumnReference R_group_ref = {R, "data"};
+//
+//    auto select_pred = Predicate{
+//        {R, "group"},
+//        arrow::compute::CompareOperator::EQUAL,
+//        arrow::Datum(std::make_shared<arrow::StringScalar>("R0"))
+//    };
+//
+//    auto select_pred_node =
+//        std::make_shared<PredicateNode>(
+//            std::make_shared<Predicate>(select_pred));
+//
+//    auto select_pred_tree = std::make_shared<PredicateTree>(select_pred_node);
+//
+//    auto result = std::make_shared<OperatorResult>();
+//    auto out_result_select = std::make_shared<OperatorResult>();
+//    auto out_result_agg = std::make_shared<OperatorResult>();
+//    result->append(R);
+//
+//    Select select_op(0, result, out_result_select, select_pred_tree);
+//
+//    AggregateReference agg_ref = {AggregateKernels::SUM, "data_sum", R,
+//    "data"}; Aggregate agg_op(0, out_result_select, out_result_agg, {agg_ref},
+//    {}, {});
+//
+//    Scheduler &scheduler = Scheduler::GlobalInstance();
+//
+//    ExecutionPlan plan(0);
+//    auto select_id = plan.addOperator(&select_op);
+//    auto agg_id = plan.addOperator(&agg_op);
+//
+//    plan.createLink(select_id, agg_id);
+//    scheduler.addTask(&plan);
+//
+//    scheduler.start();
+//    scheduler.join();
+//
+//    auto out_table = out_result_agg->materialize({{nullptr, "data_sum"}});
+//    out_table->print();
+//
+//    // Construct expected results
+//    arrow::Status status;
+//    status = int_builder.Append(90);
+//    status = int_builder.Finish(&expected_agg_col_1);
+//
+//    EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+//}
+
+/*
+ * SELECT sum(R.data) as data_sum
+ * FROM R
+ * GROUP BY R.group
+ */
+TEST_F(HashAggregateTestFixture, SumWithGroupByTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "group"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+  HashAggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
+                   {R_group_ref});
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table =
+    out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = str_builder.AppendValues({"R2", "R1", "R0"});
+  status = str_builder.Finish(&expected_agg_col_1);
+
+  status = int_builder.AppendValues({10, 50, 90});
+  status = int_builder.Finish(&expected_agg_col_2);
+
+  auto group_col = std::static_pointer_cast<arrow::StringArray>(
+    out_table->get_column(0)->chunk(0));
+  auto agg_col = std::static_pointer_cast<arrow::Int64Array>(
+    out_table->get_column(1)->chunk(0));
+
+  for (int i = 0; i < group_col->length(); i++) {
+    if (group_col->GetString(i) == "R0") {
+      ASSERT_EQ(agg_col->Value(i), 90);
+    } else if (group_col->GetString(i) == "R1") {
+      ASSERT_EQ(agg_col->Value(i), 50);
+    } else if (group_col->GetString(i) == "R2") {
+      ASSERT_EQ(agg_col->Value(i), 10);
+    } else {
+      FAIL();
+    }
+  }
+}
+
+/*
+ * SELECT sum(R.data) as data_sum
+ * FROM R
+ * GROUP BY R.group
+ * ORDER BY R.group
+ */
+TEST_F(HashAggregateTestFixture, SumWithGroupByOrderByTest) {
+  R = read_from_csv_file("R.csv", schema, BLOCK_SIZE);
+
+  ColumnReference R_key_ref = {R, "key"};
+  ColumnReference R_group_ref = {R, "group"};
+
+  auto result = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  result->append(R);
+
+  AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
+  HashAggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
+                   {R_group_ref});
+  Scheduler &scheduler = Scheduler::GlobalInstance();
+  scheduler.addTask(agg_op.createTask());
+
+  scheduler.start();
+  scheduler.join();
+
+  auto out_table =
+    out_result->materialize({{nullptr, "group"}, {nullptr, "data_sum"}});
+  //    out_table->print();
+
+  // Construct expected results
+  arrow::Status status;
+  status = str_builder.AppendValues({"R0", "R1", "R2"});
+  status = str_builder.Finish(&expected_agg_col_1);
+
+  status = int_builder.AppendValues({90, 50, 10});
+  status = int_builder.Finish(&expected_agg_col_2);
+
+  EXPECT_TRUE(out_table->get_column(0)->chunk(0)->Equals(expected_agg_col_1));
+  EXPECT_TRUE(out_table->get_column(1)->chunk(0)->Equals(expected_agg_col_2));
+}
+


### PR DESCRIPTION
**Changes**
- Add `HashAggregate`. The usage is similar to `Aggregate` (see `hash_aggregate_test.cc`). 
- Add `HashAggregateStrategy`. For now, it is just a simple class to control the expected `partitions` and `chunk` to be used within each aggregate worker. More configs can be set in this class to control the behavior of hash aggregate.
- Add a simple `HashCombine` function. See `HashCombine`.

**To Reviewers**
The hash aggregate is getting a little bit too long, so I decided to organize a functional version and make a draft PR for review. @srsuryadev Would really love you to have a look at the code for some advice. 

Basically:

1. **Excessive type-checking.** You will see a lot of `switch` statements that determines the type of the column, type of kernel, hash map, etc. I am trying to abstract these away while ensuring comparable performance.

2. **Not using `arrow` properly.** `HashAggregate` is very different from `Aggregate`: we can't use `arrow::compute` to do the aggregation, so most of the hard works are spend talking to arrow (and try to talk nicely). I have tried to use `arrow` at the best I could, but couldn't write idiomatic `arrow` code in most cases because of the API. If @srsuryadev and @gaffneyk have suggestions, let me know and I will be more than happy to do a big change.


**Next Iteration**

- [x] Replace the `std::unordered_map` hash tables to `phmap`.
- [ ] Design an abstraction over the hash table, and remove some redundant type-checking codes of the arrow arrays.
- [ ] Refactor `arrow_compute_wrapper` and add some helpers to optimize the array construction.
- [ ] Eliminate most data copy.
- [x] Handle hash conflict more elegantly. (Using phmap and custom hash_combine function can eliminate the problem).
- [ ] Memory leak.