### PR TITLE
Make tuple_map sufficiently large at init time

### DIFF
--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -159,7 +159,7 @@ void HashAggregate::Initialize(Task *ctx) {
 
   // Initialize the Tuple Map
   tuple_map = new phmap::parallel_flat_hash_map<hash_t, std::tuple<int, int>>();
-  tuple_map->reserve(1024);
+  tuple_map->reserve(64);
 
 }
 

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -159,6 +159,7 @@ void HashAggregate::Initialize(Task *ctx) {
 
   // Initialize the Tuple Map
   tuple_map = new phmap::parallel_flat_hash_map<hash_t, std::tuple<int, int>>();
+  tuple_map->reserve(1024);
 
 }
 


### PR DESCRIPTION
Fixed #60. The trace shows that sometimes our `phmap::flat_hash_map<...> tuple_map` can hit an assertion to check if its capacity is large enough

https://github.com/UWHustle/hustle/blob/3406248302e8a8c75f8eca923cc3c1fb563749f7/src/utils/parallel_hashmap/phmap.h#L1815

and triggers the error. 

Reserve enough capacity will avoid this problem.