### PR TITLE
Add flag to toggle the SSBWorkload to use HashAggregate / normal aggregate

### DIFF
--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
         predicate.cc predicate.h
         operator.h
         operator_options.h
+        aggregate_options.h
         fused/select_build_hash.cc fused/select_build_hash.h
         fused/filter_join.cc fused/filter_join.h
         utils/lazy_table.cc utils/lazy_table.h

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
         utils/operator_result.cc utils/operator_result.h
         utils/lip.cc utils/lip.h
         ../utils/bloom_filter.h
-        ../utils/xxHash.h)
+        ../utils/xxHash.h base_aggregate.h)
 
 
 target_include_directories(hustle_src_operators PUBLIC ${ARROW_INCLUDE_DIR})

--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -46,7 +46,7 @@ Aggregate::Aggregate(const std::size_t query_id,
                      std::vector<ColumnReference> group_by_refs,
                      std::vector<ColumnReference> order_by_refs,
                      std::shared_ptr<OperatorOptions> options)
-    : Operator(query_id, options),
+    : BaseAggregate(query_id, options),
       prev_result_(prev_result),
       output_result_(output_result),
       aggregate_refs_(aggregate_refs),

--- a/src/operators/aggregate.h
+++ b/src/operators/aggregate.h
@@ -82,7 +82,7 @@ namespace operators {
  * which means the filtered aggregate column with have length 0. Thus, this
  * group will be excluded from the output.
  */
-class Aggregate : public Operator {
+class Aggregate : public BaseAggregate {
  public:
   /**
    * Construct an Aggregate operator. Group by and order by clauses are

--- a/src/operators/aggregate_const.h
+++ b/src/operators/aggregate_const.h
@@ -1,6 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Created by Ginda on 10/14/20.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef HUSTLE_AGGREGATE_CONST_H
 #define HUSTLE_AGGREGATE_CONST_H

--- a/src/operators/aggregate_const.h
+++ b/src/operators/aggregate_const.h
@@ -6,6 +6,7 @@
 #define HUSTLE_AGGREGATE_CONST_H
 
 #include "operators/operator.h"
+#include "base_aggregate.h"
 
 namespace hustle::operators {
 

--- a/src/operators/aggregate_const.h
+++ b/src/operators/aggregate_const.h
@@ -27,6 +27,9 @@ namespace hustle::operators {
 // Types of aggregates we can perform. COUNT is currently not supported.
 enum AggregateKernel { SUM, COUNT, MEAN };
 
+// Types of aggregate algorithm we can use.
+enum AggregateType { HASH_AGGREGATE, ARROW_AGGREGATE };
+
 /**
  * A reference structure containing all the information needed to perform an
  * aggregate over a column.

--- a/src/operators/aggregate_options.h
+++ b/src/operators/aggregate_options.h
@@ -19,11 +19,9 @@
 #define HUSTLE_AGGREGATE_OPTIONS_H
 
 #include "operator_options.h"
+#include "aggregate_const.h"
 
 namespace hustle::operators {
-
-// Types of aggregate algorithm we can use.
-enum AggregateType { HASH_AGGREGATE, ARROW_AGGREGATE };
 
 /**
  * The AggregateOptions define the scope of configurable parameters that

--- a/src/operators/aggregate_options.h
+++ b/src/operators/aggregate_options.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_AGGREGATE_OPTIONS_H
+#define HUSTLE_AGGREGATE_OPTIONS_H
+
+#include "operator_options.h"
+
+namespace hustle::operators {
+
+// Types of aggregate algorithm we can use.
+enum AggregateType { HASH_AGGREGATE, ARROW_AGGREGATE };
+
+/**
+ * The AggregateOptions define the scope of configurable parameters that
+ * user can choose when aggregation happens.
+ * TODO: Expand the options to configurate the aggregation.
+ */
+class AggregateOptions: public OperatorOptions {
+public:
+  explicit AggregateOptions(): aggregateType(AggregateType::ARROW_AGGREGATE) {};
+
+  double get_aggregate_type() const { return aggregateType; }
+  /**
+   * Select the aggregate algorithm (arrow.compute or our own hash aggregate)
+   */
+  AggregateOptions & set_aggregate_type(AggregateType type){
+    aggregateType = type;
+    return *this;
+  }
+
+private:
+  AggregateType aggregateType;
+
+};
+
+}
+
+#endif //HUSTLE_AGGREGATE_OPTIONS_H

--- a/src/operators/base_aggregate.h
+++ b/src/operators/base_aggregate.h
@@ -22,9 +22,18 @@
 
 namespace hustle::operators {
 
-class BaseAggregate: public Operator {};
+class BaseAggregate: public Operator {
+protected:
+
+  explicit BaseAggregate(const size_t query_id)
+  : BaseAggregate(query_id, std::make_shared<OperatorOptions>()){};
+
+  explicit BaseAggregate(const size_t query_id,
+                         std::shared_ptr<OperatorOptions> sharedPtr)
+    : Operator(query_id, sharedPtr) {};
+
+};
 
 }; // namespace hustle::operators
-
 
 #endif //HUSTLE_BASE_AGGREGATE_H

--- a/src/operators/base_aggregate.h
+++ b/src/operators/base_aggregate.h
@@ -1,6 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Created by Ginda on 11/6/20.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef HUSTLE_BASE_AGGREGATE_H
 #define HUSTLE_BASE_AGGREGATE_H

--- a/src/operators/base_aggregate.h
+++ b/src/operators/base_aggregate.h
@@ -1,0 +1,17 @@
+//
+// Created by Ginda on 11/6/20.
+//
+
+#ifndef HUSTLE_BASE_AGGREGATE_H
+#define HUSTLE_BASE_AGGREGATE_H
+
+#include "operator.h"
+
+namespace hustle::operators {
+
+class BaseAggregate: public Operator {};
+
+}; // namespace hustle::operators
+
+
+#endif //HUSTLE_BASE_AGGREGATE_H

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -41,6 +41,11 @@ int HashAggregateStrategy::suggestedNumTasks() const {
 }
 
 std::tuple<int, int> HashAggregateStrategy::getChunkID(
+  // TODO: We assume each chunk has the same number of data.
+  //   It is not always true. The correct algorithm is to
+  //      linearly traverse the chunkarray.
+  //   Change this algorithm to a generate (and yield the
+  //      result each time we calls it).
   int tid, int totalThreads, int totalNumChunks){
 
   assert(tid >= 0);
@@ -94,7 +99,7 @@ HashAggregate::HashAggregate(const std::size_t query_id,
                              std::vector<ColumnReference> group_by_refs,
                              std::vector<ColumnReference> order_by_refs,
                              std::shared_ptr<OperatorOptions> options)
-  : Operator(query_id, options),
+  : BaseAggregate(query_id, options),
     prev_result_(prev_result),
     output_result_(output_result),
     aggregate_refs_(aggregate_refs),

--- a/src/operators/hash_aggregate.h
+++ b/src/operators/hash_aggregate.h
@@ -41,7 +41,7 @@ private:
 
 };
 
-class HashAggregate : public Operator {
+class HashAggregate : public BaseAggregate {
   /**
    * Two-phase aggregate.
    * Procedure:

--- a/src/operators/operator_options.h
+++ b/src/operators/operator_options.h
@@ -30,7 +30,7 @@ class OperatorOptions {
   explicit OperatorOptions() : parallel_factor_(1.0) {}
   double get_parallel_factor() const { return parallel_factor_; }
 
-  OperatorOptions set_parallel_factor(double parallel_factor) {
+  OperatorOptions & set_parallel_factor(double parallel_factor) {
     parallel_factor_ = parallel_factor;
     return *this;
   }


### PR DESCRIPTION
Related to #58.

**Changes**
- Add a `constexpr int aggregate_type` flag inside the `SSBWorkload` to toggle the aggregate operator.
- Use the `get_agg_op` function to return the proper aggregate operator depending on the `aggregate_type` constant.

@srsuryadev I had a [previous commit](https://github.com/UWHustle/hustle/pull/62/commits/f817735d5f3b15aa8bc6fc47fd498301fad06c58#diff-6e6798c8cca4f0af65f5ef611297d16f9d2bcb4992338257bbd943414d1be45aR37-R55) that use preprocessor to do the job - it just looked uglier... Also, I am a little bit struggled to the factory pattern to generate the proper aggregate operator. Let me know if you have any idea.