### PR TITLE
Added Existing Hustle Schema as wrappers to the arrow schemas (3/n)

### DIFF
--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -18,6 +18,7 @@
 #ifndef HUSTLE_HUSTLEDB_H
 #define HUSTLE_HUSTLEDB_H
 
+#include <memory>
 #include <string>
 
 #include "absl/strings/str_cat.h"
@@ -31,6 +32,12 @@ namespace hustle {
 
 class HustleDB {
  public:
+  static std::map<std::string, std::shared_ptr<Catalog>> catalogs;
+
+  static void addCatalog(std::string db_name, std::shared_ptr<Catalog> catalog);
+
+  static std::shared_ptr<Catalog> getCatalog(std::string db_name);
+
   HustleDB(std::string path);
 
   bool createTable(const TableSchema ts);
@@ -41,22 +48,20 @@ class HustleDB {
 
   std::string getPlan(const std::string &sql);
 
-  const std::string getSqliteDBPath() {
-    return SqliteDBPath_;
-  }
+  const std::string getSqliteDBPath() { return SqliteDBPath_; }
   // Not implemented yet.
   bool insert();
 
   // Not implemented yet.
   bool select();
 
-  Catalog *getCatalog() { return &catalog_; }
+  Catalog *getCatalog() { return catalog_.get(); }
 
  private:
   const std::string DBPath_;
   const std::string CatalogPath_;
   const std::string SqliteDBPath_;
-  Catalog catalog_;
+  std::shared_ptr<Catalog> catalog_;
 };
 
 }  // namespace hustle

--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(
         absl::flat_hash_map
         map_utils
         sqlite_utils
+        ${ARROW_SHARED_LIB}
 )
 
 

--- a/src/catalog/catalog.cc
+++ b/src/catalog/catalog.cc
@@ -93,8 +93,24 @@ Catalog Catalog::CreateCatalog(std::string CatalogPath,
   }
 }
 
+std::shared_ptr<Catalog> Catalog::CreateCatalogObject(std::string CatalogPath,
+                                                      std::string SqlitePath) {
+  return std::make_shared<Catalog>(CatalogPath, SqlitePath);
+}
+
 std::shared_ptr<DBTable> Catalog::getTable(size_t table_id) {
   // TODO: maintain a structure for storing tables in the db
+  return nullptr;
+}
+
+std::shared_ptr<DBTable> Catalog::getTable(std::string name) {
+  auto search = name_to_id_.find(name);
+  if (search == name_to_id_.end()) {
+    return nullptr;
+  }
+  if (name_to_id_[name] < table_refs_.size()) {
+    return table_refs_[name_to_id_[name]];
+  }
   return nullptr;
 }
 

--- a/src/catalog/catalog.h
+++ b/src/catalog/catalog.h
@@ -48,6 +48,8 @@ namespace catalog {
 class Catalog {
  public:
   static Catalog CreateCatalog(std::string CatalogPath, std::string SqlitePath);
+  static std::shared_ptr<Catalog> CreateCatalogObject(std::string CatalogPath,
+                                                      std::string SqlitePath);
 
   bool addTable(TableSchema t);
 
@@ -58,6 +60,7 @@ class Catalog {
   void print() const;
 
   std::shared_ptr<DBTable> getTable(size_t table_id);
+  std::shared_ptr<DBTable> getTable(std::string table_name);
 
   int getTableIdbyName(const std::string& name) { return name_to_id_[name]; }
 
@@ -68,17 +71,20 @@ class Catalog {
             CEREAL_NVP(name_to_id_), CEREAL_NVP(tables_));
   }
 
+  Catalog(){};
+
+  Catalog(std::string CatalogPath, std::string SqlitePath)
+      : CatalogPath_(CatalogPath), SqlitePath_(SqlitePath){};
+
  private:
   // Serializes and writes the catalog to a file in json format.
   void SaveToFile();
 
   // TODO(chronis) make private
-  Catalog(){};
-  Catalog(std::string CatalogPath, std::string SqlitePath)
-      : CatalogPath_(CatalogPath), SqlitePath_(SqlitePath){};
 
   std::vector<TableSchema> tables_;
-  absl::flat_hash_map<std::string, int> name_to_id_;
+  std::vector<std::shared_ptr<DBTable>> table_refs_;
+  std::map<std::string, int> name_to_id_;
   std::string CatalogPath_;
   std::string SqlitePath_;
 

--- a/src/catalog/column_schema.h
+++ b/src/catalog/column_schema.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "absl/strings/str_cat.h"
+#include "arrow/api.h"
 
 namespace hustle {
 namespace catalog {
@@ -88,7 +89,31 @@ class ColumnType {
 class ColumnSchema {
  public:
   ColumnSchema(std::string name, ColumnType type, bool notNull, bool unique)
-      : name_(name), type_(type), notNull_(notNull), unique_(unique){};
+      : name_(name), type_(type), notNull_(notNull), unique_(unique) {
+    switch (type.getHustleType()) {
+      case HustleType::CHAR: {
+        field_ = arrow::field(name, arrow::utf8());
+        break;
+      }
+      case HustleType::INTEGER: {
+        field_ = arrow::field(name, arrow::int64());
+        break;
+      }
+      default: {
+        // not supported
+        // TODO: throw exception
+      }
+    }
+    /*
+    if (type.getHustleType() == HustleType::CHAR) {
+      field_ = arrow::field(name, arrow::utf8());
+    } else if (type.getHustleType() == HustleType::INTEGER) {
+      field_ = arrow::field(name, arrow::int64());
+    } else {
+      // not supported
+      // TODO: throw exception
+    }*/
+  };
 
   // TODO(chronis) make private
   ColumnSchema(){};
@@ -97,6 +122,7 @@ class ColumnSchema {
   const ColumnType &getType() const { return type_; }
   const HustleType &getHustleType() const { return type_.getHustleType(); }
   const std::optional<int> &getTypeSize() const { return type_.getSize(); }
+  const std::shared_ptr<arrow::Field> getField() const { return field_; }
   const bool isUnique() const { return unique_; }
   const bool isNotNull() const { return notNull_; }
 
@@ -118,6 +144,7 @@ class ColumnSchema {
   ColumnType type_;
   bool notNull_;
   bool unique_;
+  std::shared_ptr<arrow::Field> field_;  // support arrow field
 };
 
 }  // namespace catalog

--- a/src/catalog/column_schema.h
+++ b/src/catalog/column_schema.h
@@ -28,6 +28,8 @@ namespace catalog {
 
 enum HustleType { INTEGER, CHAR };
 
+const int kDefaultCharSize = 64;
+
 class ColumnType {
  public:
   ColumnType(HustleType type) : type_(type), size_(std::nullopt){};

--- a/src/catalog/table_schema.cc
+++ b/src/catalog/table_schema.cc
@@ -35,6 +35,7 @@ bool TableSchema::addColumn(ColumnSchema c) {
           c.getName(), name_to_id_)) {
     return false;
   }
+  fields_.push_back(c.getField());
   columns_.push_back(c);
   name_to_id_[c.getName()] = columns_.size() - 1;
   return true;

--- a/src/catalog/table_schema.h
+++ b/src/catalog/table_schema.h
@@ -48,6 +48,10 @@ class TableSchema {
 
   const std::string& getName() const { return name_; }
 
+  const std::shared_ptr<arrow::Schema> getArrowSchema() const {
+    return arrow::schema(fields_);
+  }
+
   void print() const;
 
   template <class Archive>
@@ -60,6 +64,7 @@ class TableSchema {
   std::string name_;
   std::vector<std::string> primary_key_;
   std::vector<ColumnSchema> columns_;
+  std::vector<std::shared_ptr<arrow::Field>> fields_;
   absl::flat_hash_map<std::string, int> name_to_id_;
 };
 

--- a/src/catalog/tests/catalog_test.cc
+++ b/src/catalog/tests/catalog_test.cc
@@ -245,6 +245,108 @@ TEST(TableSchema, Serialization) {
   EXPECT_THAT(ts_cereal.getPrimaryKey(), ElementsAre("c1", "c2"));
 }
 
+TEST(TableSchema, basic_arrow_test1) {
+  TableSchema ts("Subscriber");
+
+  EXPECT_EQ(ts.getName(), "Subscriber");
+
+  EXPECT_FALSE(ts.ColumnExists("c1"));
+
+  EXPECT_TRUE(ts.addColumn({"c1", {HustleType::INTEGER}, true, false}));
+
+  EXPECT_TRUE(ts.ColumnExists("c1"));
+  EXPECT_EQ(ts.ColumnExists("c1").value()->getName(), "c1");
+
+  std::shared_ptr<arrow::Schema> arrow_schema = ts.getArrowSchema();
+  EXPECT_EQ(arrow_schema->field_names().size(), 1);
+}
+
+TEST(TableSchema, basic_arrow_test2) {
+  TableSchema ts("Subscriber");
+
+  EXPECT_EQ(ts.getName(), "Subscriber");
+
+  EXPECT_FALSE(ts.ColumnExists("c1"));
+  EXPECT_FALSE(ts.ColumnExists("c2"));
+
+  EXPECT_TRUE(ts.addColumn({"c1", {HustleType::INTEGER}, true, false}));
+  EXPECT_TRUE(ts.addColumn({"c2", {HustleType::CHAR, 10}, false, true}));
+  EXPECT_FALSE(ts.addColumn({"c2", {HustleType::CHAR, 10}, false, true}));
+
+  EXPECT_TRUE(ts.ColumnExists("c1"));
+  EXPECT_EQ(ts.ColumnExists("c1").value()->getName(), "c1");
+  EXPECT_TRUE(ts.ColumnExists("c2"));
+  EXPECT_EQ(ts.ColumnExists("c2").value()->getName(), "c2");
+
+  std::shared_ptr<arrow::Schema> arrow_schema = ts.getArrowSchema();
+  EXPECT_EQ(arrow_schema->field_names().size(), 2);
+}
+
+TEST(TableSchema, arrow_test) {
+  TableSchema ts("Subscriber");
+  EXPECT_EQ(ts.getName(), "Subscriber");
+
+  TableSchema ts_p("Producer");
+  EXPECT_EQ(ts_p.getName(), "Producer");
+
+  EXPECT_FALSE(ts.ColumnExists("c1"));
+  EXPECT_FALSE(ts.ColumnExists("c2"));
+
+  EXPECT_TRUE(ts.addColumn({"c1", {HustleType::INTEGER}, true, false}));
+  EXPECT_TRUE(ts.addColumn({"c2", {HustleType::CHAR, 10}, false, true}));
+  EXPECT_FALSE(ts.addColumn({"c2", {HustleType::CHAR, 10}, false, true}));
+
+  EXPECT_TRUE(ts.ColumnExists("c1"));
+  EXPECT_EQ(ts.ColumnExists("c1").value()->getName(), "c1");
+  EXPECT_TRUE(ts.ColumnExists("c2"));
+  EXPECT_EQ(ts.ColumnExists("c2").value()->getName(), "c2");
+
+  std::shared_ptr<arrow::Schema> arrow_schema = ts.getArrowSchema();
+  EXPECT_EQ(arrow_schema->field_names().size(), 2);
+
+  EXPECT_FALSE(ts_p.ColumnExists("c1"));
+  EXPECT_FALSE(ts_p.ColumnExists("c2"));
+  EXPECT_FALSE(ts_p.ColumnExists("c3"));
+  EXPECT_FALSE(ts_p.ColumnExists("c4"));
+  EXPECT_FALSE(ts_p.ColumnExists("c5"));
+  EXPECT_FALSE(ts_p.ColumnExists("c6"));
+
+  EXPECT_TRUE(ts_p.addColumn({"c1", {HustleType::INTEGER}, true, false}));
+  EXPECT_TRUE(ts_p.addColumn({"c2", {HustleType::CHAR, 10}, false, true}));
+  EXPECT_TRUE(ts_p.addColumn({"c3", {HustleType::INTEGER}, true, false}));
+  EXPECT_TRUE(ts_p.addColumn({"c4", {HustleType::CHAR, 10}, false, true}));
+  EXPECT_TRUE(ts_p.addColumn({"c5", {HustleType::CHAR, 10}, false, true}));
+  EXPECT_TRUE(ts_p.addColumn({"c6", {HustleType::CHAR, 10}, false, true}));
+
+  EXPECT_TRUE(ts_p.ColumnExists("c1"));
+  EXPECT_EQ(ts_p.ColumnExists("c1").value()->getName(), "c1");
+  EXPECT_TRUE(ts_p.ColumnExists("c2"));
+  EXPECT_EQ(ts_p.ColumnExists("c2").value()->getName(), "c2");
+  EXPECT_TRUE(ts_p.ColumnExists("c3"));
+  EXPECT_EQ(ts_p.ColumnExists("c3").value()->getName(), "c3");
+  EXPECT_TRUE(ts_p.ColumnExists("c4"));
+  EXPECT_EQ(ts_p.ColumnExists("c4").value()->getName(), "c4");
+  EXPECT_TRUE(ts_p.ColumnExists("c5"));
+  EXPECT_EQ(ts_p.ColumnExists("c5").value()->getName(), "c5");
+  EXPECT_TRUE(ts_p.ColumnExists("c6"));
+  EXPECT_EQ(ts_p.ColumnExists("c6").value()->getName(), "c6");
+
+  arrow_schema = ts_p.getArrowSchema();
+  EXPECT_EQ(arrow_schema->field_names().size(), 6);
+  EXPECT_EQ((*arrow_schema->field(0)).name(), "c1");
+  EXPECT_EQ((*arrow_schema->field(0)).type(), arrow::int64());
+  EXPECT_EQ((*arrow_schema->field(1)).name(), "c2");
+  EXPECT_EQ((*arrow_schema->field(1)).type(), arrow::utf8());
+  EXPECT_EQ((*arrow_schema->field(2)).name(), "c3");
+  EXPECT_EQ((*arrow_schema->field(2)).type(), arrow::int64());
+  EXPECT_EQ((*arrow_schema->field(3)).name(), "c4");
+  EXPECT_EQ((*arrow_schema->field(3)).type(), arrow::utf8());
+  EXPECT_EQ((*arrow_schema->field(4)).name(), "c5");
+  EXPECT_EQ((*arrow_schema->field(4)).type(), arrow::utf8());
+  EXPECT_EQ((*arrow_schema->field(5)).name(), "c6");
+  EXPECT_EQ((*arrow_schema->field(5)).type(), arrow::utf8());
+}
+
 namespace hustle {
 namespace catalog {
 

--- a/src/resolver/CMakeLists.txt
+++ b/src/resolver/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(hustle_src_resolver
         hustle_src_parser
         hustle_src_operators
         hustle_src_catalog
+        hustleDB
 )
 
 

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -2,9 +2,11 @@
 
 #include <iostream>
 
+#include "api/hustle_db.h"
+#include "catalog/catalog.h"
 #include "resolver/select_resolver.h"
 
-int resolveSelect(Sqlite3Select* queryTree) {
+int resolveSelect(char* dbName, Sqlite3Select* queryTree) {
   ExprList* pEList = queryTree->pEList;
   Expr* pWhere = queryTree->pWhere;
   ExprList* pGroupBy = queryTree->pGroupBy;
@@ -13,9 +15,12 @@ int resolveSelect(Sqlite3Select* queryTree) {
 
   // TODO: (@srsuryadev) resolve the select query
   // return 0 if query is supported in column store else return 1
-
   using hustle::resolver::SelectResolver;
-  SelectResolver* select_resolver = new SelectResolver();
+  Catalog* catalog = hustle::HustleDB::getCatalog(dbName).get();
+  if (dbName == NULL || catalog == nullptr) return 0;
+
+  SelectResolver* select_resolver = new SelectResolver(catalog);
   select_resolver->ResolveSelectTree(queryTree);
+  delete select_resolver;
   return 0;
 }

--- a/src/resolver/cresolver.h
+++ b/src/resolver/cresolver.h
@@ -696,7 +696,7 @@ struct Schema {
   int cache_size;      /* Number of pages to use in the cache */
 };
 
-int resolveSelect(Select* queryTree);
+int resolveSelect(char* dbName, Select* queryTree);
 
 #ifdef __cplusplus
 }

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -26,9 +26,9 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
 
       if ((leftExpr != NULL && leftExpr->op == TK_COLUMN) &&
           (rightExpr != NULL && rightExpr->op == TK_COLUMN)) {
-        lRef = {catalog_->getTable(leftExpr->iTable),
+        lRef = {catalog_->getTable(leftExpr->y.pTab->zName),
                 leftExpr->y.pTab->aCol[leftExpr->iColumn].zName};
-        rRef = {catalog_->getTable(rightExpr->iTable),
+        rRef = {catalog_->getTable(rightExpr->y.pTab->zName),
                 rightExpr->y.pTab->aCol[rightExpr->iColumn].zName};
         JoinPredicate join_pred = {lRef, arrow::compute::EQUAL, rRef};
         join_predicates_->emplace_back(join_pred);
@@ -97,7 +97,7 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
       if ((leftExpr != NULL && leftExpr->op == TK_COLUMN) &&
           (rightExpr != NULL &&
            (rightExpr->op == TK_INTEGER || rightExpr->op == TK_STRING))) {
-        colRef = {catalog_->getTable(leftExpr->iTable),
+        colRef = {catalog_->getTable(leftExpr->y.pTab->zName),
                   leftExpr->y.pTab->aCol[leftExpr->iColumn].zName};
         if (rightExpr->op == TK_STRING) {
           datum = arrow::Datum(
@@ -147,7 +147,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     if (pEList->a[k].pExpr->op == TK_AGG_FUNCTION) {
       Expr* expr = pEList->a[k].pExpr->x.pList->a[0].pExpr;
       if (expr->iColumn > 0) {
-        ColumnReference colRef = {catalog_->getTable(expr->iTable),
+        ColumnReference colRef = {catalog_->getTable(expr->y.pTab->zName),
                                   expr->y.pTab->aCol[expr->iColumn].zName};
         char* zName = NULL;
         if (pEList->a[k].zEName != NULL) {
@@ -164,7 +164,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     } else if (pEList->a[k].pExpr->op == TK_COLUMN ||
                pEList->a[k].pExpr->op == TK_AGG_COLUMN) {
       Expr* expr = pEList->a[k].pExpr;
-      ColumnReference colRef = {catalog_->getTable(expr->iTable),
+      ColumnReference colRef = {catalog_->getTable(expr->y.pTab->zName),
                                 expr->y.pTab->aCol[expr->iColumn].zName};
       std::shared_ptr<ProjectReference> projRef =
           std::make_shared<ProjectReference>(ProjectReference{colRef});
@@ -188,7 +188,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
       if (pGroupBy->a[i].pExpr->iColumn >= 1) {
         std::shared_ptr<ColumnReference> colRef =
             std::make_shared<ColumnReference>(ColumnReference{
-                catalog_->getTable(pGroupBy->a[i].pExpr->iTable),
+                catalog_->getTable(pGroupBy->a[i].pExpr->y.pTab->zName),
                 pGroupBy->a[i]
                     .pExpr->y.pTab->aCol[pGroupBy->a[i].pExpr->iColumn]
                     .zName});
@@ -211,7 +211,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
                     ->alias});
           } else {
             colRef = std::make_shared<ColumnReference>(ColumnReference{
-                catalog_->getTable(pOrderBy->a[i].pExpr->iTable),
+                catalog_->getTable(pOrderBy->a[i].pExpr->y.pTab->zName),
                 pOrderBy->a[i]
                     .pExpr->y.pTab->aCol[pOrderBy->a[i].pExpr->iColumn]
                     .zName});
@@ -221,8 +221,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
       }
     }
   }
- 
-  return true; // TODO: return true or false based on query resolvability
+  return true;  // TODO: return true or false based on query resolvability
 }
 }  // namespace resolver
 }  // namespace hustle

--- a/src/resolver/tests/resolver_test.cc
+++ b/src/resolver/tests/resolver_test.cc
@@ -354,7 +354,7 @@ TEST_F(ResolverTest, q1) {
 
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 1);
@@ -379,9 +379,12 @@ TEST_F(ResolverTest, q2) {
       "and lo_discount < 6\n"
       "and lo_quantity < 35;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 1);
@@ -406,9 +409,12 @@ TEST_F(ResolverTest, q3) {
       "and lo_discount < 7\n"
       "and lo_quantity < 40;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 1);
@@ -435,9 +441,12 @@ TEST_F(ResolverTest, q4) {
       "group by d_year, p_brand1\n"
       "order by d_year, p_brand1;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -464,9 +473,12 @@ TEST_F(ResolverTest, q5) {
       "\tgroup by d_year, p_brand1\n"
       "\torder by d_year, p_brand1;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -493,9 +505,12 @@ TEST_F(ResolverTest, q6) {
       "\tgroup by d_year, p_brand1\n"
       "\torder by d_year, p_brand1;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -524,9 +539,12 @@ TEST_F(ResolverTest, q7) {
       "\tgroup by c_nation, s_nation, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -555,9 +573,12 @@ TEST_F(ResolverTest, q8) {
       "\tgroup by c_city, s_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -586,9 +607,12 @@ TEST_F(ResolverTest, q9) {
       "\tgroup by c_city, s_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -617,9 +641,12 @@ TEST_F(ResolverTest, q10) {
       "\tgroup by c_city, s_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 3);
@@ -649,9 +676,12 @@ TEST_F(ResolverTest, q11) {
       "\tgroup by d_year, c_nation\n"
       "\torder by d_year, c_nation;";
 
+  std::cout << "For query: " << query << std::endl
+            << "The plan is: " << std::endl
+            << hustleDB.getPlan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
       hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver;
+  SelectResolver select_resolver(hustleDB.getCatalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.get_join_predicates()->size(), 4);

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -42,7 +42,7 @@ class DBTable {
    * @param block_capacity Block size
    */
   DBTable(std::string name, const std::shared_ptr<arrow::Schema> &schema,
-        int block_capacity);
+          int block_capacity);
 
   /**
    * Construct a table from a vector of RecordBatches read from a file.
@@ -52,8 +52,8 @@ class DBTable {
    * @param block_capacity Block size
    */
   DBTable(std::string name,
-        std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches,
-        int block_capacity);
+          std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches,
+          int block_capacity);
 
   //
   /**
@@ -162,6 +162,8 @@ class DBTable {
   void print();
 
   std::shared_ptr<arrow::ChunkedArray> get_valid_column();
+
+  std::string get_name() const { return table_name; }
 
   int get_num_cols() const;
 

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -82,7 +82,6 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
   int rc;
 
   rc = sqlite3_open(sqlitePath.c_str(), &db);
-
   if (rc) {
     fprintf(stderr, "Can't open sqlite catalog database: %s\n",
             sqlite3_errmsg(db));
@@ -101,7 +100,6 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
     //    fprintf(stdout, "Query ececuted successfully\n");
   }
   sqlite3_close(db);
-
   return true;
 }
 


### PR DESCRIPTION
### Summary (Simple changes)

* In this pull request, added the arrow schemas to the catalog module in hustle by using existing TableSchema and ColumnSchema classes in the hustle catalog as wrappers.
* Added vector of pointers to arrow tables in the catalog for references in other modules, especially the resolver.
* Added static map containing a list of catalog objects for different database schemas that are present in the hustle, so that the relevant catalog object can be accessed in the resolver based on the database at which the query is executed.

### Test
* Added additional Unit test for the catalog. (Will do the integration test and other full flow tests once the operator execution is integrated with the resolver in the subsequent pull requests).