### PR TITLE
Aggregate benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Brewfile.lock.json
 arrow/
 ssb/
 .vscode/
+cmake-3.15.5/

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ debug
 Brewfile.lock.json
 arrow/
 ssb/
+!scripts/ssb/
 .vscode/
 cmake-3.15.5/

--- a/scripts/ssb/gen_benchmark_data.sh
+++ b/scripts/ssb/gen_benchmark_data.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCALE_FACTOR=1
+SCALE_FACTOR=$1
 
 cur_dir=`dirname $0`
 src_dir=${cur_dir}/../..
@@ -17,5 +17,7 @@ cd ssb-dbgen
 cmake . && cmake --build .
 
 # generate ssb data for benchmark
+echo Run benchmark on scale factor $SCALE_FACTOR 
+echo    ./dbgen -v -s $SCALE_FACTOR
 ./dbgen -v -s $SCALE_FACTOR
 cp *.tbl ../.

--- a/scripts/ssb/run_benchmark.sh
+++ b/scripts/ssb/run_benchmark.sh
@@ -5,4 +5,4 @@ src_dir=${cur_dir}/../..
 
 # run the benchmark
 cd ${src_dir}/build/src/benchmark/
-./hustle_src_benchmark_main
+./hustle_src_benchmark_main --agg_op $1

--- a/scripts/ssb/run_benchmark_suite.sh
+++ b/scripts/ssb/run_benchmark_suite.sh
@@ -1,0 +1,8 @@
+cur_dir=`dirname $0`
+
+for i in 16 32 64 128 256; do
+    echo Run benchmark on $i scale factor
+    sh ${cur_dir}/gen_benchmark_data.sh $i
+    sh ${cur_dir}/run_benchmark.sh hash_aggregate| tee "result_ssb_$(date '+%Y%m%d_%H%M%S')_hash_$i.txt"
+	sh ${cur_dir}/run_benchmark.sh arrow_aggregate| tee "result_ssb_$(date '+%Y%m%d_%H%M%S')_arrow_$i.txt"
+done

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(benchmark REQUIRED)
 add_library(hustle_src_benchmark
         ssb_workload.cc ssb_workload.h
-        ssb_workload_lip.cc)
+        ssb_workload_lip.cc
+        aggregate_workload.cc aggregate_workload.h)
 
 target_include_directories(hustle_src_benchmark PUBLIC ${ARROW_INCLUDE_DIR})
 target_link_libraries(hustle_src_benchmark PUBLIC
@@ -17,7 +18,8 @@ target_link_libraries(hustle_src_benchmark PUBLIC
 
 add_executable(hustle_src_benchmark_main main.cc
         ../utils/bloom_filter.h
-        ../utils/xxHash.h)
+        ../utils/xxHash.h
+        aggregate_workload.cc aggregate_workload.h)
 target_link_libraries(hustle_src_benchmark_main PUBLIC
         hustle_src_benchmark
         benchmark::benchmark

--- a/src/benchmark/aggregate_workload.cc
+++ b/src/benchmark/aggregate_workload.cc
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+#include <operators/utils/aggregate_factory.h>
+#include "aggregate_workload.h"
+
+namespace hustle::operators {
+
+AggregateWorkload::AggregateWorkload(int cardinality, int numGroupby) {
+
+  this->cardinality = cardinality;
+  this->num_group_by = numGroupby;
+
+  auto aggregate_parallel_factor = std::thread::hardware_concurrency();
+  this->num_threads_ = aggregate_parallel_factor;
+
+  this->aggregate_options = std::make_shared<OperatorOptions>();
+  aggregate_options->set_parallel_factor(aggregate_parallel_factor);
+
+  this->scheduler = std::make_shared<Scheduler>(num_threads_, true);
+};
+
+
+void AggregateWorkload::prepareData() {
+
+  // Build schema of the input table
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+
+  for (int i = 0; i < 1 + num_group_by; ++i) {
+    auto colname = "Col" + std::to_string(i);
+    fields.push_back(arrow::field(colname, arrow::int64()));
+
+    std::shared_ptr<arrow::Int64Array> col;
+
+    arrow::Int64Builder builder;
+    builder.Reserve(cardinality);
+    for (int j = 0; j < cardinality; ++j) {
+      builder.UnsafeAppend(j);
+    }
+    builder.Finish(&col);
+
+    inputData.push_back(col->data());
+  }
+
+  schema = arrow::schema(fields);
+
+  inputTable = std::make_shared<hustle::storage::DBTable>(
+    "table", schema, BLOCK_SIZE);
+
+  inputTable->insert_records(inputData);
+}
+
+std::string
+AggregateWorkload::eventName(AggregateType t, const std::string & name) {
+  if (t == AggregateType::ARROW_AGGREGATE) {
+    return name + "_arrow";
+  } else if (t == AggregateType::HASH_AGGREGATE) {
+    return name + "_hash";
+  }
+  throw std::runtime_error("Unkown aggregate type");
+}
+
+void AggregateWorkload::q1(AggregateType agg_type) {
+
+  auto input_ = std::make_shared<OperatorResult>();
+  auto out_result = std::make_shared<OperatorResult>();
+  input_->append(inputTable);
+
+  AggregateReference agg_ref = {
+    AggregateKernel::MEAN, "agg_col", inputTable, "Col0"};
+  std::vector<ColumnReference> group_by_refs;
+  std::vector<ColumnReference> output_refs;
+
+  output_refs.push_back({nullptr, "agg_col"});
+
+  for (int i = 0; i < num_group_by; ++i) {
+    auto name = "Col" + std::to_string(i + 1);
+    group_by_refs.push_back({inputTable, name});
+    output_refs.push_back({nullptr, name});
+  }
+
+  BaseAggregate *agg_op = get_agg_op(
+    0, agg_type, input_, out_result,
+    {agg_ref}, group_by_refs, group_by_refs,
+    aggregate_options);
+
+  ExecutionPlan plan(0);
+  plan.addOperator(agg_op);
+
+  auto container = simple_profiler.getContainer();
+  auto name = "Q1_" + std::to_string(cardinality) + "*" +
+                      std::to_string(num_group_by);
+  auto eventName = this->eventName(agg_type, name);
+  scheduler->addTask(&plan);
+  container->startEvent(eventName);
+  scheduler->start();
+  scheduler->join();
+  container->endEvent(eventName);
+
+  auto out_table = out_result->materialize(output_refs);
+  if (print_) {
+    out_table->print();
+  }
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
+
+};
+
+
+}

--- a/src/benchmark/aggregate_workload.h
+++ b/src/benchmark/aggregate_workload.h
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+#ifndef HUSTLE_AGGREGATE_WORKLOAD_H
+#define HUSTLE_AGGREGATE_WORKLOAD_H
+
+#include <operators/aggregate_const.h>
+#include <execution/execution_plan.h>
+#include <operators/aggregate.h>
+#include <operators/hash_aggregate.h>
+#include <scheduler/scheduler.h>
+
+namespace hustle::operators {
+
+class AggregateWorkload {
+public:
+
+  explicit AggregateWorkload(int cardinality, int numGroupby);
+  void setPrint(bool shouldPrint){print_ = shouldPrint;}
+
+  void prepareData();
+
+  void q1(AggregateType agg_type);
+
+
+private:
+  bool print_ = false;
+  int cardinality;
+  int num_group_by;
+  int num_threads_;
+  std::shared_ptr<Scheduler> scheduler;
+
+  std::shared_ptr<OperatorOptions> aggregate_options;
+
+  std::shared_ptr<arrow::Schema> schema;
+  std::shared_ptr<hustle::storage::DBTable> inputTable;
+  std::vector<std::shared_ptr<arrow::ArrayData>> inputData;
+
+  std::string eventName(AggregateType t, const std::string &name);
+};
+
+
+} // namespace hustle::operators
+
+#endif //HUSTLE_AGGREGATE_WORKLOAD_H

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -26,12 +26,12 @@ using namespace std::chrono;
 
 #define DEBUG false
 
-SSB* workload;
+SSB *workload;
 
 void read_from_csv() {
   std::shared_ptr<DBTable> lo, c, s, p, d;
   std::shared_ptr<arrow::Schema> lo_schema, c_schema, s_schema, p_schema,
-      d_schema;
+    d_schema;
 
   auto field1 = arrow::field("order key", arrow::uint32());
   auto field2 = arrow::field("line number", arrow::int64());
@@ -63,7 +63,7 @@ void read_from_csv() {
   auto s_field7 = arrow::field("s phone", arrow::utf8());
 
   s_schema = arrow::schema(
-      {s_field1, s_field2, s_field3, s_field4, s_field5, s_field6, s_field7});
+    {s_field1, s_field2, s_field3, s_field4, s_field5, s_field6, s_field7});
 
   auto c_field1 = arrow::field("c cust key", arrow::int64());
   auto c_field2 = arrow::field("c name", arrow::utf8());
@@ -136,79 +136,79 @@ void read_from_csv() {
   std::cout << "read the table files..." << std::endl;
 }
 
-static void query11(benchmark::State& state) {
+static void query11(benchmark::State &state) {
   for (auto _ : state) {
     workload->q11();
   }
 }
 
-static void query12(benchmark::State& state) {
+static void query12(benchmark::State &state) {
   for (auto _ : state) {
     workload->q12();
   }
 }
 
-static void query13(benchmark::State& state) {
+static void query13(benchmark::State &state) {
   for (auto _ : state) {
     workload->q13();
   }
 }
 
-static void query21(benchmark::State& state) {
+static void query21(benchmark::State &state) {
   for (auto _ : state) {
     workload->q21_lip();
   }
 }
 
-static void query22(benchmark::State& state) {
+static void query22(benchmark::State &state) {
   for (auto _ : state) {
     workload->q22_lip();
   }
 }
 
-static void query23(benchmark::State& state) {
+static void query23(benchmark::State &state) {
   for (auto _ : state) {
     workload->q23_lip();
   }
 }
 
-static void query31(benchmark::State& state) {
+static void query31(benchmark::State &state) {
   for (auto _ : state) {
     workload->q31_lip();
   }
 }
 
-static void query32(benchmark::State& state) {
+static void query32(benchmark::State &state) {
   for (auto _ : state) {
     workload->q32_lip();
   }
 }
 
-static void query33(benchmark::State& state) {
+static void query33(benchmark::State &state) {
   for (auto _ : state) {
     workload->q33_lip();
   }
 }
 
-static void query34(benchmark::State& state) {
+static void query34(benchmark::State &state) {
   for (auto _ : state) {
     workload->q34_lip();
   }
 }
 
-static void query41(benchmark::State& state) {
+static void query41(benchmark::State &state) {
   for (auto _ : state) {
     workload->q41_lip();
   }
 }
 
-static void query42(benchmark::State& state) {
+static void query42(benchmark::State &state) {
   for (auto _ : state) {
     workload->q42_lip();
   }
 }
 
-static void query43(benchmark::State& state) {
+static void query43(benchmark::State &state) {
   for (auto _ : state) {
     workload->q43_lip();
   }
@@ -228,12 +228,38 @@ BENCHMARK(query41);
 BENCHMARK(query42);
 BENCHMARK(query43);
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
+
+  // TODO: (Refactor) Use C++ parser to parse these command line args.
+  AggregateType agg_type = AggregateType::ARROW_AGGREGATE;
+  for (int i = 1; i < argc; i++) {
+    auto s = std::string(argv[i]);
+    if (s == "--agg_op") {
+      if (i + 1 >= argc) {
+        std::cerr << "Expect aggregate operator!" << std::endl;
+        exit(1);
+      }
+      i += 1;
+      auto v = std::string(argv[i]);
+      if (v.find("hash_aggregate") != ((size_t) -1)) {
+        agg_type = AggregateType::HASH_AGGREGATE;
+        std::cout << "Use Hash Aggregate" << std::endl;
+      } else if (v.find("arrow_aggregate") != ((size_t) -1)) {
+        agg_type = AggregateType::ARROW_AGGREGATE;
+        std::cout << "Use Arrow Aggregate" << std::endl;
+      } else {
+        std::cerr << "Aggregate operator invalid!" << std::endl;
+        exit(1);
+      }
+    }
+  }
+
+
   std::cout << "Started initializing with the required data ..." << std::endl;
   read_from_csv();
 
   if (DEBUG) {
-    workload = new SSB(0, 1);
+    workload = new SSB(0, true, agg_type);
     workload->q11();
     workload->q12();
     workload->q13();
@@ -248,7 +274,7 @@ int main(int argc, char* argv[]) {
     workload->q42_lip();
     workload->q43_lip();
   } else {
-    workload = new SSB();
+    workload = new SSB(0, false, agg_type);
     ::benchmark::Initialize(&argc, argv);
 
     std::cout << "Stated running benchmarks ..." << std::endl;

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -20,6 +20,7 @@
 #include "skew.h"
 #include "ssb_workload.h"
 #include "storage/util.h"
+#include "aggregate_workload.h"
 
 using namespace hustle::operators;
 using namespace std::chrono;
@@ -27,12 +28,12 @@ using namespace std::chrono;
 #define DEBUG false
 
 SSB *workload;
+AggregateWorkload *aggregateWorkload;
 
 void read_from_csv() {
   std::shared_ptr<DBTable> lo, c, s, p, d;
   std::shared_ptr<arrow::Schema> lo_schema, c_schema, s_schema, p_schema,
     d_schema;
-
   auto field1 = arrow::field("order key", arrow::uint32());
   auto field2 = arrow::field("line number", arrow::int64());
   auto field3 = arrow::field("cust key", arrow::int64());
@@ -228,9 +229,8 @@ BENCHMARK(query41);
 BENCHMARK(query42);
 BENCHMARK(query43);
 
-int main(int argc, char *argv[]) {
-
-  // TODO: (Refactor) Use C++ parser to parse these command line args.
+// TODO: Refactor this using C++ command line arg parser.
+AggregateType get_agg_type(int argc, char *argv[]) {
   AggregateType agg_type = AggregateType::ARROW_AGGREGATE;
   for (int i = 1; i < argc; i++) {
     auto s = std::string(argv[i]);
@@ -253,7 +253,44 @@ int main(int argc, char *argv[]) {
       }
     }
   }
+  return agg_type;
+}
 
+#define SSB_WORKLOAD 0
+#define AGGREGATE_WORKLOAD 1
+
+// TODO: Refactor this using C++ command line arg parser.
+int get_test(int argc, char *argv[]) {
+  int bench_type = SSB_WORKLOAD;
+  for (int i = 1; i < argc; i++) {
+    auto s = std::string(argv[i]);
+    if (s == "--agg_op") {
+      if (i + 1 >= argc) {
+        std::cerr << "Expect aggregate operator!" << std::endl;
+        exit(1);
+      }
+      i += 1;
+      auto v = std::string(argv[i]);
+      if (v.find("ssb") != ((size_t) -1)) {
+        bench_type = SSB_WORKLOAD;
+        std::cout << "Benchmark using SSB workload." << std::endl;
+      } else if (v.find("aggregate") != ((size_t) -1)) {
+        bench_type = AGGREGATE_WORKLOAD;
+        std::cout << "Benchmark using aggregate workload" << std::endl;
+      } else {
+        std::cerr << "Expected --benchmark [ssb | aggregate], got " << v
+                  << std::endl;
+        exit(1);
+      }
+    }
+  }
+  return bench_type;
+}
+
+
+int ssb_main(int argc, char *argv[]) {
+
+  AggregateType agg_type = get_agg_type(argc, argv);
 
   std::cout << "Started initializing with the required data ..." << std::endl;
   read_from_csv();
@@ -280,4 +317,48 @@ int main(int argc, char *argv[]) {
     std::cout << "Stated running benchmarks ..." << std::endl;
     ::benchmark::RunSpecifiedBenchmarks();
   }
+  return 0;
+}
+
+void _aggregate_workload(int cardinality, int numGroupBy){
+
+  aggregateWorkload = new AggregateWorkload(cardinality, numGroupBy);
+  if constexpr (DEBUG) {
+    aggregateWorkload->setPrint(true);
+  }
+  aggregateWorkload->prepareData();
+  aggregateWorkload->q1(AggregateType::HASH_AGGREGATE);
+
+  aggregateWorkload = new AggregateWorkload(cardinality, numGroupBy);
+  if constexpr (DEBUG) {
+    aggregateWorkload->setPrint(true);
+  }
+  aggregateWorkload->prepareData();
+  aggregateWorkload->q1(AggregateType::ARROW_AGGREGATE);
+}
+
+int aggregate_main(int argc, char *argv[]) {
+
+  for (int cardinality = 1; cardinality <= 8; cardinality++) {
+    for (int numGroupBy = 1; numGroupBy <= 8; numGroupBy++) {
+      _aggregate_workload(cardinality, numGroupBy);
+    }
+  }
+
+  return 0;
+}
+
+
+int main(int argc, char *argv[]) {
+  int benchmark_type = get_test(argc, argv);
+
+  if (benchmark_type == AGGREGATE_WORKLOAD) {
+    return aggregate_main(argc, argv);
+
+  } else if (benchmark_type == SSB_WORKLOAD) {
+    return ssb_main(argc, argv);
+  }
+
+  std::cerr << "Abort: Wrong benchmark type: " << benchmark_type << std::endl;
+  exit(10);
 }

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -35,13 +35,6 @@
 
 using namespace std::chrono;
 
-// TODO: Use C++ factory to handle the init of BaseAggregate operator
-// Define the Hash Aggregate algorithm.
-//
-#define USE_ARROW_AGGREGATE 0
-#define USE_HASH_AGGREGATE 1
-
-
 namespace hustle::operators {
 
 // Flag that control the aggregate factory to use.
@@ -50,7 +43,7 @@ constexpr int aggregate_type = AggregateType::ARROW_AGGREGATE ;
 // TODO: Modify this to a proper factory in the future.
 //  For now, this is a convenient way to serve the aggregate
 //  operator inside SSBWorkload.
-auto get_agg_op(const std::size_t query_id,
+Operator * get_agg_op(const std::size_t query_id,
               const std::shared_ptr<OperatorResult>& prev_result,
               const std::shared_ptr<OperatorResult>& output_result,
               const std::vector<AggregateReference>& aggregate_units,
@@ -58,18 +51,19 @@ auto get_agg_op(const std::size_t query_id,
               const std::vector<ColumnReference>& order_by_refs,
               const std::shared_ptr<OperatorOptions>& options){
 
-  if constexpr (aggregate_type == USE_ARROW_AGGREGATE){
-    return HashAggregate(
+  if constexpr (aggregate_type == AggregateType::ARROW_AGGREGATE){
+    return new Aggregate(
       query_id, prev_result, output_result,
       aggregate_units, group_by_refs, order_by_refs, options);
 
-  }else if constexpr (aggregate_type == USE_HASH_AGGREGATE){
-    return HashAggregate(
+
+  }else if constexpr (aggregate_type == AggregateType::HASH_AGGREGATE){
+    return new HashAggregate(
       query_id, prev_result, output_result,
       aggregate_units, group_by_refs, order_by_refs, options);
   } else{
     std::cerr << "Unexpectd AggregateType: " << aggregate_type << std::endl;
-    assert(false);
+    exit(1);
   }
 }
 
@@ -258,7 +252,7 @@ void SSB::q11() {
   auto lo_select_id = plan.addOperator(&lo_select_op);
   auto d_select_id = plan.addOperator(&d_select_op);
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(lo_select_id, join_id);
@@ -340,7 +334,7 @@ void SSB::q12() {
   auto lo_select_id = plan.addOperator(&lo_select_op);
   auto d_select_id = plan.addOperator(&d_select_op);
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(lo_select_id, join_id);
@@ -432,7 +426,7 @@ void SSB::q13() {
   auto lo_select_id = plan.addOperator(&lo_select_op);
   auto d_select_id = plan.addOperator(&d_select_op);
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(lo_select_id, join_id);
@@ -505,7 +499,7 @@ void SSB::q21() {
   auto s_select_id = plan.addOperator(&s_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(p_select_id, join_id);
@@ -593,7 +587,7 @@ void SSB::q22() {
   auto s_select_id = plan.addOperator(&s_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(p_select_id, join_id);
@@ -669,7 +663,7 @@ void SSB::q23() {
   auto s_select_id = plan.addOperator(&s_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(p_select_id, join_id);
@@ -758,7 +752,7 @@ void SSB::q31() {
   auto d_select_id = plan.addOperator(&d_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(s_select_id, join_id);
@@ -849,7 +843,7 @@ void SSB::q32() {
   auto d_select_id = plan.addOperator(&d_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(s_select_id, join_id);
@@ -964,7 +958,7 @@ void SSB::q33() {
   auto d_select_id = plan.addOperator(&d_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(s_select_id, join_id);
@@ -1077,7 +1071,7 @@ void SSB::q34() {
   auto d_select_id = plan.addOperator(&d_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(s_select_id, join_id);
@@ -1179,7 +1173,7 @@ void SSB::q41() {
   auto c_select_id = plan.addOperator(&c_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(p_select_id, join_id);
@@ -1293,7 +1287,7 @@ void SSB::q42() {
   auto d_select_id = plan.addOperator(&d_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(p_select_id, join_id);
@@ -1398,7 +1392,7 @@ void SSB::q43() {
   auto d_select_id = plan.addOperator(&d_select_op);
 
   auto join_id = plan.addOperator(&join_op);
-  auto agg_id = plan.addOperator(&agg_op);
+  auto agg_id = plan.addOperator(agg_op);
 
   // Declare join dependency on select operators
   plan.createLink(p_select_id, join_id);

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -38,7 +38,7 @@ using namespace std::chrono;
 namespace hustle::operators {
 
 // Flag that control the aggregate factory to use.
-constexpr int aggregate_type = AggregateType::ARROW_AGGREGATE ;
+static int aggregate_type = AggregateType::ARROW_AGGREGATE;
 
 // TODO: Modify this to a proper factory in the future.
 //  For now, this is a convenient way to serve the aggregate
@@ -51,13 +51,13 @@ Operator * get_agg_op(const std::size_t query_id,
               const std::vector<ColumnReference>& order_by_refs,
               const std::shared_ptr<OperatorOptions>& options){
 
-  if constexpr (aggregate_type == AggregateType::ARROW_AGGREGATE){
+  if (aggregate_type == AggregateType::ARROW_AGGREGATE){
     return new Aggregate(
       query_id, prev_result, output_result,
       aggregate_units, group_by_refs, order_by_refs, options);
 
 
-  }else if constexpr (aggregate_type == AggregateType::HASH_AGGREGATE){
+  }else if (aggregate_type == AggregateType::HASH_AGGREGATE){
     return new HashAggregate(
       query_id, prev_result, output_result,
       aggregate_units, group_by_refs, order_by_refs, options);
@@ -68,9 +68,11 @@ Operator * get_agg_op(const std::size_t query_id,
 }
 
 
-SSB::SSB(int SF, bool print) {
+SSB::SSB(int SF, bool print, AggregateType agg_type) {
   print_ = print;
   num_threads_ = std::thread::hardware_concurrency();
+  aggregate_type = agg_type;
+
 
   scheduler = std::make_shared<Scheduler>(num_threads_, true);
   Config::Init("../../../hustle.cfg");

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -37,42 +37,10 @@ using namespace std::chrono;
 
 namespace hustle::operators {
 
-// Flag that control the aggregate factory to use.
-static int aggregate_type = AggregateType::ARROW_AGGREGATE;
-
-// TODO: Modify this to a proper factory in the future.
-//  For now, this is a convenient way to serve the aggregate
-//  operator inside SSBWorkload.
-Operator * get_agg_op(const std::size_t query_id,
-              const std::shared_ptr<OperatorResult>& prev_result,
-              const std::shared_ptr<OperatorResult>& output_result,
-              const std::vector<AggregateReference>& aggregate_units,
-              const std::vector<ColumnReference>& group_by_refs,
-              const std::vector<ColumnReference>& order_by_refs,
-              const std::shared_ptr<OperatorOptions>& options){
-
-  if (aggregate_type == AggregateType::ARROW_AGGREGATE){
-    return new Aggregate(
-      query_id, prev_result, output_result,
-      aggregate_units, group_by_refs, order_by_refs, options);
-
-
-  }else if (aggregate_type == AggregateType::HASH_AGGREGATE){
-    return new HashAggregate(
-      query_id, prev_result, output_result,
-      aggregate_units, group_by_refs, order_by_refs, options);
-  } else{
-    std::cerr << "Unexpectd AggregateType: " << aggregate_type << std::endl;
-    exit(1);
-  }
-}
-
-
 SSB::SSB(int SF, bool print, AggregateType agg_type) {
   print_ = print;
   num_threads_ = std::thread::hardware_concurrency();
   aggregate_type = agg_type;
-
 
   scheduler = std::make_shared<Scheduler>(num_threads_, true);
   Config::Init("../../../hustle.cfg");
@@ -245,7 +213,7 @@ void SSB::q11() {
   Join join_op(0, join_result_in, join_result_out, graph, join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out,
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out,
                                    {agg_ref}, {}, {}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -327,7 +295,7 @@ void SSB::q12() {
   Join join_op(0, join_result_in, join_result_out, graph, join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out,
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out,
                                    {agg_ref}, {}, {}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -419,7 +387,7 @@ void SSB::q13() {
   Join join_op(0, join_result_in, join_result_out, graph, join_options);
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out,
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out,
                                    {agg_ref}, {}, {}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -493,7 +461,7 @@ void SSB::q21() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {{d, "year"}, {p, "brand1"}};
   std::vector<ColumnReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);
@@ -580,7 +548,7 @@ void SSB::q22() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {{d, "year"}, {p, "brand1"}};
   std::vector<ColumnReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
 
@@ -657,7 +625,7 @@ void SSB::q23() {
 
   std::vector<ColumnReference> group_by_refs = {{d, "year"}, {p, "brand1"}};
   std::vector<ColumnReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);
@@ -745,7 +713,7 @@ void SSB::q31() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_nation_ref, s_nation_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, {nullptr, "revenue"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);
@@ -836,7 +804,7 @@ void SSB::q32() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_city_ref, s_city_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, {nullptr, "revenue"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);
@@ -951,7 +919,7 @@ void SSB::q33() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_city_ref, s_city_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, {nullptr, "revenue"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);
@@ -1064,7 +1032,7 @@ void SSB::q34() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_city_ref, s_city_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, {nullptr, "revenue"}};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);
@@ -1164,7 +1132,7 @@ void SSB::q41() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_nation_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, c_nation_ref};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1277,7 +1245,7 @@ void SSB::q42() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, s_nation_ref, p_category_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, s_nation_ref, p_category_ref};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1384,7 +1352,7 @@ void SSB::q43() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, s_city_ref, p_brand1_ref};
   std::vector<ColumnReference> order_by_refs = {d_year_ref, s_city_ref, p_brand1_ref};
-  auto agg_op = get_agg_op(0, join_result_out, agg_result_out, {agg_ref},
+  auto agg_op = get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                                    group_by_refs, order_by_refs,aggregate_options);
 
   ExecutionPlan plan(0);

--- a/src/benchmark/ssb_workload.h
+++ b/src/benchmark/ssb_workload.h
@@ -18,6 +18,7 @@
 #ifndef HUSTLE_SSB_WORKLOAD_H
 #define HUSTLE_SSB_WORKLOAD_H
 
+#include <operators/aggregate_const.h>
 #include "execution/execution_plan.h"
 #include "operators/operator_options.h"
 #include "operators/predicate.h"
@@ -27,7 +28,7 @@
 namespace hustle::operators {
 class SSB {
  public:
-  explicit SSB(int SF = 1, bool print = false);
+  explicit SSB(int SF, bool print, hustle::operators::AggregateType agg_type);
 
   void execute(ExecutionPlan &plan,
                std::shared_ptr<OperatorResult> &final_result);

--- a/src/benchmark/ssb_workload.h
+++ b/src/benchmark/ssb_workload.h
@@ -24,6 +24,7 @@
 #include "operators/predicate.h"
 #include "scheduler/scheduler.h"
 #include "storage/table.h"
+#include "operators/utils/aggregate_factory.h"
 
 namespace hustle::operators {
 class SSB {
@@ -32,6 +33,7 @@ class SSB {
 
   void execute(ExecutionPlan &plan,
                std::shared_ptr<OperatorResult> &final_result);
+
 
   void q11();
   void q12();
@@ -74,6 +76,7 @@ class SSB {
  private:
   bool print_;
   int num_threads_;
+  AggregateType aggregate_type;
   std::shared_ptr<Scheduler> scheduler;
 
   std::shared_ptr<OperatorResult> lo_result_in;

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
         utils/operator_result.cc utils/operator_result.h
         utils/lip.cc utils/lip.h
         ../utils/bloom_filter.h
-        ../utils/xxHash.h base_aggregate.h)
+        ../utils/xxHash.h base_aggregate.h utils/aggregate_factory.cc utils/aggregate_factory.h)
 
 
 target_include_directories(hustle_src_operators PUBLIC ${ARROW_INCLUDE_DIR})

--- a/src/operators/aggregate_const.h
+++ b/src/operators/aggregate_const.h
@@ -25,10 +25,25 @@ namespace hustle::operators {
 
 
 // Types of aggregates we can perform. COUNT is currently not supported.
-enum AggregateKernel { SUM, COUNT, MEAN };
+enum AggregateKernel {
+  SUM, COUNT, MEAN
+};
 
 // Types of aggregate algorithm we can use.
-enum AggregateType { HASH_AGGREGATE, ARROW_AGGREGATE };
+enum AggregateType {
+  HASH_AGGREGATE, ARROW_AGGREGATE
+};
+
+//std::string aggTypeName(AggregateType t) {
+//  switch (t) {
+//    case HASH_AGGREGATE:
+//      return "hash_aggregate";
+//    case ARROW_AGGREGATE:
+//      return "arrow_aggregate";
+//    default:
+//      return "unkown_aggregate";
+//  }
+//}
 
 /**
  * A reference structure containing all the information needed to perform an

--- a/src/operators/utils/aggregate_factory.cc
+++ b/src/operators/utils/aggregate_factory.cc
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_factory.h"
+
+
+namespace hustle::operators {
+
+BaseAggregate * get_agg_op(
+  const std::size_t query_id,
+  const AggregateType aggregate_type,
+  const std::shared_ptr<OperatorResult> &prev_result,
+  const std::shared_ptr<OperatorResult> &output_result,
+  const std::vector<AggregateReference> &aggregate_units,
+  const std::vector<ColumnReference> &group_by_refs,
+  const std::vector<ColumnReference> &order_by_refs,
+  const std::shared_ptr<OperatorOptions> &options) {
+
+  if (aggregate_type == AggregateType::ARROW_AGGREGATE) {
+    return new Aggregate(
+      query_id, prev_result, output_result,
+      aggregate_units, group_by_refs, order_by_refs, options);
+
+  } else if (aggregate_type == AggregateType::HASH_AGGREGATE) {
+    return new HashAggregate(
+      query_id, prev_result, output_result,
+      aggregate_units, group_by_refs, order_by_refs, options);
+  } else {
+    throw std::invalid_argument("Unexpected AggregateType");
+  }
+}
+
+}

--- a/src/operators/utils/aggregate_factory.h
+++ b/src/operators/utils/aggregate_factory.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_AGGREGATE_FACTORY_H
+#define HUSTLE_AGGREGATE_FACTORY_H
+
+#include "operators/base_aggregate.h"
+#include "operators/aggregate_const.h"
+#include "operators/aggregate.h"
+#include "operators/hash_aggregate.h"
+
+namespace hustle::operators {
+
+/**
+ * Return the aggregate operator, with respect to the aggregate_type.
+ *
+ * @param query_id Query ID.
+ * @param aggregate_type AggregateType.
+ * @param prev_result Input for aggregation.
+ * @param output_result Output from the aggregate operator.
+ * @param aggregate_units
+ * @param group_by_refs
+ * @param order_by_refs
+ * @param options
+ * @return
+ */
+BaseAggregate * get_agg_op(
+  std::size_t query_id,
+  AggregateType aggregate_type,
+  const std::shared_ptr<OperatorResult> &prev_result,
+  const std::shared_ptr<OperatorResult> &output_result,
+  const std::vector<AggregateReference> &aggregate_units,
+  const std::vector<ColumnReference> &group_by_refs,
+  const std::vector<ColumnReference> &order_by_refs,
+  const std::shared_ptr<OperatorOptions> &options);
+
+} // namespace hustle::operators
+
+#endif //HUSTLE_AGGREGATE_FACTORY_H


### PR DESCRIPTION
**Changes**
- Add aggregate benchmark.
- Slightly refactor the aggregate code.

**Instruction**
Run 
```
./hustle_benchmark_main --benchmark aggregate
```
and will get the latency comparison between the `Aggregate` and `HashAggregate`. 

For now, we only implement a naive query (`q1`) that performs group by on every column except the aggregate column:
```
SELECT MEAN(agg_col) FROM table 
GROUP BY col_1, col_2, ..., col_n
```

**Result**

**Figure 1. `HashAggregate` out performs `Aggregate` on small input table.** 
<img width="1360" alt="Screen Shot 2020-11-20 at 12 41 15 AM" src="https://user-images.githubusercontent.com/32371474/99767713-1ab82180-2ac9-11eb-89a5-36d823f8430d.png">

**Figure 2. Speedup achieved by `HashAggregate` over `Aggregate` on small input table.** 
<img width="1376" alt="Screen Shot 2020-11-20 at 12 41 28 AM" src="https://user-images.githubusercontent.com/32371474/99767733-21469900-2ac9-11eb-9200-cb0fe20e4788.png">


**Lessons learnt**
1. Our SSB benchmark does not increase the cardinality of the unique values in the group by columns. The biggest aggregate output table has only `800 rows`, which does not favor `HashAggregate`.
2. **Dynamic depth nested loop (DDNL) is exponential, and it performs really bad when group-by columns are slightly more.** In our naive setting, running an aggregate on `8` group by columns, each has `8` unique values (`8x8`), `HashAggregate` only spent `0.001`s, where as using DDNL we spent nearly `71`s! This is expected as there are `8^8` combinations of the values we have recorded. Most of the time spent in the loop trying to construct all the unique values. Even if we are using the `Aggregate`, we will need to optimize the DDNL in the future to make it usable.