### PR TITLE
Support for Update and delete operation from sqlite-hustle and simple TATP bench driver

### DIFF
--- a/scripts/ssb/run_benchmark.sh
+++ b/scripts/ssb/run_benchmark.sh
@@ -5,4 +5,4 @@ src_dir=${cur_dir}/../..
 
 # run the benchmark
 cd ${src_dir}/build/src/benchmark/
-./hustle_src_benchmark_main --agg_op $1
+./hustle_src_benchmark_main --test $1 --agg_op $2

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(benchmark REQUIRED)
 add_library(hustle_src_benchmark
         ssb_workload.cc ssb_workload.h
+        tatp_workload.cc tatp_workload.h
         ssb_workload_lip.cc
         aggregate_workload.cc aggregate_workload.h)
 

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -259,6 +259,7 @@ AggregateType get_agg_type(int argc, char *argv[]) {
 
 #define SSB_WORKLOAD 0
 #define AGGREGATE_WORKLOAD 1
+#define TATP_WORKLOAD 2
 
 // TODO: Refactor this using C++ command line arg parser.
 int get_test(int argc, char *argv[]) {
@@ -275,6 +276,9 @@ int get_test(int argc, char *argv[]) {
       if (v.find("ssb") != ((size_t)-1)) {
         bench_type = SSB_WORKLOAD;
         std::cout << "Benchmark using SSB workload." << std::endl;
+      } else if (v.find("tatp") != ((size_t)-1)) {
+        bench_type = TATP_WORKLOAD;
+        std::cout << "Benchmark using aggregate workload" << std::endl;
       } else if (v.find("aggregate") != ((size_t)-1)) {
         bench_type = AGGREGATE_WORKLOAD;
         std::cout << "Benchmark using aggregate workload" << std::endl;
@@ -346,17 +350,17 @@ int aggregate_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  TATP tatp;
-  tatp.RunBenchmark();
-  /*int benchmark_type = get_test(argc, argv);
+  int benchmark_type = get_test(argc, argv);
 
   if (benchmark_type == AGGREGATE_WORKLOAD) {
     return aggregate_main(argc, argv);
-
   } else if (benchmark_type == SSB_WORKLOAD) {
     return ssb_main(argc, argv);
+  } else if (benchmark_type == TATP_WORKLOAD) {
+    TATP tatp;
+    tatp.RunBenchmark();
   }
 
   std::cerr << "Abort: Wrong benchmark type: " << benchmark_type << std::endl;
-  exit(10);*/
+  exit(10);
 }

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -264,7 +264,7 @@ int get_test(int argc, char *argv[]) {
   int bench_type = SSB_WORKLOAD;
   for (int i = 1; i < argc; i++) {
     auto s = std::string(argv[i]);
-    if (s == "--agg_op") {
+    if (s == "--test") {
       if (i + 1 >= argc) {
         std::cerr << "Expect aggregate operator!" << std::endl;
         exit(1);

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -19,6 +19,7 @@
 
 #include "skew.h"
 #include "ssb_workload.h"
+#include "tatp_workload.h"
 #include "storage/util.h"
 #include "aggregate_workload.h"
 
@@ -350,7 +351,8 @@ int aggregate_main(int argc, char *argv[]) {
 
 
 int main(int argc, char *argv[]) {
-  int benchmark_type = get_test(argc, argv);
+  TATP tatp;
+  /*int benchmark_type = get_test(argc, argv);
 
   if (benchmark_type == AGGREGATE_WORKLOAD) {
     return aggregate_main(argc, argv);
@@ -360,5 +362,5 @@ int main(int argc, char *argv[]) {
   }
 
   std::cerr << "Abort: Wrong benchmark type: " << benchmark_type << std::endl;
-  exit(10);
+  exit(10);*/
 }

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -17,11 +17,11 @@
 
 #include <benchmark/benchmark.h>
 
+#include "aggregate_workload.h"
 #include "skew.h"
 #include "ssb_workload.h"
-#include "tatp_workload.h"
 #include "storage/util.h"
-#include "aggregate_workload.h"
+#include "tatp_workload.h"
 
 using namespace hustle::operators;
 using namespace std::chrono;
@@ -34,7 +34,7 @@ AggregateWorkload *aggregateWorkload;
 void read_from_csv() {
   std::shared_ptr<DBTable> lo, c, s, p, d;
   std::shared_ptr<arrow::Schema> lo_schema, c_schema, s_schema, p_schema,
-    d_schema;
+      d_schema;
   auto field1 = arrow::field("order key", arrow::uint32());
   auto field2 = arrow::field("line number", arrow::int64());
   auto field3 = arrow::field("cust key", arrow::int64());
@@ -65,7 +65,7 @@ void read_from_csv() {
   auto s_field7 = arrow::field("s phone", arrow::utf8());
 
   s_schema = arrow::schema(
-    {s_field1, s_field2, s_field3, s_field4, s_field5, s_field6, s_field7});
+      {s_field1, s_field2, s_field3, s_field4, s_field5, s_field6, s_field7});
 
   auto c_field1 = arrow::field("c cust key", arrow::int64());
   auto c_field2 = arrow::field("c name", arrow::utf8());
@@ -242,10 +242,10 @@ AggregateType get_agg_type(int argc, char *argv[]) {
       }
       i += 1;
       auto v = std::string(argv[i]);
-      if (v.find("hash_aggregate") != ((size_t) -1)) {
+      if (v.find("hash_aggregate") != ((size_t)-1)) {
         agg_type = AggregateType::HASH_AGGREGATE;
         std::cout << "Use Hash Aggregate" << std::endl;
-      } else if (v.find("arrow_aggregate") != ((size_t) -1)) {
+      } else if (v.find("arrow_aggregate") != ((size_t)-1)) {
         agg_type = AggregateType::ARROW_AGGREGATE;
         std::cout << "Use Arrow Aggregate" << std::endl;
       } else {
@@ -272,10 +272,10 @@ int get_test(int argc, char *argv[]) {
       }
       i += 1;
       auto v = std::string(argv[i]);
-      if (v.find("ssb") != ((size_t) -1)) {
+      if (v.find("ssb") != ((size_t)-1)) {
         bench_type = SSB_WORKLOAD;
         std::cout << "Benchmark using SSB workload." << std::endl;
-      } else if (v.find("aggregate") != ((size_t) -1)) {
+      } else if (v.find("aggregate") != ((size_t)-1)) {
         bench_type = AGGREGATE_WORKLOAD;
         std::cout << "Benchmark using aggregate workload" << std::endl;
       } else {
@@ -288,9 +288,7 @@ int get_test(int argc, char *argv[]) {
   return bench_type;
 }
 
-
 int ssb_main(int argc, char *argv[]) {
-
   AggregateType agg_type = get_agg_type(argc, argv);
 
   std::cout << "Started initializing with the required data ..." << std::endl;
@@ -321,8 +319,7 @@ int ssb_main(int argc, char *argv[]) {
   return 0;
 }
 
-void _aggregate_workload(int cardinality, int numGroupBy){
-
+void _aggregate_workload(int cardinality, int numGroupBy) {
   aggregateWorkload = new AggregateWorkload(cardinality, numGroupBy);
   if constexpr (DEBUG) {
     aggregateWorkload->setPrint(true);
@@ -339,7 +336,6 @@ void _aggregate_workload(int cardinality, int numGroupBy){
 }
 
 int aggregate_main(int argc, char *argv[]) {
-
   for (int cardinality = 1; cardinality <= 8; cardinality++) {
     for (int numGroupBy = 1; numGroupBy <= 8; numGroupBy++) {
       _aggregate_workload(cardinality, numGroupBy);
@@ -349,9 +345,9 @@ int aggregate_main(int argc, char *argv[]) {
   return 0;
 }
 
-
 int main(int argc, char *argv[]) {
   TATP tatp;
+  tatp.RunBenchmark();
   /*int benchmark_type = get_test(argc, argv);
 
   if (benchmark_type == AGGREGATE_WORKLOAD) {

--- a/src/benchmark/main.cc
+++ b/src/benchmark/main.cc
@@ -359,6 +359,7 @@ int main(int argc, char *argv[]) {
   } else if (benchmark_type == TATP_WORKLOAD) {
     TATP tatp;
     tatp.RunBenchmark();
+    return 0;
   }
 
   std::cerr << "Abort: Wrong benchmark type: " << benchmark_type << std::endl;

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -1,0 +1,462 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+#include "benchmark/tatp_workload.h"
+#include "utils/event_profiler.h"
+
+namespace hustle::operators {
+
+TATP::TATP() {
+    CreateTable();
+}
+
+void TATP::CreateTable() {
+
+  std::shared_ptr<arrow::Schema>  s_schema, ai_schema,
+      sf_schema, cf_schema;
+  hustle::catalog::TableSchema subscriber("Subscriber");
+  hustle::catalog::ColumnSchema s_id(
+      "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema sub_nbr(
+      "sub_nbr", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+  hustle::catalog::ColumnSchema bit_1(
+      "bit_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema bit_2(
+      "bit_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema bit_3(
+      "bit_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema bit_4(
+      "bit_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema bit_5(
+      "bit_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_6(
+      "bit_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_7(
+      "bit_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_8(
+      "bit_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_9(
+      "bit_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_10(
+      "bit_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_1(
+      "hex_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_2(
+      "hex_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_3(
+      "hex_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_4(
+      "hex_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_5(
+      "hex_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_6(
+      "hex_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_7(
+      "hex_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_8(
+      "hex_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_9(
+      "hex_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema hex_10(
+      "hex_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_1(
+      "byte2_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_2(
+      "byte2_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema byte2_3(
+      "byte2_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_4(
+      "byte2_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  
+   hustle::catalog::ColumnSchema byte2_5(
+      "byte2_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_6(
+      "byte2_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_7(
+      "byte2_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_8(
+      "byte2_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_9(
+      "byte2_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema byte2_10(
+      "byte2_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema msc_location(
+      "msc_location", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+   hustle::catalog::ColumnSchema vlr_location(
+      "vlr_location", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  
+  
+  subscriber.addColumn(s_id);
+  subscriber.addColumn(sub_nbr);
+  subscriber.addColumn(bit_1);
+  subscriber.addColumn(bit_2);
+  subscriber.addColumn(bit_3);
+  subscriber.addColumn(bit_4);
+  subscriber.addColumn(bit_5);
+  subscriber.addColumn(bit_6);
+  subscriber.addColumn(bit_7);
+  subscriber.addColumn(bit_8);
+  subscriber.addColumn(bit_9);
+  subscriber.addColumn(bit_10);
+  subscriber.addColumn(hex_1);
+  subscriber.addColumn(hex_2);
+  subscriber.addColumn(hex_3);
+  subscriber.addColumn(hex_4);
+  subscriber.addColumn(hex_5);
+  subscriber.addColumn(hex_6);
+  subscriber.addColumn(hex_7);
+  subscriber.addColumn(hex_8);
+  subscriber.addColumn(hex_9);
+  subscriber.addColumn(hex_10);
+  subscriber.addColumn(byte2_1);
+  subscriber.addColumn(byte2_2);
+  subscriber.addColumn(byte2_3);
+  subscriber.addColumn(byte2_4);
+  subscriber.addColumn(byte2_5);
+  subscriber.addColumn(byte2_6);
+  subscriber.addColumn(byte2_7);
+  subscriber.addColumn(byte2_8);
+  subscriber.addColumn(byte2_9);
+  subscriber.addColumn(byte2_10);
+  subscriber.addColumn(msc_location);
+  subscriber.addColumn(vlr_location);
+  subscriber.setPrimaryKey({});
+  s_schema = subscriber.getArrowSchema();
+
+  hustle::catalog::TableSchema access_info("Access_Info");
+ /* hustle::catalog::ColumnSchema s_id(
+      "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);*/
+  hustle::catalog::ColumnSchema ai_type(
+      "ai_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data1(
+      "data1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data2(
+      "data2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data3(
+      "data3", {hustle::catalog::HustleType::CHAR, 3}, true, false);
+  hustle::catalog::ColumnSchema data4(
+      "data4", {hustle::catalog::HustleType::CHAR, 5}, true, false);
+  access_info.addColumn(s_id);
+  access_info.addColumn(ai_type);
+  access_info.addColumn(data1);
+  access_info.addColumn(data2);
+  access_info.addColumn(data3);
+  access_info.addColumn(data4);
+
+  access_info.setPrimaryKey({});
+  ai_schema = access_info.getArrowSchema();
+
+  hustle::catalog::TableSchema special_facility("Special_Facility");
+  hustle::catalog::ColumnSchema sf_s_id(
+      "sf_s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema sf_sf_type(
+      "sf_sf_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema is_active(
+      "is_active", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema error_cntrl(
+      "error_cntrl", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data_a(
+      "data_a", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data_b(
+      "data_b", {hustle::catalog::HustleType::CHAR, 5}, true, false);
+  special_facility.addColumn(sf_s_id);
+  special_facility.addColumn(sf_sf_type);
+  special_facility.addColumn(is_active);
+  special_facility.addColumn(error_cntrl);
+  special_facility.addColumn(data_a);
+  special_facility.addColumn(data_b);
+  special_facility.setPrimaryKey({});
+  sf_schema = special_facility.getArrowSchema();
+
+  hustle::catalog::TableSchema call_forwarding("Call_Forwarding");
+  hustle::catalog::ColumnSchema cf_s_id(
+      "cf_s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema cf_sf_type(
+      "cf_sf_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema start_time(
+      "start_time", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema end_time(
+      "end_time", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema numberx(
+      "numberx", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+  call_forwarding.addColumn(cf_s_id);
+  call_forwarding.addColumn(cf_sf_type);
+  call_forwarding.addColumn(start_time);
+  call_forwarding.addColumn(end_time);
+  call_forwarding.addColumn(numberx);
+  call_forwarding.setPrimaryKey({});
+  cf_schema = call_forwarding.getArrowSchema();
+  
+  std::shared_ptr<DBTable> s, ai, sf, cf;
+
+  s = std::make_shared<hustle::storage::DBTable>("table", s_schema, BLOCK_SIZE);
+  ai = std::make_shared<hustle::storage::DBTable>("table", ai_schema, BLOCK_SIZE);
+  sf = std::make_shared<hustle::storage::DBTable>("table", sf_schema, BLOCK_SIZE);
+  cf = std::make_shared<hustle::storage::DBTable>("table", cf_schema, BLOCK_SIZE);
+  std::filesystem::remove_all("db_directory");
+  // EXPECT_FALSE(std::filesystem::exists("db_directory"));
+
+  hustle::HustleDB hustleDB("db_directory2");
+  // it will only start if it is not running.
+  hustle::HustleDB::startScheduler();
+
+  hustleDB.createTable(subscriber, s);
+
+  hustleDB.createTable(access_info, ai); 
+
+  hustleDB.createTable(special_facility, sf);
+  hustleDB.createTable(call_forwarding, cf);
+
+ for (int i  = 9; i < 1000; i++) {
+    std::string query =
+        "BEGIN TRANSACTION; "
+        "INSERT INTO Subscriber VALUES ("+std::to_string(i)+", 'hello"+std::to_string(i)+"', 131321,"
+        "131321, 131321,"
+        "131321, 131321, 131321, 131321, 131321,"
+        "131321, 1131321, 131321, 131321, 131321,"
+        "131321, 131321, 131321, 131321, 131321,"
+        "131321, 131321, 131321, 131321, 131321,"
+        "131321, 131321, 131321, 131321, 131321,"
+        "131321, 131321, 131321, 131321);"
+        "COMMIT;";
+    hustleDB.executeQuery(query);
+ }
+ for (int i  = 9; i < 1000; i++) {
+    std::string query =
+        "BEGIN TRANSACTION; "
+        "INSERT INTO Access_Info VALUES ("+std::to_string(i)+", 131321,"
+        "131321, 131321,"
+        "'LOW', 'Great');"
+        "COMMIT;";
+    hustleDB.executeQuery(query);
+ }
+
+ for (int i  = 9; i < 1000; i++) {
+    std::string query =
+        "BEGIN TRANSACTION; "
+        "INSERT INTO Special_Facility VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131321,"
+        "131321, 131321,"
+        "'great');"
+        "COMMIT;";
+    hustleDB.executeQuery(query);
+ }
+
+  for (int i  = 9; i < 1000; i++) {
+    std::string query =
+        "BEGIN TRANSACTION; "
+        "INSERT INTO Call_Forwarding VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131,"
+        "131321,"
+        "'great');"
+        "COMMIT;";
+    hustleDB.executeQuery(query);
+ }
+
+ std::cout << "Query1 : " << std::endl;
+ std::string query1 = "SELECT s_id, sub_nbr,"
+    "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+    "bit_8, bit_9, bit_10,"
+    "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+    "hex_8, hex_9, hex_10,"
+    "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+    "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+    "msc_location, vlr_location "
+    "FROM Subscriber "
+    "WHERE s_id=10;";
+ auto container = simple_profiler.getContainer();
+ container->startEvent("tatp - 1");
+ hustleDB.executeQuery(query1);
+ container->endEvent("tatp - 1");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+
+
+  std::cout << "Query 2" << std::endl;
+ std::string query2 =
+     "SELECT numberx "
+    "FROM Special_Facility, Call_Forwarding "
+    "WHERE "
+    "cf_s_id=sf_s_id "
+    "AND cf_sf_type=sf_sf_type "
+    "AND sf_s_id=10 "
+    "AND sf_sf_type=10 "
+    "AND is_active=131321 "
+    "AND start_time\<=1000 "
+    "AND end_time\> 1000;";
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 2");
+ hustleDB.executeQuery(query2);
+ container->endEvent("tatp - 2");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+
+ std::cout << "Running Query3 : " << std::endl;
+ std::string query3 = "SELECT data1, data2, data3, data4 "
+    "FROM Access_Info "
+    "WHERE s_id=10 "
+    "AND ai_type=131321;";
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 3");
+ hustleDB.executeQuery(query3);
+ container->endEvent("tatp - 3");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+
+ std::cout << "Running Query4.1 : " << std::endl;
+ std::string query4 = "UPDATE Subscriber "
+    "SET bit_1=999 "
+    "WHERE s_id=10; ";
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 4.1");
+ hustleDB.executeQuery(query4);
+ container->endEvent("tatp - 4.1");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+
+ std::cout << "Verify Query 4.1: " << std::endl;
+ query4 = "SELECT s_id, sub_nbr,"
+    "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+    "bit_8, bit_9, bit_10,"
+    "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+    "hex_8, hex_9, hex_10,"
+    "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+    "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+    "msc_location, vlr_location "
+    "FROM Subscriber "
+    "WHERE s_id=10;";
+ hustleDB.executeQuery(query4);
+
+ std::cout << "Running Query4.2 : " << std::endl;
+ query4 = "UPDATE Special_Facility "
+            "SET data_a = 999 "
+            "WHERE sf_s_id=10 "
+            "AND sf_sf_type=10"; 
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 4.2");
+ hustleDB.executeQuery(query4);
+ container->endEvent("tatp - 4.2");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+
+ std::cout << "Verify Query 4.2: " << std::endl;
+ query4 = "SELECT sf_s_id, sf_sf_type,"
+    "data_a "
+    "FROM Special_Facility "
+    "WHERE sf_s_id=10 AND sf_sf_type=10;";
+ hustleDB.executeQuery(query4);
+
+ std::cout << "Updating Query 5: " << std::endl;
+ std::string query5 = "UPDATE Subscriber"
+    " SET  vlr_location=50 "
+    "WHERE sub_nbr='hello10';";
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 5");
+ hustleDB.executeQuery(query5);
+ container->endEvent("tatp - 5");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+std::cout << "Verify Query 5: " << std::endl;
+ query4 = "SELECT s_id, sub_nbr,"
+    "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+    "bit_8, bit_9, bit_10,"
+    "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+    "hex_8, hex_9, hex_10,"
+    "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+    "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+    "msc_location, vlr_location "
+    "FROM Subscriber "
+    "WHERE s_id=10;";
+ hustleDB.executeQuery(query5);
+
+ std::cout << "Query 6" << std::endl;
+ std::string query6 =
+        "BEGIN TRANSACTION; "
+        "INSERT INTO Call_Forwarding VALUES (1111111, 1111111, 131321,"
+        "131321,"
+        "'great');"
+        "COMMIT;";
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 6");
+ hustleDB.executeQuery(query6);
+ container->endEvent("tatp - 6");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+ std::cout << "Verify Query 6: " << std::endl;
+ query6 = "SELECT cf_s_id, start_time, end_time "
+    "FROM Call_Forwarding "
+    "WHERE cf_s_id=1111111;";
+ hustleDB.executeQuery(query6);
+
+ std::cout << "Query 7" << std::endl;
+ std::string query7 =
+        "DELETE FROM Call_Forwarding "
+        "WHERE cf_s_id = 1111111;";
+ container = simple_profiler.getContainer();
+ container->startEvent("tatp - 7");
+ hustleDB.executeQuery(query5);
+ container->endEvent("tatp - 7");
+ simple_profiler.summarizeToStream(std::cout);
+ simple_profiler.clear();
+ std::cout << "Verify Query 7: " << std::endl;
+ query7 = "SELECT cf_s_id, start_time, end_time "
+    "FROM Call_Forwarding "
+    "WHERE cf_s_id=1111111;";
+ hustleDB.executeQuery(query7);
+
+
+ hustle::HustleDB::stopScheduler();
+ 
+}
+
+
+void TATP::RunBenchmark() {
+
+}
+
+void TATP::RunQuery1() {
+    
+}
+
+void TATP::RunQuery2() {
+    
+}
+
+
+void TATP::RunQuery3() {
+    
+}
+
+void TATP::RunQuery4() {
+    
+}
+
+
+void TATP::RunQuery5() {
+    
+}
+
+void TATP::RunQuery6() {
+    
+}
+
+void TATP::RunQuery7() {
+    
+}
+
+
+
+}

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -223,9 +223,9 @@ void TATP::CreateTable() {
   hustleDB.createTable(call_forwarding, cf);
 
  std::cout << "Subscriber insert" << std::endl;
- for (int i  = 9; i < 20; i++) {
-    std::string query =
-        "BEGIN TRANSACTION; "
+ std::string query =  "BEGIN TRANSACTION; ";
+ for (int i  = 9; i < 100000; i++) {
+     query +=
         "INSERT INTO Subscriber VALUES ("+std::to_string(i)+", 'h"+std::to_string(i)+"', 131321,"
         "131321, 131321,"
         "131321, 131321, 131321, 131321, 131321,"
@@ -233,41 +233,43 @@ void TATP::CreateTable() {
         "131321, 131321, 131321, 131321, 131321,"
         "131321, 131321, 131321, 131321, 131321,"
         "131321, 131321, 131321, 131321, 131321,"
-        "131321, 131321, 131321, 131321);"
-        "COMMIT;";
-    hustleDB.executeQuery(query);
+        "131321, 131321, 131321, 131321);";
  }
- std::cout << "Subscriber insert ends" << std::endl;
+ query +=  "COMMIT;";
+ hustleDB.executeQuery(query);
 
- for (int i  = 9; i < 20; i++) {
-    std::string query =
-        "BEGIN TRANSACTION; "
+ query =  "BEGIN TRANSACTION; ";
+ for (int i  = 9; i < 100000; i++) {
+    query +=
         "INSERT INTO Access_Info VALUES ("+std::to_string(i)+", 131321,"
         "131321, 131321,"
-        "'LOW', 'Great');"
-        "COMMIT;";
-    hustleDB.executeQuery(query);
+        "'LOW', 'Great');";
  }
+ query +=  "COMMIT;";
+ hustleDB.executeQuery(query);
+ std::cout << "access info insert ends" << std::endl;
 
- for (int i  = 9; i < 20; i++) {
-    std::string query =
-        "BEGIN TRANSACTION; "
+ query =  "BEGIN TRANSACTION; ";
+ for (int i  = 9; i < 100000; i++) {
+    query +=
         "INSERT INTO Special_Facility VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131321,"
         "131321, 131321,"
-        "'great');"
-        "COMMIT;";
-    hustleDB.executeQuery(query);
+        "'great');";
+   // hustleDB.executeQuery(query);
  }
+ query +=  "COMMIT;";
+ hustleDB.executeQuery(query);
 
-  for (int i  = 9; i < 20; i++) {
-    std::string query =
-        "BEGIN TRANSACTION; "
+ query =  "BEGIN TRANSACTION; ";
+  for (int i  = 9; i < 100000; i++) {
+   query +=
         "INSERT INTO Call_Forwarding VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131,"
         "131321,"
-        "'great');"
-        "COMMIT;";
-    hustleDB.executeQuery(query);
+        "'great');";
+   // hustleDB.executeQuery(query);
  }
+ query +=  "COMMIT;";
+ hustleDB.executeQuery(query);
 
  std::cout << "Query1 : " << std::endl;
  std::string query1 = "SELECT s_id, sub_nbr,"
@@ -298,11 +300,11 @@ void TATP::CreateTable() {
     "AND sf_s_id=10 "
     "AND sf_sf_type=10 "
     "AND is_active=131321 "
-    "AND start_time\<=1000 "
-    "AND end_time\> 1000;";
+    "AND start_time <=1000 "
+    "AND end_time > 1000;";
  container = simple_profiler.getContainer();
  container->startEvent("tatp - 2");
- //hustleDB.executeQuery(query2);
+ hustleDB.executeQuery(query2);
  container->endEvent("tatp - 2");
  simple_profiler.summarizeToStream(std::cout);
  simple_profiler.clear();

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -15,20 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 #include "benchmark/tatp_workload.h"
+
 #include "utils/event_profiler.h"
 
 namespace hustle::operators {
 
 TATP::TATP() {
-    CreateTable();
+  std::filesystem::remove_all("db_directory");
+  hustle_db = std::make_shared<HustleDB>("db_directory2");
+  // it will only start if it is not running.
+  hustle::HustleDB::startScheduler();
+  CreateTable();
 }
 
-void TATP::CreateTable() {
+TATP::~TATP() { hustle::HustleDB::stopScheduler(); }
 
-  std::shared_ptr<arrow::Schema>  s_schema, ai_schema,
-      sf_schema, cf_schema;
+void TATP::CreateTable() {
+  std::shared_ptr<arrow::Schema> s_schema, ai_schema, sf_schema, cf_schema;
   hustle::catalog::TableSchema subscriber("Subscriber");
   hustle::catalog::ColumnSchema s_id(
       "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
@@ -36,13 +40,13 @@ void TATP::CreateTable() {
       "sub_nbr", {hustle::catalog::HustleType::CHAR, 15}, true, false);
   hustle::catalog::ColumnSchema bit_1(
       "bit_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema bit_2(
+  hustle::catalog::ColumnSchema bit_2(
       "bit_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema bit_3(
+  hustle::catalog::ColumnSchema bit_3(
       "bit_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-    hustle::catalog::ColumnSchema bit_4(
+  hustle::catalog::ColumnSchema bit_4(
       "bit_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema bit_5(
+  hustle::catalog::ColumnSchema bit_5(
       "bit_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
   hustle::catalog::ColumnSchema bit_6(
       "bit_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
@@ -56,51 +60,50 @@ void TATP::CreateTable() {
       "bit_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
   hustle::catalog::ColumnSchema hex_1(
       "hex_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_2(
+  hustle::catalog::ColumnSchema hex_2(
       "hex_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_3(
+  hustle::catalog::ColumnSchema hex_3(
       "hex_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
   hustle::catalog::ColumnSchema hex_4(
       "hex_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
   hustle::catalog::ColumnSchema hex_5(
       "hex_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_6(
+  hustle::catalog::ColumnSchema hex_6(
       "hex_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_7(
+  hustle::catalog::ColumnSchema hex_7(
       "hex_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_8(
+  hustle::catalog::ColumnSchema hex_8(
       "hex_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_9(
+  hustle::catalog::ColumnSchema hex_9(
       "hex_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema hex_10(
+  hustle::catalog::ColumnSchema hex_10(
       "hex_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_1(
+  hustle::catalog::ColumnSchema byte2_1(
       "byte2_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_2(
+  hustle::catalog::ColumnSchema byte2_2(
       "byte2_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-    hustle::catalog::ColumnSchema byte2_3(
+  hustle::catalog::ColumnSchema byte2_3(
       "byte2_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_4(
+  hustle::catalog::ColumnSchema byte2_4(
       "byte2_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-  
-   hustle::catalog::ColumnSchema byte2_5(
+
+  hustle::catalog::ColumnSchema byte2_5(
       "byte2_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_6(
+  hustle::catalog::ColumnSchema byte2_6(
       "byte2_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_7(
+  hustle::catalog::ColumnSchema byte2_7(
       "byte2_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_8(
+  hustle::catalog::ColumnSchema byte2_8(
       "byte2_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_9(
+  hustle::catalog::ColumnSchema byte2_9(
       "byte2_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema byte2_10(
+  hustle::catalog::ColumnSchema byte2_10(
       "byte2_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-    hustle::catalog::ColumnSchema msc_location(
+  hustle::catalog::ColumnSchema msc_location(
       "msc_location", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-   hustle::catalog::ColumnSchema vlr_location(
+  hustle::catalog::ColumnSchema vlr_location(
       "vlr_location", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
-  
-  
+
   subscriber.addColumn(s_id);
   subscriber.addColumn(sub_nbr);
   subscriber.addColumn(bit_1);
@@ -139,8 +142,8 @@ void TATP::CreateTable() {
   s_schema = subscriber.getArrowSchema();
 
   hustle::catalog::TableSchema access_info("Access_Info");
- /* hustle::catalog::ColumnSchema s_id(
-      "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);*/
+  /* hustle::catalog::ColumnSchema s_id(
+       "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);*/
   hustle::catalog::ColumnSchema ai_type(
       "ai_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
   hustle::catalog::ColumnSchema data1(
@@ -201,267 +204,258 @@ void TATP::CreateTable() {
   call_forwarding.addColumn(numberx);
   call_forwarding.setPrimaryKey({});
   cf_schema = call_forwarding.getArrowSchema();
-  
+
   std::shared_ptr<DBTable> s, ai, sf, cf;
 
   s = std::make_shared<hustle::storage::DBTable>("table", s_schema, BLOCK_SIZE);
-  ai = std::make_shared<hustle::storage::DBTable>("table", ai_schema, BLOCK_SIZE);
-  sf = std::make_shared<hustle::storage::DBTable>("table", sf_schema, BLOCK_SIZE);
-  cf = std::make_shared<hustle::storage::DBTable>("table", cf_schema, BLOCK_SIZE);
-  std::filesystem::remove_all("db_directory");
-  // EXPECT_FALSE(std::filesystem::exists("db_directory"));
+  ai = std::make_shared<hustle::storage::DBTable>("table", ai_schema,
+                                                  BLOCK_SIZE);
+  sf = std::make_shared<hustle::storage::DBTable>("table", sf_schema,
+                                                  BLOCK_SIZE);
+  cf = std::make_shared<hustle::storage::DBTable>("table", cf_schema,
+                                                  BLOCK_SIZE);
 
-  hustle::HustleDB hustleDB("db_directory2");
-  // it will only start if it is not running.
-  hustle::HustleDB::startScheduler();
+  hustle_db->createTable(subscriber, s);
 
-  hustleDB.createTable(subscriber, s);
+  hustle_db->createTable(access_info, ai);
 
-  hustleDB.createTable(access_info, ai); 
+  hustle_db->createTable(special_facility, sf);
+  hustle_db->createTable(call_forwarding, cf);
 
-  hustleDB.createTable(special_facility, sf);
-  hustleDB.createTable(call_forwarding, cf);
+  std::cout << "Subscriber insert" << std::endl;
+  std::string query = "BEGIN TRANSACTION; ";
+  for (int i = 9; i < 100000; i++) {
+    query += "INSERT INTO Subscriber VALUES (" + std::to_string(i) + ", 'h" +
+             std::to_string(i) +
+             "', 131321,"
+             "131321, 131321,"
+             "131321, 131321, 131321, 131321, 131321,"
+             "131321, 1131321, 131321, 131321, 131321,"
+             "131321, 131321, 131321, 131321, 131321,"
+             "131321, 131321, 131321, 131321, 131321,"
+             "131321, 131321, 131321, 131321, 131321,"
+             "131321, 131321, 131321, 131321);";
+  }
+  query += "COMMIT;";
+  hustle_db->executeQuery(query);
 
- std::cout << "Subscriber insert" << std::endl;
- std::string query =  "BEGIN TRANSACTION; ";
- for (int i  = 9; i < 100000; i++) {
-     query +=
-        "INSERT INTO Subscriber VALUES ("+std::to_string(i)+", 'h"+std::to_string(i)+"', 131321,"
-        "131321, 131321,"
-        "131321, 131321, 131321, 131321, 131321,"
-        "131321, 1131321, 131321, 131321, 131321,"
-        "131321, 131321, 131321, 131321, 131321,"
-        "131321, 131321, 131321, 131321, 131321,"
-        "131321, 131321, 131321, 131321, 131321,"
-        "131321, 131321, 131321, 131321);";
- }
- query +=  "COMMIT;";
- hustleDB.executeQuery(query);
+  query = "BEGIN TRANSACTION; ";
+  for (int i = 9; i < 100000; i++) {
+    query += "INSERT INTO Access_Info VALUES (" + std::to_string(i) +
+             ", 131321,"
+             "131321, 131321,"
+             "'LOW', 'Great');";
+  }
+  query += "COMMIT;";
+  hustle_db->executeQuery(query);
+  std::cout << "access info insert ends" << std::endl;
 
- query =  "BEGIN TRANSACTION; ";
- for (int i  = 9; i < 100000; i++) {
-    query +=
-        "INSERT INTO Access_Info VALUES ("+std::to_string(i)+", 131321,"
-        "131321, 131321,"
-        "'LOW', 'Great');";
- }
- query +=  "COMMIT;";
- hustleDB.executeQuery(query);
- std::cout << "access info insert ends" << std::endl;
+  query = "BEGIN TRANSACTION; ";
+  for (int i = 9; i < 100000; i++) {
+    query += "INSERT INTO Special_Facility VALUES (" + std::to_string(i) +
+             ", " + std::to_string(i) +
+             ", 131321,"
+             "131321, 131321,"
+             "'great');";
+    // hustleDB.executeQuery(query);
+  }
+  query += "COMMIT;";
+  hustle_db->executeQuery(query);
 
- query =  "BEGIN TRANSACTION; ";
- for (int i  = 9; i < 100000; i++) {
-    query +=
-        "INSERT INTO Special_Facility VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131321,"
-        "131321, 131321,"
-        "'great');";
-   // hustleDB.executeQuery(query);
- }
- query +=  "COMMIT;";
- hustleDB.executeQuery(query);
-
- query =  "BEGIN TRANSACTION; ";
-  for (int i  = 9; i < 100000; i++) {
-   query +=
-        "INSERT INTO Call_Forwarding VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131,"
-        "131321,"
-        "'great');";
-   // hustleDB.executeQuery(query);
- }
- query +=  "COMMIT;";
- hustleDB.executeQuery(query);
-
- std::cout << "Query1 : " << std::endl;
- std::string query1 = "SELECT s_id, sub_nbr,"
-    "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
-    "bit_8, bit_9, bit_10,"
-    "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
-    "hex_8, hex_9, hex_10,"
-    "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
-    "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
-    "msc_location, vlr_location "
-    "FROM Subscriber "
-    "WHERE s_id=10;";
- auto container = simple_profiler.getContainer();
- container->startEvent("tatp - 1");
- hustleDB.executeQuery(query1);
- container->endEvent("tatp - 1");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
-
-
-  std::cout << "Query 2" << std::endl;
- std::string query2 =
-     "SELECT numberx "
-    "FROM Special_Facility, Call_Forwarding "
-    "WHERE "
-    "cf_s_id=sf_s_id "
-    "AND cf_sf_type=sf_sf_type "
-    "AND sf_s_id=10 "
-    "AND sf_sf_type=10 "
-    "AND is_active=131321 "
-    "AND start_time <=1000 "
-    "AND end_time > 1000;";
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 2");
- hustleDB.executeQuery(query2);
- container->endEvent("tatp - 2");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
-
- std::cout << "Running Query3 : " << std::endl;
- std::string query3 = "SELECT data1, data2, data3, data4 "
-    "FROM Access_Info "
-    "WHERE s_id=10 "
-    "AND ai_type=131321;";
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 3");
- hustleDB.executeQuery(query3);
- container->endEvent("tatp - 3");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
-
- std::cout << "Running Query4.1 : " << std::endl;
- std::string query4 = "UPDATE Subscriber "
-    "SET bit_1=999 "
-    "WHERE s_id=10; ";
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 4.1");
- hustleDB.executeQuery(query4);
- container->endEvent("tatp - 4.1");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
-
- std::cout << "Verify Query 4.1: " << std::endl;
- query4 = "SELECT s_id, sub_nbr,"
-    "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
-    "bit_8, bit_9, bit_10,"
-    "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
-    "hex_8, hex_9, hex_10,"
-    "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
-    "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
-    "msc_location, vlr_location "
-    "FROM Subscriber "
-    "WHERE s_id=10;";
- hustleDB.executeQuery(query4);
-
- std::cout << "Running Query4.2 : " << std::endl;
- query4 = "UPDATE Special_Facility "
-            "SET data_a = 999 "
-            "WHERE sf_s_id=10 "
-            "AND sf_sf_type=10"; 
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 4.2");
- hustleDB.executeQuery(query4);
- container->endEvent("tatp - 4.2");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
-
- std::cout << "Verify Query 4.2: " << std::endl;
- query4 = "SELECT sf_s_id, sf_sf_type,"
-    "data_a "
-    "FROM Special_Facility "
-    "WHERE sf_s_id=10 AND sf_sf_type=10;";
- hustleDB.executeQuery(query4);
-
- std::cout << "Updating Query 5: " << std::endl;
- std::string query5 = "UPDATE Subscriber"
-    " SET  vlr_location=50 "
-    "WHERE sub_nbr='hello10';";
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 5");
- hustleDB.executeQuery(query5);
- container->endEvent("tatp - 5");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
-std::cout << "Verify Query 5: " << std::endl;
- query4 = "SELECT s_id, sub_nbr,"
-    "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
-    "bit_8, bit_9, bit_10,"
-    "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
-    "hex_8, hex_9, hex_10,"
-    "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
-    "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
-    "msc_location, vlr_location "
-    "FROM Subscriber "
-    "WHERE s_id=10;";
- hustleDB.executeQuery(query5);
-
- std::cout << "Query 6" << std::endl;
- std::string query6 =
-        "BEGIN TRANSACTION; "
-        "INSERT INTO Call_Forwarding VALUES (1111111, 1111111, 131321,"
-        "131321,"
-        "'great');"
-        "COMMIT;";
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 6");
- hustleDB.executeQuery(query6);
- container->endEvent("tatp - 6");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
- std::cout << "Verify Query 6: " << std::endl;
- query6 = "SELECT cf_s_id, start_time, end_time "
-    "FROM Call_Forwarding "
-    "WHERE cf_s_id=1111111;";
- hustleDB.executeQuery(query6);
-
- std::cout << "Query 7" << std::endl;
- std::string query7 =
-        "DELETE FROM Call_Forwarding "
-        "WHERE cf_s_id = 11;";
- container = simple_profiler.getContainer();
- container->startEvent("tatp - 7");
- hustleDB.executeQuery(query5);
- container->endEvent("tatp - 7");
- simple_profiler.summarizeToStream(std::cout);
- simple_profiler.clear();
- std::cout << "Verify Query 7: " << std::endl;
- query7 = "SELECT cf_s_id, start_time, end_time "
-    "FROM Call_Forwarding "
-    "WHERE cf_s_id=1111111;";
- hustleDB.executeQuery(query7);
-
-
- hustle::HustleDB::stopScheduler();
- 
+  query = "BEGIN TRANSACTION; ";
+  for (int i = 9; i < 100000; i++) {
+    query += "INSERT INTO Call_Forwarding VALUES (" + std::to_string(i) + ", " +
+             std::to_string(i) +
+             ", 131,"
+             "131321,"
+             "'great');";
+    // hustleDB.executeQuery(query);
+  }
+  query += "COMMIT;";
+  hustle_db->executeQuery(query);
 }
 
-
 void TATP::RunBenchmark() {
-
+  this->RunQuery1();
+  this->RunQuery3();
+  this->RunQuery4();
+  this->RunQuery5();
+  this->RunQuery6();
+  this->RunQuery7();
 }
 
 void TATP::RunQuery1() {
-    
+  std::cout << "Query1 : " << std::endl;
+  std::string query1 =
+      "SELECT s_id, sub_nbr,"
+      "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+      "bit_8, bit_9, bit_10,"
+      "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+      "hex_8, hex_9, hex_10,"
+      "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+      "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+      "msc_location, vlr_location "
+      "FROM Subscriber "
+      "WHERE s_id=10;";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 1");
+  hustle_db->executeQuery(query1);
+  container->endEvent("tatp - 1");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
 }
 
 void TATP::RunQuery2() {
-    
+  std::cout << "Query 2" << std::endl;
+  std::string query2 =
+      "SELECT numberx "
+      "FROM Special_Facility, Call_Forwarding "
+      "WHERE "
+      "cf_s_id=sf_s_id "
+      "AND cf_sf_type=sf_sf_type "
+      "AND sf_s_id=10 "
+      "AND sf_sf_type=10 "
+      "AND is_active=131321 "
+      "AND start_time <=1000 "
+      "AND end_time > 1000;";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 2");
+  hustle_db->executeQuery(query2);
+  container->endEvent("tatp - 2");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
 }
 
-
 void TATP::RunQuery3() {
-    
+  std::cout << "Running Query3 : " << std::endl;
+  std::string query3 =
+      "SELECT data1, data2, data3, data4 "
+      "FROM Access_Info "
+      "WHERE s_id=10 "
+      "AND ai_type=131321;";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 3");
+  hustle_db->executeQuery(query3);
+  container->endEvent("tatp - 3");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
 }
 
 void TATP::RunQuery4() {
-    
+  std::cout << "Running Query4.1 : " << std::endl;
+  std::string query4 =
+      "UPDATE Subscriber "
+      "SET bit_1=999 "
+      "WHERE s_id=10; ";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 4.1");
+  hustle_db->executeQuery(query4);
+  container->endEvent("tatp - 4.1");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
+
+  std::cout << "Verify Query 4.1: " << std::endl;
+  query4 =
+      "SELECT s_id, sub_nbr,"
+      "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+      "bit_8, bit_9, bit_10,"
+      "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+      "hex_8, hex_9, hex_10,"
+      "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+      "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+      "msc_location, vlr_location "
+      "FROM Subscriber "
+      "WHERE s_id=10;";
+  hustle_db->executeQuery(query4);
+
+  std::cout << "Running Query4.2 : " << std::endl;
+  query4 =
+      "UPDATE Special_Facility "
+      "SET data_a = 999 "
+      "WHERE sf_s_id=10 "
+      "AND sf_sf_type=10";
+  container = simple_profiler.getContainer();
+  container->startEvent("tatp - 4.2");
+  hustle_db->executeQuery(query4);
+  container->endEvent("tatp - 4.2");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
+
+  std::cout << "Verify Query 4.2: " << std::endl;
+  query4 =
+      "SELECT sf_s_id, sf_sf_type,"
+      "data_a "
+      "FROM Special_Facility "
+      "WHERE sf_s_id=10 AND sf_sf_type=10;";
+  hustle_db->executeQuery(query4);
 }
 
-
 void TATP::RunQuery5() {
-    
+  std::cout << "Updating Query 5: " << std::endl;
+  std::string query5 =
+      "UPDATE Subscriber"
+      " SET  vlr_location=50 "
+      "WHERE sub_nbr='h10';";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 5");
+  hustle_db->executeQuery(query5);
+  container->endEvent("tatp - 5");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
+  std::cout << "Verify Query 5: " << std::endl;
+  query5 =
+      "SELECT s_id, sub_nbr,"
+      "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+      "bit_8, bit_9, bit_10,"
+      "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+      "hex_8, hex_9, hex_10,"
+      "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+      "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+      "msc_location, vlr_location "
+      "FROM Subscriber "
+      "WHERE s_id=10;";
+  hustle_db->executeQuery(query5);
 }
 
 void TATP::RunQuery6() {
-    
+  std::cout << "Query 6" << std::endl;
+  std::string query6 =
+      "BEGIN TRANSACTION; "
+      "INSERT INTO Call_Forwarding VALUES (1111111, 1111111, 131321,"
+      "131321,"
+      "'great');"
+      "COMMIT;";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 6");
+  hustle_db->executeQuery(query6);
+  container->endEvent("tatp - 6");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
+  std::cout << "Verify Query 6: " << std::endl;
+  query6 =
+      "SELECT cf_s_id, start_time, end_time "
+      "FROM Call_Forwarding "
+      "WHERE cf_s_id=1111111;";
+  hustle_db->executeQuery(query6);
 }
 
 void TATP::RunQuery7() {
-    
+  std::cout << "Query 7" << std::endl;
+  std::string query7 =
+      "DELETE FROM Call_Forwarding "
+      "WHERE cf_s_id = 11;";
+  auto container = simple_profiler.getContainer();
+  container->startEvent("tatp - 7");
+  hustle_db->executeQuery(query7);
+  container->endEvent("tatp - 7");
+  simple_profiler.summarizeToStream(std::cout);
+  simple_profiler.clear();
+  std::cout << "Verify Query 7: " << std::endl;
+  query7 =
+      "SELECT cf_s_id, start_time, end_time "
+      "FROM Call_Forwarding "
+      "WHERE cf_s_id=1111111;";
+  hustle_db->executeQuery(query7);
 }
 
-
-
-}
+}  // namespace hustle::operators

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -222,10 +222,11 @@ void TATP::CreateTable() {
   hustleDB.createTable(special_facility, sf);
   hustleDB.createTable(call_forwarding, cf);
 
- for (int i  = 9; i < 1000; i++) {
+ std::cout << "Subscriber insert" << std::endl;
+ for (int i  = 9; i < 10000; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
-        "INSERT INTO Subscriber VALUES ("+std::to_string(i)+", 'hello"+std::to_string(i)+"', 131321,"
+        "INSERT INTO Subscriber VALUES ("+std::to_string(i)+", 'h"+std::to_string(i)+"', 131321,"
         "131321, 131321,"
         "131321, 131321, 131321, 131321, 131321,"
         "131321, 1131321, 131321, 131321, 131321,"
@@ -236,7 +237,9 @@ void TATP::CreateTable() {
         "COMMIT;";
     hustleDB.executeQuery(query);
  }
- for (int i  = 9; i < 1000; i++) {
+ std::cout << "Subscriber insert ends" << std::endl;
+
+ for (int i  = 9; i < 10000; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Access_Info VALUES ("+std::to_string(i)+", 131321,"
@@ -246,7 +249,7 @@ void TATP::CreateTable() {
     hustleDB.executeQuery(query);
  }
 
- for (int i  = 9; i < 1000; i++) {
+ for (int i  = 9; i < 10000; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Special_Facility VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131321,"
@@ -256,7 +259,7 @@ void TATP::CreateTable() {
     hustleDB.executeQuery(query);
  }
 
-  for (int i  = 9; i < 1000; i++) {
+  for (int i  = 9; i < 10000; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Call_Forwarding VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131,"
@@ -299,7 +302,7 @@ void TATP::CreateTable() {
     "AND end_time\> 1000;";
  container = simple_profiler.getContainer();
  container->startEvent("tatp - 2");
- hustleDB.executeQuery(query2);
+ //hustleDB.executeQuery(query2);
  container->endEvent("tatp - 2");
  simple_profiler.summarizeToStream(std::cout);
  simple_profiler.clear();
@@ -404,7 +407,7 @@ std::cout << "Verify Query 5: " << std::endl;
  std::cout << "Query 7" << std::endl;
  std::string query7 =
         "DELETE FROM Call_Forwarding "
-        "WHERE cf_s_id = 1111111;";
+        "WHERE cf_s_id = 11;";
  container = simple_profiler.getContainer();
  container->startEvent("tatp - 7");
  hustleDB.executeQuery(query5);

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -223,7 +223,7 @@ void TATP::CreateTable() {
   hustleDB.createTable(call_forwarding, cf);
 
  std::cout << "Subscriber insert" << std::endl;
- for (int i  = 9; i < 10000; i++) {
+ for (int i  = 9; i < 20; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Subscriber VALUES ("+std::to_string(i)+", 'h"+std::to_string(i)+"', 131321,"
@@ -239,7 +239,7 @@ void TATP::CreateTable() {
  }
  std::cout << "Subscriber insert ends" << std::endl;
 
- for (int i  = 9; i < 10000; i++) {
+ for (int i  = 9; i < 20; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Access_Info VALUES ("+std::to_string(i)+", 131321,"
@@ -249,7 +249,7 @@ void TATP::CreateTable() {
     hustleDB.executeQuery(query);
  }
 
- for (int i  = 9; i < 10000; i++) {
+ for (int i  = 9; i < 20; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Special_Facility VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131321,"
@@ -259,7 +259,7 @@ void TATP::CreateTable() {
     hustleDB.executeQuery(query);
  }
 
-  for (int i  = 9; i < 10000; i++) {
+  for (int i  = 9; i < 20; i++) {
     std::string query =
         "BEGIN TRANSACTION; "
         "INSERT INTO Call_Forwarding VALUES ("+std::to_string(i)+", "+std::to_string(i)+", 131,"

--- a/src/benchmark/tatp_workload.h
+++ b/src/benchmark/tatp_workload.h
@@ -18,6 +18,10 @@
 #ifndef HUSTLE_TATP_WORKLOAD_H
 #define HUSTLE_TATP_WORKLOAD_H
 
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+
 #include <iostream>
 
 #include "api/hustle_db.h"
@@ -25,40 +29,37 @@
 #include "catalog/column_schema.h"
 #include "catalog/table_schema.h"
 #include "parser/parser.h"
-#include "storage/util.h"
-
-
-#include "catalog/catalog.h"
 #include "sqlite3/sqlite3.h"
-
-#include <stdlib.h> 
-#include <unistd.h> 
-#include <pthread.h> 
+#include "storage/util.h"
 
 namespace hustle::operators {
 class TATP {
-    public:
-         TATP();
+ public:
+  TATP();
 
-          void RunBenchmark();
+  void RunBenchmark();
 
-    private:
-          void CreateTable();
+  ~TATP();
 
-          void RunQuery1();
+ private:
+  std::shared_ptr<HustleDB> hustle_db;
 
-          void RunQuery2();
+  void CreateTable();
 
-          void RunQuery3();
+  void RunQuery1();
 
-          void RunQuery4();
+  void RunQuery2();
 
-          void RunQuery5();
+  void RunQuery3();
 
-          void RunQuery6();
+  void RunQuery4();
 
-          void RunQuery7();
+  void RunQuery5();
+
+  void RunQuery6();
+
+  void RunQuery7();
 };
-}
+}  // namespace hustle::operators
 
 #endif  // HUSTLE_TATP_WORKLOAD_H

--- a/src/benchmark/tatp_workload.h
+++ b/src/benchmark/tatp_workload.h
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef HUSTLE_TATP_WORKLOAD_H
+#define HUSTLE_TATP_WORKLOAD_H
+
+#include <iostream>
+
+#include "api/hustle_db.h"
+#include "catalog/catalog.h"
+#include "catalog/column_schema.h"
+#include "catalog/table_schema.h"
+#include "parser/parser.h"
+#include "storage/util.h"
+
+
+#include "catalog/catalog.h"
+#include "sqlite3/sqlite3.h"
+
+#include <stdlib.h> 
+#include <unistd.h> 
+#include <pthread.h> 
+
+namespace hustle::operators {
+class TATP {
+    public:
+         TATP();
+
+          void RunBenchmark();
+
+    private:
+          void CreateTable();
+
+          void RunQuery1();
+
+          void RunQuery2();
+
+          void RunQuery3();
+
+          void RunQuery4();
+
+          void RunQuery5();
+
+          void RunQuery6();
+
+          void RunQuery7();
+};
+}
+
+#endif  // HUSTLE_TATP_WORKLOAD_H

--- a/src/catalog/catalog.cc
+++ b/src/catalog/catalog.cc
@@ -134,15 +134,14 @@ bool Catalog::dropTable(std::string name) {
     return false;
   }
 
-  tables_.erase(tables_.begin());
-  name_to_id_.erase(search);
-
-  SaveToFile();
-
   if (!utils::executeSqliteNoOutput(SqlitePath_,
                                     absl::StrCat("DROP TABLE ", name, ";"))) {
     std::cerr << "SqliteDB catalog out of sync" << std::endl;
   }
+
+  tables_.erase(tables_.begin());
+  name_to_id_.erase(search);
+  SaveToFile();
   return true;
 }
 
@@ -163,7 +162,6 @@ bool Catalog::addTable(TableSchema t) {
 
   tables_.push_back(t);
   name_to_id_[t.getName()] = tables_.size() - 1;
-
   SaveToFile();
 
   if (!utils::executeSqliteNoOutput(SqlitePath_, createCreateSql(t))) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -381,9 +381,7 @@ int main(int argc, char *argv[]) {
       "\tgroup by d_year, s_nation, p_category\n"
       "\torder by d_year, s_nation, p_category;";
 
-  std::cout << "Query in 1" << std::endl;  
-  //hustleDB.executeQuery(query);
-  std::cout << "Query in 2" << std::endl;  
+  hustleDB.executeQuery(query);
 
   std::string query2 =
       "BEGIN TRANSACTION; "
@@ -404,26 +402,23 @@ int main(int argc, char *argv[]) {
       "INSERT INTO recipes  "
       "VALUES (1,'Tacos');"
       "COMMIT;";
-  //hustleDB.executeQuery(query2);
+  hustleDB.executeQuery(query2);
 
   pthread_t tid1, tid2, tid3; 
   
   // Let us create three threads 
 
-  /*pthread_create(&tid1, NULL, readQuery, (void *)&hustleDB); 
-  pthread_create(&tid2, NULL, readQuery, (void *)&hustleDB); */
-  //pthread_create(&tid3, NULL, writeQuery, (void *)&hustleDB); 
+  pthread_create(&tid1, NULL, readQuery, (void *)&hustleDB); 
+  pthread_create(&tid2, NULL, readQuery, (void *)&hustleDB);
+  pthread_create(&tid3, NULL, writeQuery, (void *)&hustleDB); 
   
-  /*pthread_join(tid1, NULL); 
-  pthread_join(tid2, NULL); */
-  //pthread_join(tid3, NULL); 
-  std::cout << "Query in 3" << std::endl;  
+  pthread_join(tid1, NULL); 
+  pthread_join(tid2, NULL); 
+  pthread_join(tid3, NULL); 
+
   writeQuery((void *)&hustleDB);
-  std::cout << "Query in 4" << std::endl; 
   writeQuery2((void *)&hustleDB);
-  std::cout << "Query in 5" << std::endl; 
-  //readQuery((void *)&hustleDB);
-  std::cout << "Query in 6" << std::endl; 
+  readQuery((void *)&hustleDB);
   readQuery2((void *)&hustleDB);
 
   updateQuery((void *)&hustleDB);

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,11 +57,35 @@ void *writeQuery(void *db) {
       "INSERT INTO customer VALUES (800224, 'James', "
       " 'good',"
       "'Houston', 'Great',"
-      "         'best', 'fit', 'done');"
+      "         'best1', 'fit', 'done');"
        "INSERT INTO customer VALUES (800225, 'James1', "
       " 'good1',"
       "'Houston1', 'Great1',"
-      "         'best', 'fit', 'done');"
+      "         'best2', 'fit', 'done');"
+      "INSERT INTO customer VALUES (800226, 'James1', "
+      " 'good1',"
+      "'Houston1', 'Great1',"
+      "         'best3', 'fit', 'done');"
+      "COMMIT;";
+
+  ((hustle::HustleDB*)db)->executeQuery(query);
+} 
+
+// The function to be executed by all threads 
+void *updateQuery(void *db) { 
+   std::string query =
+      "BEGIN TRANSACTION;"
+      "UPDATE customer set c_region = 'fine' where c_custkey=800224;"
+      "COMMIT;";
+
+  ((hustle::HustleDB*)db)->executeQuery(query);
+} 
+
+
+void *deleteQuery(void *db) { 
+   std::string query =
+      "BEGIN TRANSACTION;"
+      "DELETE FROM customer where c_custkey=800226;"
       "COMMIT;";
 
   ((hustle::HustleDB*)db)->executeQuery(query);
@@ -73,6 +97,9 @@ void *writeQuery2(void *db) {
    std::string query =
       "BEGIN TRANSACTION; "
       "INSERT INTO lineorder VALUES (7, 4, 800224,"
+      "163073, 48,"
+      "19960404, '3-MEDIUM', 0, 28, 3180996, 13526467, 2, 3085567, 68164, 4, 19960702, 'TRUCKS');"
+        "INSERT INTO lineorder VALUES (8, 4, 800225,"
       "163073, 48,"
       "19960404, '3-MEDIUM', 0, 28, 3180996, 13526467, 2, 3085567, 68164, 4, 19960702, 'TRUCKS');"
       "COMMIT;";
@@ -290,8 +317,28 @@ int main(int argc, char *argv[]) {
   lineorder.addColumn(lo_shipmode);
   lineorder.setPrimaryKey({});
   lo_schema = lineorder.getArrowSchema();
-
+/*
   std::shared_ptr<DBTable> t;
+
+   t = read_from_csv_file("../ssb/data/customer.tbl", c_schema,
+                         20 * BLOCK_SIZE);
+  write_to_file("../ssb/data/customer.hsl", *t);
+
+  t = read_from_csv_file("../ssb/data/supplier.tbl", s_schema,
+                         20 * BLOCK_SIZE);
+  write_to_file("../ssb/data/supplier.hsl", *t);
+
+  t = read_from_csv_file("../ssb/data/date.tbl", d_schema,
+                         20 * BLOCK_SIZE);
+  write_to_file("../ssb/data/date.hsl", *t);
+
+  t = read_from_csv_file("../ssb/data/part.tbl", p_schema,
+                         20 * BLOCK_SIZE);
+  write_to_file("../ssb/data/part.hsl", *t);
+
+  t = read_from_csv_file("../ssb/data/lineorder.tbl", lo_schema,
+                         20 * BLOCK_SIZE);
+  write_to_file("../ssb/data/lineorder.hsl", *t);*/
 
   std::cout << "read the table files..." << std::endl;
   std::shared_ptr<DBTable> lo, c, s, p, d;
@@ -300,6 +347,8 @@ int main(int argc, char *argv[]) {
   p = read_from_file("../ssb/data/part.hsl");
   c = read_from_file("../ssb/data/customer.hsl");
   s = read_from_file("../ssb/data/supplier.hsl");
+
+  c = std::make_shared<hustle::storage::DBTable>("table", c_schema, BLOCK_SIZE);
 
   std::filesystem::remove_all("db_directory");
   // EXPECT_FALSE(std::filesystem::exists("db_directory"));
@@ -332,7 +381,9 @@ int main(int argc, char *argv[]) {
       "\tgroup by d_year, s_nation, p_category\n"
       "\torder by d_year, s_nation, p_category;";
 
-  hustleDB.executeQuery(query);
+  std::cout << "Query in 1" << std::endl;  
+  //hustleDB.executeQuery(query);
+  std::cout << "Query in 2" << std::endl;  
 
   std::string query2 =
       "BEGIN TRANSACTION; "
@@ -359,16 +410,26 @@ int main(int argc, char *argv[]) {
   
   // Let us create three threads 
 
-  pthread_create(&tid1, NULL, readQuery, (void *)&hustleDB); 
-  pthread_create(&tid2, NULL, readQuery, (void *)&hustleDB); 
-  pthread_create(&tid3, NULL, writeQuery, (void *)&hustleDB); 
+  /*pthread_create(&tid1, NULL, readQuery, (void *)&hustleDB); 
+  pthread_create(&tid2, NULL, readQuery, (void *)&hustleDB); */
+  //pthread_create(&tid3, NULL, writeQuery, (void *)&hustleDB); 
   
-  pthread_join(tid1, NULL); 
-  pthread_join(tid2, NULL); 
-  pthread_join(tid3, NULL); 
+  /*pthread_join(tid1, NULL); 
+  pthread_join(tid2, NULL); */
+  //pthread_join(tid3, NULL); 
+  std::cout << "Query in 3" << std::endl;  
   writeQuery((void *)&hustleDB);
+  std::cout << "Query in 4" << std::endl; 
   writeQuery2((void *)&hustleDB);
-  readQuery((void *)&hustleDB);
+  std::cout << "Query in 5" << std::endl; 
+  //readQuery((void *)&hustleDB);
+  std::cout << "Query in 6" << std::endl; 
+  readQuery2((void *)&hustleDB);
+
+  updateQuery((void *)&hustleDB);
+  readQuery2((void *)&hustleDB);
+
+  deleteQuery((void *)&hustleDB);
   readQuery2((void *)&hustleDB);
 
   hustle::HustleDB::stopScheduler();

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -706,7 +706,6 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
         columns[i]->length++;
         column_sizes[i] += byte_widths[i];
         head += byte_widths[i];
-        std::cerr << "string insert" << byte_widths[i] << std::endl;
         increment_num_bytes(byte_widths[i]);
         break;
       }
@@ -757,7 +756,6 @@ void Block::insert_value_in_column(int i, int &head, uint8_t *record_value,
     column_sizes[i] += byte_width;
     increment_num_bytes(byte_width);
   } else {
-    std::cerr << "Block insert else part" << std::endl;
     // TODO(suryadev): Study the scope for optimization
     auto *dest = columns[i]->GetMutableValues<field_size>(1, num_rows);
     //std::cout << "Num rows: " << num_rows << " " << capacity << std::endl;

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -706,6 +706,7 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
         columns[i]->length++;
         column_sizes[i] += byte_widths[i];
         head += byte_widths[i];
+        std::cerr << "string insert" << byte_widths[i] << std::endl;
         increment_num_bytes(byte_widths[i]);
         break;
       }
@@ -754,7 +755,9 @@ void Block::insert_value_in_column(int i, int &head, uint8_t *record_value,
     std::memcpy(dest, record_value, byte_width);
     head += byte_width;
     column_sizes[i] += byte_width;
+    increment_num_bytes(byte_width);
   } else {
+    std::cerr << "Block insert else part" << std::endl;
     // TODO(suryadev): Study the scope for optimization
     auto *dest = columns[i]->GetMutableValues<field_size>(1, num_rows);
     //std::cout << "Num rows: " << num_rows << " " << capacity << std::endl;
@@ -762,11 +765,10 @@ void Block::insert_value_in_column(int i, int &head, uint8_t *record_value,
     std::memcpy(value, utils::reverse_bytes(record_value, byte_width),
                 byte_width);
     std::memcpy(dest, value, sizeof(field_size));
-
-    free(value);
-    increment_num_bytes(sizeof(field_size));
     head += byte_width;
     column_sizes[i] += sizeof(field_size);
+    increment_num_bytes(sizeof(field_size));
+    free(value);
   }
 
   columns[i]->length++;

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -296,6 +296,7 @@ void Block::decrement_num_rows() {
 
 void Block::increment_num_bytes(unsigned int n_bytes) {
   if (num_bytes + n_bytes > capacity) {
+    std::cout << "num bytes: " << num_bytes << " " << n_bytes << " " << capacity << std::endl;
     throw std::runtime_error(
         "Incremented number of bytes stored in block beyond "
         "capacity:");
@@ -705,7 +706,7 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
         columns[i]->length++;
         column_sizes[i] += byte_widths[i];
         head += byte_widths[i];
-        //increment_num_bytes(byte_widths[i]);
+        increment_num_bytes(byte_widths[i]);
         break;
       }
       case arrow::Type::DOUBLE:
@@ -733,7 +734,6 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
             schema->field(i)->type()->ToString());
     }
   }
-  increment_num_bytes(head);
   //std::cout << "bytes: " << num_bytes - initial_bytes << std::endl;
   increment_num_rows();
 
@@ -762,12 +762,10 @@ void Block::insert_value_in_column(int i, int &head, uint8_t *record_value,
     std::memcpy(value, utils::reverse_bytes(record_value, byte_width),
                 byte_width);
     std::memcpy(dest, value, sizeof(field_size));
+
     free(value);
-    //std::cout << "field size: " << sizeof(field_size) << std::endl;
-    //head += sizeof(field_size);
-   // head += 2;
     increment_num_bytes(sizeof(field_size));
-    //head += byte_width;
+    head += byte_width;
     column_sizes[i] += sizeof(field_size);
   }
 

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -296,7 +296,6 @@ void Block::decrement_num_rows() {
 
 void Block::increment_num_bytes(unsigned int n_bytes) {
   if (num_bytes + n_bytes > capacity) {
-    std::cout << "num bytes: " << num_bytes << " " << n_bytes << " " << capacity << std::endl;
     throw std::runtime_error(
         "Incremented number of bytes stored in block beyond "
         "capacity:");
@@ -418,14 +417,12 @@ bool Block::insert_records(
 
   status = valid_buffer->Resize(valid_buffer->size() + n / 8 + 1, false);
   valid_buffer->ZeroPadding();  // Ensure the additional byte is zeroed
-  // std::cout << "Number of lemen to be inserted: " << n << std::endl;
   // TODO(nicholas)
   for (int k = 0; k < n; k++) {
     set_valid(num_rows + k, true);
   }
 
   valid->length += n;
-  int initial_bytes = num_bytes;
   // NOTE: buffers do NOT account for Slice offsets!!!
   int offset = column_data[0]->offset;
 
@@ -555,7 +552,6 @@ bool Block::insert_records(
             schema->field(i)->type()->ToString());
     }
   }
- // std::cout << "Row bytes - " << (num_bytes - initial_bytes) << std::endl;
   num_rows += n;
   return true;
 }
@@ -591,7 +587,6 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
   }
   // record does not fit in the block.
   if (record_size > get_bytes_left()) {
-    std::cout << "record does not fit" << std::endl;
     return -1;
   }
 
@@ -605,7 +600,6 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
   evaluate_status(status, __FUNCTION__, __LINE__);
   set_valid(num_rows, true);
   valid->length++;
-  int initial_bytes = num_bytes;
   // Position in the record array
   int head = 0;
 
@@ -672,7 +666,6 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
             schema->field(i)->type()->ToString());
     }
   }
-  //std::cout << "bytes: " << num_bytes - initial_bytes << std::endl;
   increment_num_rows();
 
   return num_rows - 1;
@@ -696,7 +689,6 @@ void Block::insert_value_in_column(int i, int &head, uint8_t *record_value,
   } else {
     // TODO(suryadev): Study the scope for optimization
     auto *dest = columns[i]->GetMutableValues<field_size>(1, num_rows);
-    //std::cout << "Num rows: " << num_rows << " " << capacity << std::endl;
     uint8_t *value = (uint8_t *)calloc(sizeof(field_size), sizeof(uint8_t));
     std::memcpy(value, utils::reverse_bytes(record_value, byte_width),
                 byte_width);

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -370,7 +370,7 @@ void Block::print() {
 }
 
 // Note that this funciton assumes that the valid column is in column_data
-bool Block::insert_records(
+void Block::insert_records(
     std::map<int, BlockInfo>& block_map,
     std::map<int, int>& row_map,
     std::shared_ptr<arrow::Array> valid_column,

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -36,7 +36,7 @@ Block::Block(int id, const std::shared_ptr<arrow::Schema> &in_schema,
 
   num_cols = schema->num_fields();
 
-  int fixed_record_width = compute_fixed_record_width(schema);
+  this->fixed_record_width = compute_fixed_record_width(schema);
   field_sizes_ = get_field_sizes(schema);
   int num_string_cols = 0;
   for (const auto &field : schema->fields()) {
@@ -589,7 +589,6 @@ int Block::insert_record(uint8_t *record, int32_t *byte_widths) {
   for (int i = 0; i < num_cols; i++) {
     record_size += byte_widths[i];
   }
-  //std::cout << "bytes left: " << get_bytes_left() << std::endl;
   // record does not fit in the block.
   if (record_size > get_bytes_left()) {
     std::cout << "record does not fit" << std::endl;

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -379,7 +379,7 @@ bool Block::insert_records(
   // TODO(nicholas): Optimize this. Calls to schema->field(i) is non-
   //  neglible since we call it once for each column of each record.
   int column_types[num_cols];
-  std::cout << "col length: " << l << std::endl;
+  //std::cout << "col length: " << l << std::endl;
   for (int i = 0; i < num_cols; i++) {
     column_types[i] = schema->field(i)->type()->id();
   }
@@ -441,20 +441,20 @@ bool Block::insert_records(
     }
 
     if ((filter_data[row / 8] >> (row % 8u) & 1u) == 1u) {
-      std::cout << "Row: " << row << std::endl;
+      //std::cout << "Row: " << row << std::endl;
       int row_id = row_map[row + reduced_count];
       this->row_id_map[row] = row_id;
       BlockInfo blockInfo = block_map[row_id];
-      std::cout << "Row num --  " << blockInfo.rowNum << "  reduced count -- "<< reduced_count << std::endl;
+      //std::cout << "Row num --  " << blockInfo.rowNum << "  reduced count -- "<< reduced_count << std::endl;
       block_map[row_id] = {blockInfo.blockId, row};
       this->insert_records(sliced_column_data);
       //data_size += record_size;
     } else {
        reduced_count++;
-       std::cout << "Not Row: " << row << std::endl;
+       //std::cout << "Not Row: " << row << std::endl;
     }
     // num_rows++;
-    std::cout << "num rows: " << num_rows << std::endl;
+    //std::cout << "num rows: " << num_rows << std::endl;
   }
 }
 
@@ -473,7 +473,7 @@ bool Block::insert_records(
 
   status = valid_buffer->Resize(valid_buffer->size() + n / 8 + 1, false);
   valid_buffer->ZeroPadding();  // Ensure the additional byte is zeroed
-  std::cout << "Number of lemen to be inserted: " << n << std::endl;
+  // std::cout << "Number of lemen to be inserted: " << n << std::endl;
   // TODO(nicholas)
   for (int k = 0; k < n; k++) {
     set_valid(num_rows + k, true);

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -766,8 +766,8 @@ void Block::insert_value_in_column(int i, int &head, uint8_t *record_value,
     //std::cout << "field size: " << sizeof(field_size) << std::endl;
     //head += sizeof(field_size);
    // head += 2;
-   increment_num_bytes(sizeof(field_size));
-   // head += byte_width;
+    increment_num_bytes(sizeof(field_size));
+    //head += byte_width;
     column_sizes[i] += sizeof(field_size);
   }
 

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -224,6 +224,10 @@ class Block {
 
   int get_num_cols() const;
 
+  int get_fixed_record_width() const {
+      return fixed_record_width;
+  }
+
   int get_capacity() {
       return capacity;
   }
@@ -302,6 +306,8 @@ class Block {
 
   // Initialized to BLOCK_SIZE
   int capacity;
+
+  int fixed_record_width;
 
   // Number of rows in the Block, including valid and invalid rows.
   int num_rows;

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -256,7 +256,7 @@ class Block {
    * number of elements.
    * @return True if insertion was successful, false otherwise.
    */
-  bool insert_records(
+  void insert_records(
       std::map<int, BlockInfo>& block_map,
       std::map<int, int>& row_map,
       std::shared_ptr<arrow::Array> valid_column,

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -260,12 +260,13 @@ class Block {
    * number of elements.
    * @return True if insertion was successful, false otherwise.
    */
+  bool insert_records(
+      std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
+
   void insert_records(
       std::map<int, BlockInfo>& block_map,
       std::map<int, int>& row_map,
       std::shared_ptr<arrow::Array> valid_column,
-      std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
-  bool insert_records(
       std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
 
   bool insert_record(std::vector<std::string_view> record,

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -224,6 +224,10 @@ class Block {
 
   int get_num_cols() const;
 
+  int get_capacity() {
+      return capacity;
+  }
+
   std::map<int, int>& get_row_id_map() {
       return row_id_map;
   }
@@ -239,8 +243,6 @@ class Block {
    * @return True if insertion was successful, false otherwise.
    */
   int insert_record(uint8_t *record, int32_t *byte_widths);
-
-  int insert_record(int rowId, uint8_t *record, int32_t *byte_widths);
 
   /**
    * Insert one or more records into the Block as a vector of ArrayData.

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -69,13 +69,14 @@ Status hustle_memlog_initialize(HustleMemLog **mem_log, char *db_name,
  * data - SQLite's data record format with header in the begining
  * nData - the size of the data
  * */
-DBRecord *hustle_memlog_create_record(const void *data, int nData) {
-  if (data == NULL) {
+DBRecord *hustle_memlog_create_record(int mode, int rowId, const void *data,
+                                      int nData) {
+  if (data == NULL && mode != MEMLOG_HUSTLE_DELETE) {
     return NULL;
   }
-  u32 num;
   DBRecord *record = (DBRecord *)malloc(sizeof(DBRecord));
-  int nBytes = getVarint32((const unsigned char *)data, num);
+  record->mode = mode;
+  record->rowId = rowId;
   record->data = (const void *)malloc(nData);
   memcpy((void *)record->data, data, nData);
   // record->data = data;
@@ -94,7 +95,7 @@ DBRecord *hustle_memlog_create_record(const void *data, int nData) {
  * */
 Status hustle_memlog_insert_record(HustleMemLog *mem_log, DBRecord *record,
                                    int table_id) {
-  if (mem_log == NULL || record == NULL) {
+  if (mem_log == NULL || (record == NULL && record->mode != MEMLOG_HUSTLE_DELETE)) {
     return MEMLOG_ERROR;
   }
   if (table_id >= mem_log->total_size) {
@@ -158,39 +159,52 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
     struct DBRecord *head = mem_log->record_list[table_index].head;
     auto search = table_map[DEFAULT_DB_ID].find(table_index);
     if (search == table_map[DEFAULT_DB_ID].end()) {
+       //printf("here in delete -continue");
       table_index++;
       continue;
     }
-   
+
     auto table =
         catalog->getTable(table_map[DEFAULT_DB_ID][table_index].c_str());
     while (head != NULL) {
       tmp_record = head;
-      u32 hdrLen;
-      // Read header len in the record
-      u32 nBytes = getVarint32((const unsigned char *)head->data, hdrLen);
-      u32 idx = nBytes;
-      const unsigned char *hdr = (const unsigned char *)head->data;
-      std::vector<int32_t> byte_widths;
-      /* read the col width from the record and user serialTypeLen 
-          to convert to exact col width */
-      while (idx < hdrLen) {
-        u32 typeLen;
-        nBytes = getVarint32(((const unsigned char *)hdr + idx), typeLen);
-        byte_widths.emplace_back(serialTypeLen(typeLen));
-        idx += nBytes;
-      }
 
-       // Todo: (@suryadev) handle update and delete
-      uint8_t *record_data = (uint8_t *)head->data;
-      if (table != nullptr) {
-        size_t len = byte_widths.size();
-        int32_t widths[len];
-        for (size_t i = 0; i < len; i++) {
-          widths[i] = byte_widths[i];
+      if (head->mode == MEMLOG_HUSTLE_DELETE) {
+         printf("here in delete");
+        table->delete_record(head->rowId);
+
+      } else {
+        u32 hdrLen;
+        // Read header len in the record
+        u32 nBytes = getVarint32((const unsigned char *)head->data, hdrLen);
+        u32 idx = nBytes;
+        const unsigned char *hdr = (const unsigned char *)head->data;
+        std::vector<int32_t> byte_widths;
+        /* read the col width from the record and user serialTypeLen
+            to convert to exact col width */
+        while (idx < hdrLen) {
+          u32 typeLen;
+          nBytes = getVarint32(((const unsigned char *)hdr + idx), typeLen);
+          byte_widths.emplace_back(serialTypeLen(typeLen));
+          idx += nBytes;
         }
-        // Insert record to the arrow table
-        table->insert_record(record_data + hdrLen, widths);
+
+        // Todo: (@suryadev) handle update and delete
+        uint8_t *record_data = (uint8_t *)head->data;
+        if (table != nullptr) {
+          size_t len = byte_widths.size();
+          int32_t widths[len];
+          for (size_t i = 0; i < len; i++) {
+            widths[i] = byte_widths[i];
+          }
+          // Insert record to the arrow table
+          printf("Data: %s\n", record_data);
+          if (head->mode == MEMLOG_HUSTLE_INSERT) {
+            table->insert_record(head->rowId, record_data + hdrLen, widths);
+          } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
+            table->update_record(head->rowId, record_data + hdrLen, widths);
+          }
+        }
       }
 
       head = head->next_record;

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -170,7 +170,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
       tmp_record = head;
 
       if (head->mode == MEMLOG_HUSTLE_DELETE) {
-         printf("here in delete");
+        //printf("here in delete");
         table->delete_record(head->rowId);
 
       } else {
@@ -185,6 +185,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
         while (idx < hdrLen) {
           u32 typeLen;
           nBytes = getVarint32(((const unsigned char *)hdr + idx), typeLen);
+          //printf("type len length: %d\n", typeLen);
           byte_widths.emplace_back(serialTypeLen(typeLen));
           idx += nBytes;
         }
@@ -193,14 +194,17 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
         uint8_t *record_data = (uint8_t *)head->data;
         if (table != nullptr) {
           size_t len = byte_widths.size();
+          //printf("Byte widht length: %d\n", len);
           int32_t widths[len];
           for (size_t i = 0; i < len; i++) {
+            //printf("width: %d\n", byte_widths[i]);
             widths[i] = byte_widths[i];
           }
           // Insert record to the arrow table
-          printf("Data: %s\n", record_data);
+          //printf("Data: %s\n", record_data);
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
-            table->insert_record(head->rowId, record_data + hdrLen, widths);
+           // printf("In Insert\n", record_data);
+            table->insert_record_table(head->rowId, record_data + hdrLen, widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
             table->update_record(head->rowId, record_data + hdrLen, widths);
           }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -173,7 +173,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
       tmp_record = head;
 
       if (head->mode == MEMLOG_HUSTLE_DELETE) {
-        table->delete_record(head->rowId);
+        table->delete_record_table(head->rowId);
       } else {
         u32 hdrLen;
         // Read header len in the record
@@ -202,7 +202,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
             table->insert_record_table(head->rowId, record_data + hdrLen, widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
-            table->update_record(head->rowId, record_data + hdrLen, widths);
+            table->update_record_table(head->rowId, record_data + hdrLen, widths);
           }
         }
       }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -159,7 +159,6 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
     struct DBRecord *head = mem_log->record_list[table_index].head;
     auto search = table_map[DEFAULT_DB_ID].find(table_index);
     if (search == table_map[DEFAULT_DB_ID].end()) {
-       //printf("here in delete -continue");
       table_index++;
       continue;
     }
@@ -187,7 +186,6 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
         while (idx < hdrLen) {
           u32 typeLen;
           nBytes = getVarint32(((const unsigned char *)hdr + idx), typeLen);
-          //printf("type len length: %d\n", typeLen);
           byte_widths.emplace_back(serialTypeLen(typeLen));
           idx += nBytes;
         }
@@ -196,16 +194,12 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
         uint8_t *record_data = (uint8_t *)head->data;
         if (table != nullptr) {
           size_t len = byte_widths.size();
-          //printf("Byte widht length: %d\n", len);
           int32_t widths[len];
           for (size_t i = 0; i < len; i++) {
-            //printf("width: %d\n", byte_widths[i]);
             widths[i] = byte_widths[i];
           }
           // Insert record to the arrow table
-          //printf("Data: %s\n", record_data);
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
-           // printf("In Insert\n", record_data);
             table->insert_record_table(head->rowId, record_data + hdrLen, widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
             table->update_record(head->rowId, record_data + hdrLen, widths);
@@ -217,7 +211,6 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
       if (is_free) {
         uint8_t *record_data = (uint8_t *)tmp_record->data;
         free(record_data);
-        //tmp_record->data = NULL;
         free(tmp_record);
       }
     }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -213,6 +213,9 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
 
       head = head->next_record;
       if (is_free) {
+        uint8_t *record_data = (uint8_t *)tmp_record->data;
+        free(record_data);
+        tmp_record->data = NULL;
         free(tmp_record);
       }
     }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -215,7 +215,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
       if (is_free) {
         uint8_t *record_data = (uint8_t *)tmp_record->data;
         free(record_data);
-        tmp_record->data = NULL;
+        //tmp_record->data = NULL;
         free(tmp_record);
       }
     }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -166,13 +166,15 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
 
     auto table =
         catalog->getTable(table_map[DEFAULT_DB_ID][table_index].c_str());
+    if (table == nullptr) {
+      table_index++;
+      continue;
+    }
     while (head != NULL) {
       tmp_record = head;
 
       if (head->mode == MEMLOG_HUSTLE_DELETE) {
-        //printf("here in delete");
         table->delete_record(head->rowId);
-
       } else {
         u32 hdrLen;
         // Read header len in the record

--- a/src/storage/cmemlog.h
+++ b/src/storage/cmemlog.h
@@ -18,6 +18,10 @@
 extern "C" {
 #endif
 
+#define MEMLOG_HUSTLE_UPDATE 1
+#define MEMLOG_HUSTLE_INSERT 2
+#define MEMLOG_HUSTLE_DELETE 3
+
 #define MEMLOG_INIT_SIZE 100
 #define MEMLOG_OK 0
 #define MEMLOG_ERROR 1
@@ -44,6 +48,8 @@ struct DBRecordList {
 };
 
 struct DBRecord {
+  int mode;
+  int rowId;
   const void *data;
   int nData;
   struct DBRecord *next_record;
@@ -75,7 +81,8 @@ void memlog_add_table_mapping(int db_id, int root_page_id, char *table_name);
  * data - SQLite's data record format with header in the begining
  * nData - the size of the data
  * */
-DBRecord *hustle_memlog_create_record(const void *data, int nData);
+DBRecord *hustle_memlog_create_record(int mode, int rowId, 
+                                      const void *data, int nData);
 
 /**
  * Insert's the record to the memlog and grows the array size, if the table id

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -294,7 +294,7 @@ BlockInfo DBTable::insert_record(uint8_t *record, int32_t *byte_widths) {
   }
 
   int32_t rowNum = block->insert_record(record, byte_widths);
-  std::cout << "rowNum  " << rowNum << std::endl; 
+  //std::cout << "rowNum  " << rowNum << std::endl; 
   num_rows++;
 
   if (block->get_bytes_left() > fixed_record_width) {
@@ -304,13 +304,13 @@ BlockInfo DBTable::insert_record(uint8_t *record, int32_t *byte_widths) {
   return {block->get_id(), rowNum};
 }
 
-void DBTable::insert_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
+void DBTable::insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
   block_map[rowId] = insert_record(record, byte_widths);
-  std::cout << "[INSERT]:  " << rowId << " " << block_map[rowId].rowNum << std::endl;
+  //std::cout << "[INSERT]:  " << rowId << " " << block_map[rowId].rowNum << std::endl;
 }
 
 void DBTable::update_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
-   std::cout << "[UPDATE]:  " << rowId << std::endl;
+  // std::cout << "[UPDATE]:  " << rowId << std::endl;
   this->delete_record(rowId);
   block_map[rowId] = insert_record(record, byte_widths);
 }
@@ -319,17 +319,17 @@ void DBTable::update_record(uint32_t rowId, uint8_t *record, int32_t *byte_width
 void DBTable::delete_record(uint32_t rowId) {
   BlockInfo blockInfo = block_map[rowId];
   std::shared_ptr<Block> block = this->get_block(blockInfo.blockId);
-  std::cout << "block size: " << block->get_num_rows() << std::endl;
-  std::cout << "In delete " << rowId << " " <<blockInfo.rowNum << std::endl;
+  //std::cout << "block size: " << block->get_num_rows() << std::endl;
+  //std::cout << "In delete " << rowId << " " <<blockInfo.rowNum << std::endl;
   block->set_valid(blockInfo.rowNum, false);
-  block->print();
+  //block->print();
   auto updatedBlock = std::make_shared<Block>(blockInfo.blockId, schema, 
                                                           block_capacity);
-  std::cout << "block size - updated1: " << updatedBlock->get_num_rows() << std::endl;
+  //std::cout << "block size - updated1: " << updatedBlock->get_num_rows() << std::endl;
   updatedBlock->insert_records(block_map, block->get_row_id_map(), block->get_valid_column(), block->get_columns());
-  std::cout << "block size - updated: " << updatedBlock->get_num_rows() << std::endl;
+  //std::cout << "block size - updated: " << updatedBlock->get_num_rows() << std::endl;
   blocks[blockInfo.blockId] = updatedBlock;
-  updatedBlock->print();
+  //updatedBlock->print();
   //blocks[blockInfo.blockId] = nullptr;
   if (insert_pool.find(blockInfo.blockId) != insert_pool.end()) {
     insert_pool[blockInfo.blockId] = updatedBlock;

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -299,7 +299,6 @@ BlockInfo DBTable::insert_record(uint8_t *record, int32_t *byte_widths) {
   }
 
   int32_t rowNum = block->insert_record(record, byte_widths);
-  //std::cout << "Insert row num  " << rowNum << std::endl; 
   num_rows++;
 
   if (block->get_bytes_left() > fixed_record_width) {
@@ -311,32 +310,26 @@ BlockInfo DBTable::insert_record(uint8_t *record, int32_t *byte_widths) {
 
 void DBTable::insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
   block_map[rowId] = insert_record(record, byte_widths);
-  //std::cout << "[INSERT]:  " << rowId << " " << block_map[rowId].rowNum << std::endl;
 }
 
 void DBTable::update_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
-  // std::cout << "[UPDATE]:  " << rowId << std::endl;
   this->delete_record(rowId);
   block_map[rowId] = insert_record(record, byte_widths);
 }
 
 
 void DBTable::delete_record(uint32_t rowId) {
-  BlockInfo blockInfo = block_map[rowId];
+  auto block_map_it = block_map.find(rowId);
+  if (block_map_it == block_map.end()) {
+    return;
+  }
+  BlockInfo blockInfo = block_map_it->second;
   std::shared_ptr<Block> block = this->get_block(blockInfo.blockId);
-  std::cout << "block size: " << block->get_num_rows() << std::endl;
-  //std::cout << "In delete " << rowId << " " <<blockInfo.rowNum << std::endl;
   block->set_valid(blockInfo.rowNum, false);
-  //block->print();
-  //std::cout << "Current Block capacity " << block->get_capacity() << " " << block->get_num_rows() << std::endl;
   auto updatedBlock = std::make_shared<Block>(blockInfo.blockId, schema, 
                                                           block->get_capacity());
-  //std::cout << "block size - updated1: " << updatedBlock->get_num_rows() << std::endl;
   updatedBlock->insert_records(block_map, block->get_row_id_map(), block->get_valid_column(), block->get_columns());
-  std::cout << "block size - updated: " << updatedBlock->get_num_rows() << std::endl;
   blocks[blockInfo.blockId] = updatedBlock;
-  //updatedBlock->print();
-  //blocks[blockInfo.blockId] = nullptr;
   if (insert_pool.find(blockInfo.blockId) != insert_pool.end()) {
     insert_pool[blockInfo.blockId] = updatedBlock;
   }

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -330,6 +330,7 @@ void DBTable::delete_record(uint32_t rowId) {
                                                           block->get_capacity());
   updatedBlock->insert_records(block_map, block->get_row_id_map(), block->get_valid_column(), block->get_columns());
   blocks[blockInfo.blockId] = updatedBlock;
+  num_rows--;
   if (insert_pool.find(blockInfo.blockId) != insert_pool.end()) {
     insert_pool[blockInfo.blockId] = updatedBlock;
   }

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -312,13 +312,13 @@ void DBTable::insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte
   block_map[rowId] = insert_record(record, byte_widths);
 }
 
-void DBTable::update_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
-  this->delete_record(rowId);
-  block_map[rowId] = insert_record(record, byte_widths);
+void DBTable::update_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
+  this->delete_record_table(rowId);
+  this->insert_record_table(rowId, record, byte_widths);
 }
 
 
-void DBTable::delete_record(uint32_t rowId) {
+void DBTable::delete_record_table(uint32_t rowId) {
   auto block_map_it = block_map.find(rowId);
   if (block_map_it == block_map.end()) {
     return;

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -106,7 +106,7 @@ class DBTable {
 
   BlockInfo insert_record(int rowId, uint8_t *record, int32_t *byte_widths);
 
-  void insert_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
+  void insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
 
   void update_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
   void delete_record(uint32_t rowId);

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <map>
 #include <utility>
 
 #include "storage/block.h"
@@ -101,8 +102,14 @@ class DBTable {
    * @param byte_widths Byte width of each value to be inserted. Byte widths
    * should be listed in the same order as they appear in the Block's schema.
    */
-  void insert_record(uint8_t *record, int32_t *byte_widths);
+  BlockInfo insert_record(uint8_t *record, int32_t *byte_widths);
 
+  BlockInfo insert_record(int rowId, uint8_t *record, int32_t *byte_widths);
+
+  void insert_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
+
+  void update_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
+  void delete_record(uint32_t rowId);
   /**
    * Insert one or more records into the Table as a vector of ArrayData.
    * This insertion method would be used to insert the results of a query,
@@ -182,6 +189,9 @@ class DBTable {
   // Initialized to BLOCK_SIZE
   int block_capacity;
 
+  // row id to block info
+  std::map<int, BlockInfo> block_map;
+  
   std::unordered_map<int, std::shared_ptr<Block>> blocks;
 
   std::mutex blocks_mutex;

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -104,7 +104,6 @@ class DBTable {
    */
   BlockInfo insert_record(uint8_t *record, int32_t *byte_widths);
 
-  BlockInfo insert_record(int rowId, uint8_t *record, int32_t *byte_widths);
 
   void insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
 

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -109,8 +109,9 @@ class DBTable {
 
   void insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
 
-  void update_record(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
-  void delete_record(uint32_t rowId);
+  void update_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
+  
+  void delete_record_table(uint32_t rowId);
   /**
    * Insert one or more records into the Table as a vector of ArrayData.
    * This insertion method would be used to insert the results of a query,

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -93,6 +93,8 @@ class DBTable {
 
   size_t get_num_blocks() const;
 
+  int get_record_size(int32_t *byte_widths);
+
   /**
    * Insert a record into a block in the insert pool.
    *

--- a/src/storage/tests/block_test.cc
+++ b/src/storage/tests/block_test.cc
@@ -153,7 +153,7 @@ TEST_F(HustleBlockTest, EmptyBlock) {
 
 TEST_F(HustleBlockTest, OneInsertBlock) {
   Block block(0, schema, BLOCK_SIZE);
-  bool result =
+  int row_index =
       block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
 
   valid =
@@ -164,7 +164,7 @@ TEST_F(HustleBlockTest, OneInsertBlock) {
   column4 = std::static_pointer_cast<arrow::Int64Array>(block.get_column(3));
 
   int row = 0;
-  EXPECT_EQ(result, true);
+  EXPECT_EQ(row_index, 0);
   EXPECT_EQ(block.get_num_rows(), 1);
   EXPECT_EQ(valid->Value(row), true);
   EXPECT_EQ(column1->Value(row), 4242);
@@ -239,10 +239,10 @@ TEST_F(HustleBlockTest, FullBlock) {
   }
 
   // This block cannot hold a 9th copy of the first record
-  bool result =
+  int row_index =
       block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
 
-  EXPECT_EQ(result, false);
+  EXPECT_EQ(row_index, -1);
   EXPECT_EQ(block.get_bytes_left(), BLOCK_SIZE - 912);
 }
 

--- a/src/storage/tests/memlog_test.cc
+++ b/src/storage/tests/memlog_test.cc
@@ -33,10 +33,10 @@ class HustleMemLogTest : public testing::Test {
 };
 
 TEST_F(HustleMemLogTest, MemlogTestForInsertion) {
-  DBRecord* record = hustle_memlog_create_record("test", 4);
+  DBRecord* record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 0, "test", 4);
   int status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
-  record = hustle_memlog_create_record("sample", 6);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 1, "sample", 6);
   status = hustle_memlog_insert_record(hustle_memlog, record, 0);
 
   DBRecordList* recordList = hustle_memlog_get_records(hustle_memlog, 0);
@@ -52,17 +52,17 @@ TEST_F(HustleMemLogTest, MemlogTestForInsertion) {
 }
 
 TEST_F(HustleMemLogTest, MemlogTestForMultipleInsertion) {
-  DBRecord* record = hustle_memlog_create_record("test", 4);
+  DBRecord* record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 0, "test", 4);
   int status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
-  record = hustle_memlog_create_record("sample", 6);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 1, "sample", 6);
   status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
 
-  record = hustle_memlog_create_record("test2", 5);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 2, "test2", 5);
   status = hustle_memlog_insert_record(hustle_memlog, record, 1);
   EXPECT_EQ(status, MEMLOG_OK);
-  record = hustle_memlog_create_record("sample2", 7);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 3, "sample2", 7);
   status = hustle_memlog_insert_record(hustle_memlog, record, 1);
   EXPECT_EQ(status, MEMLOG_OK);
 
@@ -85,10 +85,10 @@ TEST_F(HustleMemLogTest, MemlogTestForMultipleInsertion) {
 }
 
 TEST_F(HustleMemLogTest, MemlogTestForClear) {
-  DBRecord* record = hustle_memlog_create_record("test", 4);
+  DBRecord* record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 0, "test", 4);
   int status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
-  record = hustle_memlog_create_record("sample", 6);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 1, "sample", 6);
   status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
   EXPECT_EQ(hustle_memlog->record_list[0].curr_size, 2);
@@ -101,14 +101,14 @@ TEST_F(HustleMemLogTest, MemlogTestForClear) {
 }
 
 TEST_F(HustleMemLogTest, MemlogTestExpansion) {
-  DBRecord* record = hustle_memlog_create_record("test", 4);
+  DBRecord* record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 0, "test", 4);
   EXPECT_EQ(hustle_memlog->total_size, MEMLOG_INIT_SIZE);
   int status =
       hustle_memlog_insert_record(hustle_memlog, record, MEMLOG_INIT_SIZE + 1);
   EXPECT_EQ(status, MEMLOG_OK);
   EXPECT_EQ(hustle_memlog->total_size, 2 * (MEMLOG_INIT_SIZE + 1));
 
-  record = hustle_memlog_create_record("sample", 6);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 1, "sample", 6);
   status =
       hustle_memlog_insert_record(hustle_memlog, record, MEMLOG_INIT_SIZE + 1);
   EXPECT_EQ(status, MEMLOG_OK);
@@ -120,11 +120,11 @@ TEST_F(HustleMemLogTest, MemlogTestExpansion) {
 }
 
 TEST_F(HustleMemLogTest, MemlogTestStatus) {
-  DBRecord* record = hustle_memlog_create_record("test", 4);
+  DBRecord* record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 0, "test", 4);
   int status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
 
-  record = hustle_memlog_create_record("sample", 6);
+  record = hustle_memlog_create_record(MEMLOG_HUSTLE_INSERT, 1, "sample", 6);
   status = hustle_memlog_insert_record(hustle_memlog, record, 0);
   EXPECT_EQ(status, MEMLOG_OK);
 


### PR DESCRIPTION
### Summary
* Support for update operation and delete operation- simple implementation 
 Used a global index table for mapping row id to block id and block offset and also a local index table per block to identify the corresponding row id for the record in the block so that the index table can be updated when the block offset of the record gets changed on deletion. 

Right now, the naive implementation of the update operation is combining delete and insert operation.
For the delete operation, a new block is created by omitting the records that are needed to be deleted in the old block.

* Simple fixes and improved the resolver.
* First version of simple TATP driver to run simple TATP format queries.
* Simple unit tests for the update and delete query support feature.

In the next pull request, will be handling the optimization in the arrow table update like in-place updates and batch update/insert/delete. Also, will integrate txbench for the hustle to run the multithreaded TATP benchmark (actual).