### PR TITLE
In-place update of arrow arrays and Integration of Tatp benchmark module

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,22 @@ ctest --output-on-failure
 
 You can use the following commands to run the ssb benchmark, (before running the below commands make sure you have built the executable from the source files using the steps provided in the previous section).
 
-To generate the ssb benchmark data
+To generate the ssb benchmark data, 
 
 ```
-sh ./scripts/ssb/gen_benchmark_data.sh
+sh ./scripts/ssb/gen_benchmark_data.sh ${SCALE_FACTOR}
 ```
+(Usually scale factor can be 1 or 10).
+
 
 To run the ssb benchmark,
 
 ```
-sh ./scripts/ssb/run_benchmark.sh
+sh ./scripts/ssb/run_benchmark.sh ssb [arrow_aggregate | hash_aggregate]
+```
+
+To run the tatp benchmark,
+
+```
+sh ./scripts/tatp/run_benchmark.sh 
 ```

--- a/scripts/tatp/run_benchmark.sh
+++ b/scripts/tatp/run_benchmark.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cur_dir=`dirname $0`
+src_dir=${cur_dir}/../..
+
+cd ${src_dir}/build/src/txbench/benchmarks/tatp_hustle
+# clean the previous db file
+rm -rf db_directory2
+# run the benchmark
+./tatp_hustle

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,4 +53,4 @@ add_subdirectory(operators)
 add_subdirectory(scheduler)
 add_subdirectory(execution)
 add_subdirectory(benchmark)
-
+add_subdirectory(txbench)

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -49,6 +49,7 @@ HustleDB::HustleDB(std::string DBpath)
   if (!std::filesystem::exists(DBpath)) {
     std::filesystem::create_directories(DBpath);
   }
+  utils::initialize_sqlite3();
   this->addCatalog(SqliteDBPath_, catalog_);
 };
 

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -70,6 +70,10 @@ std::string HustleDB::executeQuery(const std::string &sql) {
   return utils::executeSqliteReturnOutputString(SqliteDBPath_, sql);
 }
 
+bool HustleDB::executeNoOutputQuery(const std::string &sql) {
+  return utils::executeSqliteNoOutput(SqliteDBPath_, sql);
+}
+
 bool HustleDB::dropTable(const std::string &name) {
   return catalog_->dropTable(name);
 }

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -21,7 +21,6 @@
 #include <memory>
 #include <string>
 
-#include "absl/strings/str_cat.h"
 #include "catalog/catalog.h"
 #include "catalog/table_schema.h"
 #include "scheduler/scheduler.h"

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -50,6 +50,8 @@ class HustleDB {
 
   std::string executeQuery(const std::string &sql);
 
+  bool executeNoOutputQuery(const std::string &sql);
+
   std::string getPlan(const std::string &sql);
 
   const std::string getSqliteDBPath() { return SqliteDBPath_; }

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -277,6 +277,7 @@ void TATP::CreateTable() {
 
 void TATP::RunBenchmark() {
   this->RunQuery1();
+  this->RunQuery2();
   this->RunQuery3();
   this->RunQuery4();
   this->RunQuery5();
@@ -312,12 +313,12 @@ void TATP::RunQuery2() {
       "FROM Special_Facility, Call_Forwarding "
       "WHERE "
       "cf_s_id=sf_s_id "
-      "AND cf_sf_type=sf_sf_type "
-      "AND sf_s_id=10 "
+     // "AND cf_sf_type=sf_sf_type "
+      "AND (sf_s_id=10 "
       "AND sf_sf_type=10 "
-      "AND is_active=131321 "
-      "AND start_time <=1000 "
-      "AND end_time > 1000;";
+      "AND is_active=131321 )"
+      "AND (start_time <=1000 "
+      "AND end_time > 1000);";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 2");
   hustle_db->executeQuery(query2);

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -224,7 +224,7 @@ void TATP::CreateTable() {
 
   std::cout << "Subscriber insert" << std::endl;
   std::string query = "BEGIN TRANSACTION; ";
-  for (int i = 9; i < 100000; i++) {
+  for (int i = 9; i < 1000000; i++) {
     query += "INSERT INTO Subscriber VALUES (" + std::to_string(i) + ", 'h" +
              std::to_string(i) +
              "', 131321,"
@@ -240,7 +240,7 @@ void TATP::CreateTable() {
   hustle_db->executeQuery(query);
 
   query = "BEGIN TRANSACTION; ";
-  for (int i = 9; i < 100000; i++) {
+  for (int i = 9; i < 1000000; i++) {
     query += "INSERT INTO Access_Info VALUES (" + std::to_string(i) +
              ", 131321,"
              "131321, 131321,"
@@ -251,7 +251,7 @@ void TATP::CreateTable() {
   std::cout << "access info insert ends" << std::endl;
 
   query = "BEGIN TRANSACTION; ";
-  for (int i = 9; i < 100000; i++) {
+  for (int i = 9; i < 1000000; i++) {
     query += "INSERT INTO Special_Facility VALUES (" + std::to_string(i) +
              ", " + std::to_string(i) +
              ", 131321,"
@@ -263,7 +263,7 @@ void TATP::CreateTable() {
   hustle_db->executeQuery(query);
 
   query = "BEGIN TRANSACTION; ";
-  for (int i = 9; i < 100000; i++) {
+  for (int i = 9; i < 1000000; i++) {
     query += "INSERT INTO Call_Forwarding VALUES (" + std::to_string(i) + ", " +
              std::to_string(i) +
              ", 131,"

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -455,7 +455,7 @@ void TATP::RunQuery7() {
   query7 =
       "SELECT cf_s_id, start_time, end_time "
       "FROM Call_Forwarding "
-      "WHERE cf_s_id=1111111;";
+      "WHERE cf_s_id=11;";
   hustle_db->executeQuery(query7);
 }
 

--- a/src/operators/predicate.h
+++ b/src/operators/predicate.h
@@ -69,6 +69,17 @@ class Node {
 
   // Should only be access if is_leaf() is true
   std::shared_ptr<Predicate> predicate_;
+
+  void print() {
+    if (is_leaf()) {
+      std::cout << predicate_->col_ref_.col_name << " comp:" <<  predicate_->comparator_ <<  " " << 
+      "val" << std::endl;
+      return;
+    } 
+    left_child_->print();
+    std::cout << "CONNECTIVE: " << connective_ << std::endl;
+    right_child_->print();
+  }
 };
 
 /**
@@ -101,6 +112,9 @@ class PredicateTree {
  public:
   explicit PredicateTree(std::shared_ptr<Node> root);
   std::shared_ptr<Node> root_;
+  int table_id_;
+  std::string table_name_;
+
 };
 
 }  // namespace hustle::operators

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -55,6 +55,7 @@ std::shared_ptr<hustle::ExecutionPlan> createPlan(
           std::make_unique<hustle::operators::Select>(
               0, table_ptr, input_result, output_result, predicate_tree);
       select_operators.emplace_back(std::move(select));
+     std::shared_ptr<PredicateTree> pred =  predicate_tree;
     }
     select_result.emplace_back(output_result);
   }
@@ -62,10 +63,7 @@ std::shared_ptr<hustle::ExecutionPlan> createPlan(
   /**
    * Get the join predicates and the previous results to construct
    * the join operators.
-   */
-  std::cout << "Num join pred: " << (*(select_resolver->get_join_predicates())).size() << std::endl;
-  
-
+   */  
   bool is_join_op = true;
   std::shared_ptr<OperatorResult> join_result_out;
   std::unique_ptr<Join> join_op;
@@ -84,8 +82,6 @@ std::shared_ptr<hustle::ExecutionPlan> createPlan(
   bool is_agg_op = true;
   std::shared_ptr<std::vector<AggregateReference>> agg_refs =
       (select_resolver->get_agg_references());
-  std::cout << "Num agg refs: " << (*(agg_refs)).size() << std::endl;
-
   
   std::shared_ptr<OperatorResult> agg_result_out =
       std::make_shared<OperatorResult>();

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -177,7 +177,7 @@ std::shared_ptr<hustle::storage::DBTable> execute(
             plan->getOperatorResult();
         std::shared_ptr<hustle::storage::DBTable> out_table =
             agg_result_out->materialize(plan->getResultColumns());
-        out_table->print();
+        //out_table->print();
         sync_lock.release();
       })));
 

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -177,7 +177,7 @@ std::shared_ptr<hustle::storage::DBTable> execute(
             plan->getOperatorResult();
         std::shared_ptr<hustle::storage::DBTable> out_table =
             agg_result_out->materialize(plan->getResultColumns());
-        //out_table->print();
+        out_table->print();
         sync_lock.release();
       })));
 

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -66,7 +66,6 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
   arrow::compute::CompareOperator comparatorOperator;
   FilterOperator connective;
   std::shared_ptr<PredicateTree> predicate_tree = nullptr;
-
   switch (pExpr->op) {
     case TK_INTEGER:
     case TK_STRING:
@@ -93,8 +92,9 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
                                                FilterOperator::AND);
           predicate_tree = std::make_shared<PredicateTree>(connective_node);
         }
-
-        select_predicates_[leftExpr->pLeft->y.pTab->zName] = predicate_tree;
+        predicate_tree->table_id_ = lpred_tree->table_id_;
+        predicate_tree->table_name_ = lpred_tree->table_name_;
+        select_predicates_[predicate_tree->table_name_] = predicate_tree;
       }
       break;
     }
@@ -109,7 +109,6 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
 
       ColumnReference colRef;
       arrow::Datum datum;
-
       if ((leftExpr != NULL && leftExpr->op == TK_COLUMN) &&
           (rightExpr != NULL &&
            (rightExpr->op == TK_INTEGER || rightExpr->op == TK_STRING))) {
@@ -138,7 +137,8 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
         auto predicate_node = std::make_shared<PredicateNode>(
             std::make_shared<Predicate>(predicate));
         predicate_tree = std::make_shared<PredicateTree>(predicate_node);
-
+        predicate_tree->table_id_ = leftExpr->iTable;
+        predicate_tree->table_name_ = std::string(leftExpr->y.pTab->zName);
         select_predicates_[leftExpr->y.pTab->zName] = predicate_tree;
       }
       break;

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -20,6 +20,7 @@
 
 #include <arrow/api.h>
 #include <map>
+#include <iostream>
 #include "utils/bit_utils.h"
 
 #define BLOCK_SIZE (1 << 20)
@@ -275,6 +276,17 @@ class Block {
   bool insert_records(
       std::vector<std::shared_ptr<arrow::ArrayData>> column_data,
       int32_t offset, int64_t length);
+
+  template <typename field_size>
+  inline void update_value_in_column(int col_num, int row_num, uint8_t *record_value,
+                                   int byte_width) {
+    auto *dest = columns[col_num]->GetMutableValues<field_size>(1, row_num);
+    uint8_t *value = (uint8_t *)calloc(sizeof(field_size), sizeof(uint8_t));
+    std::memcpy(value, utils::reverse_bytes(record_value, byte_width),
+                byte_width);
+    std::memcpy(dest, value, sizeof(field_size));
+    free(value);
+  }
 
   void truncate_buffers();
 

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -201,9 +201,11 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
           }
           // Insert record to the arrow table
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
+            //std::cout << "Insert record " << std::endl;
             table->insert_record_table(head->rowId, record_data + hdrLen,
                                        widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
+            //std::cout << "Update record " << std::endl;
             table->update_record_table(head->rowId, head->nUpdateMetaInfo,
                                        head->updateMetaInfo,
                                        record_data + hdrLen, widths);

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -95,7 +95,8 @@ DBRecord *hustle_memlog_create_record(int mode, int rowId, const void *data,
  * */
 Status hustle_memlog_insert_record(HustleMemLog *mem_log, DBRecord *record,
                                    int table_id) {
-  if (mem_log == NULL || (record == NULL && record->mode != MEMLOG_HUSTLE_DELETE)) {
+  if (mem_log == NULL ||
+      (record == NULL && record->mode != MEMLOG_HUSTLE_DELETE)) {
     return MEMLOG_ERROR;
   }
   if (table_id >= mem_log->total_size) {
@@ -200,9 +201,12 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
           }
           // Insert record to the arrow table
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
-            table->insert_record_table(head->rowId, record_data + hdrLen, widths);
+            table->insert_record_table(head->rowId, record_data + hdrLen,
+                                       widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
-            table->update_record_table(head->rowId, record_data + hdrLen, widths);
+            table->update_record_table(head->rowId, head->nUpdateMetaInfo,
+                                       head->updateMetaInfo,
+                                       record_data + hdrLen, widths);
           }
         }
       }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -250,9 +250,6 @@ Status hustle_memlog_clear(HustleMemLog *mem_log) {
     while (head != NULL) {
       tmp_record = head;
       head = head->next_record;
-      if (tmp_record->updateMetaInfo != NULL) {
-        free(tmp_record->updateMetaInfo);
-      }
       uint8_t *record_data = (uint8_t *)tmp_record->data;
       free(record_data);
       free(tmp_record);

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -216,8 +216,9 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
 
       head = head->next_record;
       if (is_free) {
-        if (tmp_record->updateMetaInfo != NULL) {
-          free(tmp_record->updateMetaInfo);
+        if (tmp_record->mode == MEMLOG_HUSTLE_UPDATE) {
+          UpdateMetaInfo* updateMetaInfo = tmp_record->updateMetaInfo;
+          free(updateMetaInfo);
         }
         uint8_t *record_data = (uint8_t *)tmp_record->data;
         free(record_data);

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -79,7 +79,8 @@ DBRecord *hustle_memlog_create_record(int mode, int rowId, const void *data,
   record->rowId = rowId;
   record->data = (const void *)malloc(nData);
   memcpy((void *)record->data, data, nData);
-  // record->data = data;
+  record->nUpdateMetaInfo = 0;
+  record->updateMetaInfo = NULL;
   record->nData = nData;
   record->next_record = NULL;
   return record;
@@ -215,6 +216,9 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
 
       head = head->next_record;
       if (is_free) {
+        if (tmp_record->updateMetaInfo != NULL) {
+          free(tmp_record->updateMetaInfo);
+        }
         uint8_t *record_data = (uint8_t *)tmp_record->data;
         free(record_data);
         free(tmp_record);
@@ -245,6 +249,11 @@ Status hustle_memlog_clear(HustleMemLog *mem_log) {
     while (head != NULL) {
       tmp_record = head;
       head = head->next_record;
+      if (tmp_record->updateMetaInfo != NULL) {
+        free(tmp_record->updateMetaInfo);
+      }
+      uint8_t *record_data = (uint8_t *)tmp_record->data;
+      free(record_data);
       free(tmp_record);
     }
     mem_log->record_list[table_index].head = NULL;

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -218,7 +218,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
       if (is_free) {
         if (tmp_record->mode == MEMLOG_HUSTLE_UPDATE) {
           UpdateMetaInfo* updateMetaInfo = tmp_record->updateMetaInfo;
-          free(updateMetaInfo);
+          //free(updateMetaInfo);
         }
         uint8_t *record_data = (uint8_t *)tmp_record->data;
         free(record_data);

--- a/src/storage/cmemlog.h
+++ b/src/storage/cmemlog.h
@@ -14,6 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+#ifndef HUSTLE_MEMLOG_H
+#define HUSTLE_MEMLOG_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,14 +51,22 @@ struct DBRecordList {
   int curr_size;
 };
 
+struct UpdateMetaInfo {
+  int tableId;
+  int colNum;
+};
+
 struct DBRecord {
   int mode;
   int rowId;
   const void *data;
   int nData;
+  int nUpdateMetaInfo;
+  struct UpdateMetaInfo* updateMetaInfo;
   struct DBRecord *next_record;
 };
 
+typedef struct UpdateMetaInfo UpdateMetaInfo;
 typedef int Status;
 typedef struct DBRecord DBRecord;
 typedef struct DBRecordList DBRecordList;
@@ -131,3 +143,5 @@ Status hustle_memlog_free(HustleMemLog *mem_log);
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // HUSTLE_MEMLOG_H

--- a/src/storage/cmemlog.h
+++ b/src/storage/cmemlog.h
@@ -59,8 +59,8 @@ struct UpdateMetaInfo {
 struct DBRecord {
   int mode;
   int rowId;
-  const void *data;
   int nData;
+  const void *data;
   int nUpdateMetaInfo;
   struct UpdateMetaInfo* updateMetaInfo;
   struct DBRecord *next_record;

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -18,13 +18,14 @@
 #ifndef HUSTLE_OFFLINE_TABLE_H
 #define HUSTLE_OFFLINE_TABLE_H
 
+#include <map>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
-#include <map>
 #include <utility>
 
+#include "cmemlog.h"
 #include "storage/block.h"
 
 namespace hustle::storage {
@@ -106,11 +107,13 @@ class DBTable {
    */
   BlockInfo insert_record(uint8_t *record, int32_t *byte_widths);
 
+  void insert_record_table(uint32_t rowId, uint8_t *record,
+                           int32_t *byte_widths);
 
-  void insert_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
+  void update_record_table(uint32_t rowId, int nUpdateMetaInfo,
+                           UpdateMetaInfo *updateMetaInfo, uint8_t *record,
+                           int32_t *byte_widths);
 
-  void update_record_table(uint32_t rowId, uint8_t *record, int32_t *byte_widths);
-  
   void delete_record_table(uint32_t rowId);
   /**
    * Insert one or more records into the Table as a vector of ArrayData.
@@ -193,7 +196,7 @@ class DBTable {
 
   // row id to block info
   std::map<int, BlockInfo> block_map;
-  
+
   std::unordered_map<int, std::shared_ptr<Block>> blocks;
 
   std::mutex blocks_mutex;

--- a/src/txbench/CMakeLists.txt
+++ b/src/txbench/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.15)
+project(txbench)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Threads REQUIRED)
+
+add_subdirectory(benchmarks)
+
+add_library(
+        txbench
+        benchmark.h benchmark.cpp
+        loader.h
+        worker.h
+        random_generator.h random_generator.cpp
+)
+
+target_include_directories(
+        txbench
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}
+)
+
+target_link_libraries(
+        txbench
+        Threads::Threads
+        hustle_src_catalog
+        hustle_src_storage
+        hustle_src_operators
+        hustle_src_scheduler_Scheduler
+        hustle_src_optimizer_ExecutionPlan
+        hustle_src_utils_EventProfiler
+        hustle_src_utils_skew
+        hustle_src_utils_Config
+)

--- a/src/txbench/README.md
+++ b/src/txbench/README.md
@@ -1,0 +1,34 @@
+# txbench
+A small benchmarking library for OLTP database systems
+
+## Overview
+The aim of txbench is to provide extensible benchmarking utilities for OLTP database systems. It is particularly useful for testing systems in the early stages of development that may not yet have a well-defined client interface such as a SQL interpreter. Instead, systems must simply implement C++ functions that represent the workload's procedures.
+
+## Adding a new target system
+The steps to add a new target system are the following.
+1. Implement the benchmark loader by extending the `Loader` class in `loader.h`.
+2. Implement the system connector by extending the desired benchmark's connector. For example, a new TATP connector would extend the `TATPConnector` class in `tatp_connector.h`.
+3. Implement the benchmark configuration by extending the `Benchmark` class in `benchmark.h`.
+4. Write the executable to run the benchmark on the new target system.
+
+## Currently supported benchmarks and target systems
+Currently, txbench only supports TATP on MySQL. More benchmarks and systems will be added in the future.
+
+## System-specific instructions
+
+### MySQL
+To run bencharks on MySQL, the MySQL Connector/C++ version 8.0.19 needs to be installed. CMake looks in a specific place to find the headers and object file of this library. This will be made more flexible in the future. The following commands may be run to install Connector/C++.
+```bash
+wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn8-2_8.0.19-1ubuntu18.04_amd64.deb
+wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn7_8.0.19-1ubuntu18.04_amd64.deb
+wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_8.0.19-1ubuntu18.04_amd64.deb
+sudo dpkg -i libmysqlcppconn8-2_8.0.19-1ubuntu18.04_amd64.deb
+sudo dpkg -i libmysqlcppconn7_8.0.19-1ubuntu18.04_amd64.deb
+sudo dpkg -i libmysqlcppconn-dev_8.0.19-1ubuntu18.04_amd64.deb
+```
+
+MySQL needs to have a user named 'txbench' with the necessary permissions. The following commands may be run in the MySQL shell to create this user.
+```SQL
+CREATE USER 'txbench'@'localhost';
+GRANT ALL ON * . * TO 'txbench'@'localhost';
+```

--- a/src/txbench/benchmark.cpp
+++ b/src/txbench/benchmark.cpp
@@ -1,0 +1,54 @@
+#include "benchmark.h"
+#include "loader.h"
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+txbench::Benchmark::Benchmark(int n_workers, int warmup_duration,
+                              int measurement_duration)
+    : n_workers_(n_workers), warmup_duration_(warmup_duration),
+      measurement_duration_(measurement_duration) {}
+
+double txbench::Benchmark::run() {
+  std::unique_ptr<txbench::Loader> loader = make_loader();
+  loader->load();
+
+  std::vector<std::unique_ptr<txbench::Worker>> workers;
+  workers.reserve(n_workers_);
+
+  for (int i = 0; i < n_workers_; ++i) {
+    std::unique_ptr<txbench::Worker> worker = make_worker();
+    workers.emplace_back(std::move(worker));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(n_workers_);
+
+  std::atomic_bool terminate = false;
+  std::atomic_int transaction_count = 0;
+
+  for (const auto &worker : workers) {
+    threads.emplace_back([&] { worker->run(terminate, transaction_count); });
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(warmup_duration_));
+
+  int warmup_transaction_count = transaction_count;
+
+  std::this_thread::sleep_for(std::chrono::seconds(measurement_duration_));
+
+  int total_transaction_count = transaction_count;
+
+  terminate = true;
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  int measurement_transaction_count =
+      total_transaction_count - warmup_transaction_count;
+  double tps = (double)measurement_transaction_count / measurement_duration_;
+  return tps;
+}

--- a/src/txbench/benchmark.cpp
+++ b/src/txbench/benchmark.cpp
@@ -30,17 +30,18 @@ double txbench::Benchmark::run() {
   std::atomic_bool terminate = false;
   std::atomic_int transaction_count = 0;
 
-  std::atomic<double>	 time_1 = 0.0, time_2 = 0.0, time_3 = 0.0, time_4 = 0.0, time_5 = 0.0, time_6 = 0.0, time_7 = 0.0;
+  std::vector<std::unique_ptr<std::atomic<double>>> query_time;
+  query_time.resize(NUM_QUERIES);  
+  for (auto& query_time_ptr : query_time) {
+    query_time_ptr = std::make_unique<std::atomic<double>>(0.0);   // init atomic ints to 0.0
+  }
+  int worker_count = 0;
   for (const auto &worker : workers) {
     threads.emplace_back([&] { 
       worker->run(terminate, transaction_count); 
-      time_1 = time_1 +  worker->getTime1();
-      time_2 = time_2 +  worker->getTime2();
-      time_3 = time_3 +  worker->getTime3();
-      time_4 = time_4 +  worker->getTime4();
-      time_5 = time_5 +  worker->getTime5();
-      time_6 = time_6 +  worker->getTime6();
-      time_7 = time_7 +  worker->getTime7();
+      for (int i = 0; i < NUM_QUERIES; i++) {
+        *query_time[i] = *query_time[i] + worker->getTime(i);
+      }
     });
   }
   
@@ -57,13 +58,9 @@ double txbench::Benchmark::run() {
     thread.join();
   }
 
-  std::cout << "Query 1 Time: " << 1.0 * time_1 / n_workers_ << std::endl;
-  std::cout << "Query 2 Time: " << 1.0 * time_2 / n_workers_ << std::endl;
-  std::cout << "Query 3 Time: " << 1.0 * time_3 / n_workers_ << std::endl;
-  std::cout << "Query 4 Time: " << 1.0 * time_4 / n_workers_ << std::endl;
-  std::cout << "Query 5 Time: " << 1.0 * time_5 / n_workers_ << std::endl;
-  std::cout << "Query 6 Time: " << 1.0 * time_6 / n_workers_ << std::endl;
-  std::cout << "Query 7 Time: " << 1.0 * time_7 / n_workers_ << std::endl;
+  for (int i = 0; i < NUM_QUERIES; i++) {
+     std::cout << "Query "<<i<<" Time: " << 1.0 * (*query_time[i]) / n_workers_ << std::endl;
+  }
   int measurement_transaction_count =
       total_transaction_count - warmup_transaction_count;
   double tps = (double)measurement_transaction_count / measurement_duration_;

--- a/src/txbench/benchmark.cpp
+++ b/src/txbench/benchmark.cpp
@@ -30,10 +30,20 @@ double txbench::Benchmark::run() {
   std::atomic_bool terminate = false;
   std::atomic_int transaction_count = 0;
 
+  std::atomic<double>	 time_1 = 0.0, time_2 = 0.0, time_3 = 0.0, time_4 = 0.0, time_5 = 0.0, time_6 = 0.0, time_7 = 0.0;
   for (const auto &worker : workers) {
-    threads.emplace_back([&] { worker->run(terminate, transaction_count); });
+    threads.emplace_back([&] { 
+      worker->run(terminate, transaction_count); 
+      time_1 = time_1 +  worker->getTime1();
+      time_2 = time_2 +  worker->getTime2();
+      time_3 = time_3 +  worker->getTime3();
+      time_4 = time_4 +  worker->getTime4();
+      time_5 = time_5 +  worker->getTime5();
+      time_6 = time_6 +  worker->getTime6();
+      time_7 = time_7 +  worker->getTime7();
+    });
   }
-
+  
   std::this_thread::sleep_for(std::chrono::seconds(warmup_duration_));
 
   int warmup_transaction_count = transaction_count;
@@ -47,6 +57,13 @@ double txbench::Benchmark::run() {
     thread.join();
   }
 
+  std::cout << "Query 1 Time: " << 1.0 * time_1 / n_workers_ << std::endl;
+  std::cout << "Query 2 Time: " << 1.0 * time_2 / n_workers_ << std::endl;
+  std::cout << "Query 3 Time: " << 1.0 * time_3 / n_workers_ << std::endl;
+  std::cout << "Query 4 Time: " << 1.0 * time_4 / n_workers_ << std::endl;
+  std::cout << "Query 5 Time: " << 1.0 * time_5 / n_workers_ << std::endl;
+  std::cout << "Query 6 Time: " << 1.0 * time_6 / n_workers_ << std::endl;
+  std::cout << "Query 7 Time: " << 1.0 * time_7 / n_workers_ << std::endl;
   int measurement_transaction_count =
       total_transaction_count - warmup_transaction_count;
   double tps = (double)measurement_transaction_count / measurement_duration_;

--- a/src/txbench/benchmark.h
+++ b/src/txbench/benchmark.h
@@ -1,0 +1,32 @@
+#ifndef TXBENCH_BENCHMARKS_BENCHMARK_H_
+#define TXBENCH_BENCHMARKS_BENCHMARK_H_
+
+#include "loader.h"
+#include "worker.h"
+#include <memory>
+#include <vector>
+
+namespace txbench {
+
+class Benchmark {
+public:
+  Benchmark(int n_workers, int warmup_duration, int measurement_duration);
+
+  double run();
+
+protected:
+  virtual std::unique_ptr<txbench::Loader> make_loader() = 0;
+
+  virtual std::unique_ptr<txbench::Worker> make_worker() = 0;
+
+private:
+  int n_workers_;
+
+  int warmup_duration_;
+
+  int measurement_duration_;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH_BENCHMARKS_BENCHMARK_H_

--- a/src/txbench/benchmark.h
+++ b/src/txbench/benchmark.h
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+#define NUM_QUERIES 7
+
 namespace txbench {
 
 class Benchmark {

--- a/src/txbench/benchmarks/CMakeLists.txt
+++ b/src/txbench/benchmarks/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(tatp)
+add_subdirectory(tatp_hustle)

--- a/src/txbench/benchmarks/tatp/CMakeLists.txt
+++ b/src/txbench/benchmarks/tatp/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(
+        tatp
+        tatp_connector.h
+        tatp_worker.h tatp_worker.cpp
+        tatp_util.h tatp_util.cpp
+)
+
+target_include_directories(
+        tatp
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}
+)
+
+target_link_libraries(
+        tatp
+        txbench
+)

--- a/src/txbench/benchmarks/tatp/tatp_connector.h
+++ b/src/txbench/benchmarks/tatp/tatp_connector.h
@@ -1,0 +1,41 @@
+#ifndef TXBENCH__TATP_CONNECTOR_H
+#define TXBENCH__TATP_CONNECTOR_H
+
+#include <array>
+#include <string>
+
+namespace txbench {
+
+class TATPConnector {
+public:
+  virtual ~TATPConnector() = default;
+
+  virtual void getSubscriberData(int s_id, std::string *sub_nbr,
+                                 std::array<bool, 10> &bit,
+                                 std::array<int, 10> &hex,
+                                 std::array<int, 10> &byte2, int *msc_location,
+                                 int *vlr_location) = 0;
+
+  virtual void getNewDestination(int s_id, int sf_type, int start_time,
+                                 int end_time, std::string *numberx) = 0;
+
+  virtual void getAccessData(int s_id, int ai_type, int *data1, int *data2,
+                             std::string *data3, std::string *data4) = 0;
+
+  virtual void updateSubscriberData(int s_id, bool bit_1, int sf_type,
+                                    int data_a) = 0;
+
+  virtual void updateLocation(const std::string &sub_nbr, int vlr_location) = 0;
+
+  virtual void insertCallForwarding(const std::string &sub_nbr, int sf_type,
+                                    int start_time, int end_time,
+                                    const std::string &numberx) = 0;
+
+  virtual void deleteCallForwarding(const std::string &sub_nbr, int sf_type,
+                                    int start_time) = 0;
+
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__TATP_CONNECTOR_H

--- a/src/txbench/benchmarks/tatp/tatp_connector.h
+++ b/src/txbench/benchmarks/tatp/tatp_connector.h
@@ -4,6 +4,8 @@
 #include <array>
 #include <string>
 
+#define NUM_QUERIES 7
+
 namespace txbench {
 
 class TATPConnector {

--- a/src/txbench/benchmarks/tatp/tatp_connector.h
+++ b/src/txbench/benchmarks/tatp/tatp_connector.h
@@ -10,28 +10,28 @@ class TATPConnector {
 public:
   virtual ~TATPConnector() = default;
 
-  virtual void getSubscriberData(int s_id, std::string *sub_nbr,
+  virtual double getSubscriberData(int s_id, std::string *sub_nbr,
                                  std::array<bool, 10> &bit,
                                  std::array<int, 10> &hex,
                                  std::array<int, 10> &byte2, int *msc_location,
                                  int *vlr_location) = 0;
 
-  virtual void getNewDestination(int s_id, int sf_type, int start_time,
+  virtual double getNewDestination(int s_id, int sf_type, int start_time,
                                  int end_time, std::string *numberx) = 0;
 
-  virtual void getAccessData(int s_id, int ai_type, int *data1, int *data2,
+  virtual double getAccessData(int s_id, int ai_type, int *data1, int *data2,
                              std::string *data3, std::string *data4) = 0;
 
-  virtual void updateSubscriberData(int s_id, bool bit_1, int sf_type,
+  virtual double updateSubscriberData(int s_id, bool bit_1, int sf_type,
                                     int data_a) = 0;
 
-  virtual void updateLocation(const std::string &sub_nbr, int vlr_location) = 0;
+  virtual double updateLocation(const std::string &sub_nbr, int vlr_location) = 0;
 
-  virtual void insertCallForwarding(const std::string &sub_nbr, int sf_type,
+  virtual double insertCallForwarding(const std::string &sub_nbr, int sf_type,
                                     int start_time, int end_time,
                                     const std::string &numberx) = 0;
 
-  virtual void deleteCallForwarding(const std::string &sub_nbr, int sf_type,
+  virtual double deleteCallForwarding(const std::string &sub_nbr, int sf_type,
                                     int start_time) = 0;
 
 };

--- a/src/txbench/benchmarks/tatp/tatp_util.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_util.cpp
@@ -1,0 +1,20 @@
+#include "tatp_util.h"
+
+#include <algorithm>
+#include <cassert>
+
+std::string txbench::leading_zero_pad(int length, const std::string &s) {
+  assert(length >= s.length());
+  return std::string(length - s.length(), '0') + s;
+}
+
+std::string txbench::uppercase_string(int length, RandomGenerator &rg) {
+  static std::string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  static std::uniform_int_distribution<int> dis(0, chars.size() - 1);
+
+  std::string s(length, 0);
+  std::generate(s.begin(), s.end(),
+                [&] { return chars[rg.random_int(0, chars.size() - 1)]; });
+
+  return s;
+}

--- a/src/txbench/benchmarks/tatp/tatp_util.h
+++ b/src/txbench/benchmarks/tatp/tatp_util.h
@@ -1,0 +1,15 @@
+#ifndef TXBENCH_BENCHMARKS_TATP_TATP_UTIL_H_
+#define TXBENCH_BENCHMARKS_TATP_TATP_UTIL_H_
+
+#include "txbench/random_generator.h"
+#include <string>
+
+namespace txbench {
+
+std::string leading_zero_pad(int length, const std::string &s);
+
+std::string uppercase_string(int length, RandomGenerator &rg);
+
+}
+
+#endif // TXBENCH_BENCHMARKS_TATP_TATP_UTIL_H_

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -123,11 +123,7 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
     }
     w_trans_count++;
     commit_count++;
-    if (w_trans_count == 1000) {
-      break;
-    }
   }
- 
   this->print(w_trans_count);
 }
 

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -38,8 +38,8 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int start_time = start_times_possible[rg_.random_int(0, 2)];
       int end_time = rg_.random_int(1, 24);
       std::string numberx;
-      //connector_->getNewDestination(s_id, sf_type, start_time, end_time,
-      //                              &numberx);
+      connector_->getNewDestination(s_id, sf_type, start_time, end_time,
+                                    &numberx);
 
     } else if (transaction_type < 80) {
       // GET_ACCESS_DATA

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -123,7 +123,11 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
     }
     w_trans_count++;
     commit_count++;
+    if (w_trans_count == 1000) {
+      break;
+    }
   }
+ 
   this->print(w_trans_count);
 }
 

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -9,7 +9,17 @@ txbench::TATPWorker::TATPWorker(int n_rows,
     : n_rows_(n_rows),
       a_val_(n_rows <= 1000000 ? 65535
                                : n_rows <= 10000000 ? 1048575 : 2097151),
-      connector_(std::move(connector)) {}
+      connector_(std::move(connector)) {
+        time_1_ = 0;
+        time_2_ = 0;
+        time_3_ = 0;
+        time_4_ = 0;
+        time_5_ = 0;
+        time_6_ = 0;
+        time_7_ = 0;
+        w_trans_count = 0;
+      }
+
 
 void txbench::TATPWorker::run(std::atomic_bool &terminate,
                               std::atomic_int &commit_count) {
@@ -27,7 +37,7 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       std::array<int, 10> hex{};
       std::array<int, 10> byte2{};
       int msc_location, vlr_location;
-      connector_->getSubscriberData(s_id, &sub_nbr, bit, hex, byte2,
+      time_1_ += connector_->getSubscriberData(s_id, &sub_nbr, bit, hex, byte2,
                                     &msc_location, &vlr_location);
 
     } else if (transaction_type < 45) {
@@ -38,7 +48,7 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int start_time = start_times_possible[rg_.random_int(0, 2)];
       int end_time = rg_.random_int(1, 24);
       std::string numberx;
-      connector_->getNewDestination(s_id, sf_type, start_time, end_time,
+      time_2_ += connector_->getNewDestination(s_id, sf_type, start_time, end_time,
                                     &numberx);
 
     } else if (transaction_type < 80) {
@@ -47,7 +57,7 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int ai_type = rg_.random_int(1, 4);
       int data1, data2;
       std::string data3, data4;
-      connector_->getAccessData(s_id, ai_type, &data1, &data2, &data3, &data4);
+      time_3_ += connector_->getAccessData(s_id, ai_type, &data1, &data2, &data3, &data4);
 
     } else if (transaction_type < 82) {
       // UPDATE_SUBSCRIBER_DATA
@@ -55,14 +65,14 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       bool bit_1 = rg_.random_bool();
       int sf_type = rg_.random_int(1, 4);
       int data_a = rg_.random_int(0, 255);
-      connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
+      time_4_ += connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
 
     } else if (transaction_type < 96) {
       // UPDATE_LOCATION
       // Probability: 14%
       std::string sub_nbr = leading_zero_pad(15, std::to_string(s_id));
       int vlr_location = rg_.random_int(INT_MIN, INT_MAX);
-      connector_->updateLocation(sub_nbr, vlr_location);
+      time_5_ += connector_->updateLocation(sub_nbr, vlr_location);
 
     } else if (transaction_type < 98) {
       // INSERT_CALL_FORWARDING
@@ -74,7 +84,7 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int end_time = rg_.random_int(1, 24);
       std::string numberx =
           leading_zero_pad(15, std::to_string(rg_.random_int(1, n_rows_)));
-      connector_->insertCallForwarding(sub_nbr, sf_type, start_time, end_time,
+      time_6_ += connector_->insertCallForwarding(sub_nbr, sf_type, start_time, end_time,
                                        numberx);
 
     } else {
@@ -84,9 +94,23 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int sf_type = rg_.random_int(1, 4);
       int start_times_possible[] = {0, 8, 16};
       int start_time = start_times_possible[rg_.random_int(0, 2)];
-      connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
+      time_7_ += connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
     }
-
+    w_trans_count++;
     commit_count++;
   }
+  this->print(w_trans_count);
+}
+
+
+void txbench::TATPWorker::print(int commit_count) {
+    std::cout << "Worker time " << std::endl; 
+    std::cout << "Time 1 : " << 1.0 * (time_1_*1.0/commit_count) << std::endl;
+    std::cout << "Time 2 : " << 1.0 * (time_2_*1.0/commit_count) << std::endl;
+    std::cout << "Time 3 : " << 1.0 * (time_3_*1.0/commit_count) << std::endl;
+    std::cout << "Time 4 : " << 1.0 * (time_4_*1.0/commit_count) << std::endl;
+    std::cout << "Time 5 : " << 1.0 * (time_5_*1.0/commit_count) << std::endl;
+    std::cout << "Time 6 : " << 1.0 * (time_6_*1.0/commit_count) << std::endl;
+    std::cout << "Time 7 : " << 1.0 * (time_7_*1.0/commit_count)  << std::endl;
+    std::cout << "transaction count: " << w_trans_count << std::endl;
 }

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -18,6 +18,7 @@ txbench::TATPWorker::TATPWorker(int n_rows,
         time_6_ = 0;
         time_7_ = 0;
         w_trans_count = 0;
+        s_trans_count = 0;
       }
 
 
@@ -37,9 +38,12 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       std::array<int, 10> hex{};
       std::array<int, 10> byte2{};
       int msc_location, vlr_location;
-      time_1_ += connector_->getSubscriberData(s_id, &sub_nbr, bit, hex, byte2,
+      double time = connector_->getSubscriberData(s_id, &sub_nbr, bit, hex, byte2,
                                     &msc_location, &vlr_location);
-
+      if (time != -1) {
+       time_1_ += time;
+       s_trans_count++; 
+      }
     } else if (transaction_type < 45) {
       // GET_NEW_DESTINATION
       // Probability: 10%
@@ -48,16 +52,23 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int start_time = start_times_possible[rg_.random_int(0, 2)];
       int end_time = rg_.random_int(1, 24);
       std::string numberx;
-      time_2_ += connector_->getNewDestination(s_id, sf_type, start_time, end_time,
+      double time = connector_->getNewDestination(s_id, sf_type, start_time, end_time,
                                     &numberx);
-
+      if (time != -1) {
+        time_2_ += time;
+        s_trans_count++;
+      }
     } else if (transaction_type < 80) {
       // GET_ACCESS_DATA
       // Probability: 35%
       int ai_type = rg_.random_int(1, 4);
       int data1, data2;
       std::string data3, data4;
-      time_3_ += connector_->getAccessData(s_id, ai_type, &data1, &data2, &data3, &data4);
+      double time = connector_->getAccessData(s_id, ai_type, &data1, &data2, &data3, &data4);
+      if (time != -1) {
+        time_3_ += time;
+        s_trans_count++;
+      }
 
     } else if (transaction_type < 82) {
       // UPDATE_SUBSCRIBER_DATA
@@ -65,15 +76,23 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       bool bit_1 = rg_.random_bool();
       int sf_type = rg_.random_int(1, 4);
       int data_a = rg_.random_int(0, 255);
-      time_4_ += connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
+      double time = connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
 
+      if (time != -1) {
+        time_4_ += time;
+        s_trans_count++;
+      }
     } else if (transaction_type < 96) {
       // UPDATE_LOCATION
       // Probability: 14%
       std::string sub_nbr = leading_zero_pad(15, std::to_string(s_id));
       int vlr_location = rg_.random_int(INT_MIN, INT_MAX);
-      time_5_ += connector_->updateLocation(sub_nbr, vlr_location);
+      double time = connector_->updateLocation(sub_nbr, vlr_location);
 
+      if (time != -1) {
+        time_5_ += time;
+        s_trans_count++;
+      }
     } else if (transaction_type < 98) {
       // INSERT_CALL_FORWARDING
       // Probability: 2%
@@ -84,9 +103,12 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int end_time = rg_.random_int(1, 24);
       std::string numberx =
           leading_zero_pad(15, std::to_string(rg_.random_int(1, n_rows_)));
-      time_6_ += connector_->insertCallForwarding(sub_nbr, sf_type, start_time, end_time,
+      double time = connector_->insertCallForwarding(sub_nbr, sf_type, start_time, end_time,
                                        numberx);
-
+      if (time != -1) {
+        time_6_ += time;
+        s_trans_count++;
+      }
     } else {
       // DELETE_CALL_FORWARDING
       // Probability: 2%
@@ -94,7 +116,12 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int sf_type = rg_.random_int(1, 4);
       int start_times_possible[] = {0, 8, 16};
       int start_time = start_times_possible[rg_.random_int(0, 2)];
-      time_7_ += connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
+      double time = connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
+
+      if (time != -1) {
+        time_7_ += time;
+        s_trans_count++;
+      }
     }
     w_trans_count++;
     commit_count++;
@@ -105,12 +132,12 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
 
 void txbench::TATPWorker::print(int commit_count) {
     std::cout << "Worker time " << std::endl; 
-    std::cout << "Time 1 : " << 1.0 * (time_1_*1.0/commit_count) << std::endl;
-    std::cout << "Time 2 : " << 1.0 * (time_2_*1.0/commit_count) << std::endl;
-    std::cout << "Time 3 : " << 1.0 * (time_3_*1.0/commit_count) << std::endl;
-    std::cout << "Time 4 : " << 1.0 * (time_4_*1.0/commit_count) << std::endl;
-    std::cout << "Time 5 : " << 1.0 * (time_5_*1.0/commit_count) << std::endl;
-    std::cout << "Time 6 : " << 1.0 * (time_6_*1.0/commit_count) << std::endl;
-    std::cout << "Time 7 : " << 1.0 * (time_7_*1.0/commit_count)  << std::endl;
-    std::cout << "transaction count: " << w_trans_count << std::endl;
+    std::cout << "Time 1 : " << 1.0 * (time_1_*1.0/s_trans_count) << std::endl;
+    std::cout << "Time 2 : " << 1.0 * (time_2_*1.0/s_trans_count) << std::endl;
+    std::cout << "Time 3 : " << 1.0 * (time_3_*1.0/s_trans_count) << std::endl;
+    std::cout << "Time 4 : " << 1.0 * (time_4_*1.0/s_trans_count) << std::endl;
+    std::cout << "Time 5 : " << 1.0 * (time_5_*1.0/s_trans_count) << std::endl;
+    std::cout << "Time 6 : " << 1.0 * (time_6_*1.0/s_trans_count) << std::endl;
+    std::cout << "Time 7 : " << 1.0 * (time_7_*1.0/s_trans_count)  << std::endl;
+    std::cout << "transaction count: " << w_trans_count << " successful transaction count: " << s_trans_count << std::endl;
 }

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -1,8 +1,10 @@
 #include "tatp_worker.h"
-#include "tatp_util.h"
+
 #include <climits>
-#include <memory>
 #include <iostream>
+#include <memory>
+
+#include "tatp_util.h"
 
 txbench::TATPWorker::TATPWorker(int n_rows,
                                 std::unique_ptr<TATPConnector> connector)
@@ -10,17 +12,9 @@ txbench::TATPWorker::TATPWorker(int n_rows,
       a_val_(n_rows <= 1000000 ? 65535
                                : n_rows <= 10000000 ? 1048575 : 2097151),
       connector_(std::move(connector)) {
-        time_1_ = 0;
-        time_2_ = 0;
-        time_3_ = 0;
-        time_4_ = 0;
-        time_5_ = 0;
-        time_6_ = 0;
-        time_7_ = 0;
-        w_trans_count = 0;
-        s_trans_count = 0;
-      }
-
+  query_time_ = (double *)calloc(NUM_QUERIES, sizeof(double));
+  s_trans_count_ = (int *)calloc(NUM_QUERIES, sizeof(int));
+}
 
 void txbench::TATPWorker::run(std::atomic_bool &terminate,
                               std::atomic_int &commit_count) {
@@ -29,7 +23,7 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
         (rg_.random_int(0, a_val_) | rg_.random_int(1, n_rows_)) % n_rows_ + 1;
 
     int transaction_type = rg_.random_int(0, 99);
-    //std::cout << "Query executing " << transaction_type << std::endl;
+    // std::cout << "Query executing " << transaction_type << std::endl;
     if (transaction_type < 35) {
       // GET_SUBSCRIBER_DATA
       // Probability: 35%
@@ -38,11 +32,11 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       std::array<int, 10> hex{};
       std::array<int, 10> byte2{};
       int msc_location, vlr_location;
-      double time = connector_->getSubscriberData(s_id, &sub_nbr, bit, hex, byte2,
-                                    &msc_location, &vlr_location);
+      double time = connector_->getSubscriberData(
+          s_id, &sub_nbr, bit, hex, byte2, &msc_location, &vlr_location);
       if (time != -1) {
-       time_1_ += time;
-       s_trans_count++; 
+        query_time_[0] += time;
+        s_trans_count_[0]++;
       }
     } else if (transaction_type < 45) {
       // GET_NEW_DESTINATION
@@ -52,11 +46,11 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int start_time = start_times_possible[rg_.random_int(0, 2)];
       int end_time = rg_.random_int(1, 24);
       std::string numberx;
-      double time = connector_->getNewDestination(s_id, sf_type, start_time, end_time,
-                                    &numberx);
+      double time = connector_->getNewDestination(s_id, sf_type, start_time,
+                                                  end_time, &numberx);
       if (time != -1) {
-        time_2_ += time;
-        s_trans_count++;
+        query_time_[1] += time;
+        s_trans_count_[1]++;
       }
     } else if (transaction_type < 80) {
       // GET_ACCESS_DATA
@@ -64,10 +58,11 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int ai_type = rg_.random_int(1, 4);
       int data1, data2;
       std::string data3, data4;
-      double time = connector_->getAccessData(s_id, ai_type, &data1, &data2, &data3, &data4);
+      double time = connector_->getAccessData(s_id, ai_type, &data1, &data2,
+                                              &data3, &data4);
       if (time != -1) {
-        time_3_ += time;
-        s_trans_count++;
+        query_time_[2] += time;
+        s_trans_count_[2]++;
       }
 
     } else if (transaction_type < 82) {
@@ -76,11 +71,12 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       bool bit_1 = rg_.random_bool();
       int sf_type = rg_.random_int(1, 4);
       int data_a = rg_.random_int(0, 255);
-      double time = connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
+      double time =
+          connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
 
       if (time != -1) {
-        time_4_ += time;
-        s_trans_count++;
+        query_time_[3] += time;
+        s_trans_count_[3]++;
       }
     } else if (transaction_type < 96) {
       // UPDATE_LOCATION
@@ -90,8 +86,8 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       double time = connector_->updateLocation(sub_nbr, vlr_location);
 
       if (time != -1) {
-        time_5_ += time;
-        s_trans_count++;
+        query_time_[4] += time;
+        s_trans_count_[4]++;
       }
     } else if (transaction_type < 98) {
       // INSERT_CALL_FORWARDING
@@ -103,11 +99,11 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int end_time = rg_.random_int(1, 24);
       std::string numberx =
           leading_zero_pad(15, std::to_string(rg_.random_int(1, n_rows_)));
-      double time = connector_->insertCallForwarding(sub_nbr, sf_type, start_time, end_time,
-                                       numberx);
+      double time = connector_->insertCallForwarding(
+          sub_nbr, sf_type, start_time, end_time, numberx);
       if (time != -1) {
-        time_6_ += time;
-        s_trans_count++;
+        query_time_[5] += time;
+        s_trans_count_[5]++;
       }
     } else {
       // DELETE_CALL_FORWARDING
@@ -116,11 +112,12 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
       int sf_type = rg_.random_int(1, 4);
       int start_times_possible[] = {0, 8, 16};
       int start_time = start_times_possible[rg_.random_int(0, 2)];
-      double time = connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
+      double time =
+          connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
 
       if (time != -1) {
-        time_7_ += time;
-        s_trans_count++;
+        query_time_[6] += time;
+        s_trans_count_[6]++;
       }
     }
     w_trans_count++;
@@ -129,15 +126,15 @@ void txbench::TATPWorker::run(std::atomic_bool &terminate,
   this->print(w_trans_count);
 }
 
-
 void txbench::TATPWorker::print(int commit_count) {
-    std::cout << "Worker time " << std::endl; 
-    std::cout << "Time 1 : " << 1.0 * (time_1_*1.0/s_trans_count) << std::endl;
-    std::cout << "Time 2 : " << 1.0 * (time_2_*1.0/s_trans_count) << std::endl;
-    std::cout << "Time 3 : " << 1.0 * (time_3_*1.0/s_trans_count) << std::endl;
-    std::cout << "Time 4 : " << 1.0 * (time_4_*1.0/s_trans_count) << std::endl;
-    std::cout << "Time 5 : " << 1.0 * (time_5_*1.0/s_trans_count) << std::endl;
-    std::cout << "Time 6 : " << 1.0 * (time_6_*1.0/s_trans_count) << std::endl;
-    std::cout << "Time 7 : " << 1.0 * (time_7_*1.0/s_trans_count)  << std::endl;
-    std::cout << "transaction count: " << w_trans_count << " successful transaction count: " << s_trans_count << std::endl;
+  std::cout << "Worker time " << std::endl;
+  int total_s_trans_count = 0;
+  for (int i = 0; i < NUM_QUERIES; i++) {
+    std::cout << "Time " << (i + 1) << " : "
+              << 1.0 * (query_time_[i] * 1.0 / s_trans_count_[i]) << std::endl;
+    total_s_trans_count += s_trans_count_[i];
+  }
+  std::cout << "transaction count: " << w_trans_count
+            << " successful transaction count: " << total_s_trans_count
+            << std::endl;
 }

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -12,6 +12,7 @@ txbench::TATPWorker::TATPWorker(int n_rows,
       a_val_(n_rows <= 1000000 ? 65535
                                : n_rows <= 10000000 ? 1048575 : 2097151),
       connector_(std::move(connector)) {
+  w_trans_count = 0;
   query_time_ = (double *)calloc(NUM_QUERIES, sizeof(double));
   s_trans_count_ = (int *)calloc(NUM_QUERIES, sizeof(int));
 }

--- a/src/txbench/benchmarks/tatp/tatp_worker.cpp
+++ b/src/txbench/benchmarks/tatp/tatp_worker.cpp
@@ -1,0 +1,92 @@
+#include "tatp_worker.h"
+#include "tatp_util.h"
+#include <climits>
+#include <memory>
+#include <iostream>
+
+txbench::TATPWorker::TATPWorker(int n_rows,
+                                std::unique_ptr<TATPConnector> connector)
+    : n_rows_(n_rows),
+      a_val_(n_rows <= 1000000 ? 65535
+                               : n_rows <= 10000000 ? 1048575 : 2097151),
+      connector_(std::move(connector)) {}
+
+void txbench::TATPWorker::run(std::atomic_bool &terminate,
+                              std::atomic_int &commit_count) {
+  while (!terminate) {
+    int s_id =
+        (rg_.random_int(0, a_val_) | rg_.random_int(1, n_rows_)) % n_rows_ + 1;
+
+    int transaction_type = rg_.random_int(0, 99);
+    //std::cout << "Query executing " << transaction_type << std::endl;
+    if (transaction_type < 35) {
+      // GET_SUBSCRIBER_DATA
+      // Probability: 35%
+      std::string sub_nbr;
+      std::array<bool, 10> bit{};
+      std::array<int, 10> hex{};
+      std::array<int, 10> byte2{};
+      int msc_location, vlr_location;
+      connector_->getSubscriberData(s_id, &sub_nbr, bit, hex, byte2,
+                                    &msc_location, &vlr_location);
+
+    } else if (transaction_type < 45) {
+      // GET_NEW_DESTINATION
+      // Probability: 10%
+      int sf_type = rg_.random_int(1, 4);
+      int start_times_possible[] = {0, 8, 16};
+      int start_time = start_times_possible[rg_.random_int(0, 2)];
+      int end_time = rg_.random_int(1, 24);
+      std::string numberx;
+      //connector_->getNewDestination(s_id, sf_type, start_time, end_time,
+      //                              &numberx);
+
+    } else if (transaction_type < 80) {
+      // GET_ACCESS_DATA
+      // Probability: 35%
+      int ai_type = rg_.random_int(1, 4);
+      int data1, data2;
+      std::string data3, data4;
+      connector_->getAccessData(s_id, ai_type, &data1, &data2, &data3, &data4);
+
+    } else if (transaction_type < 82) {
+      // UPDATE_SUBSCRIBER_DATA
+      // Probability: 2%
+      bool bit_1 = rg_.random_bool();
+      int sf_type = rg_.random_int(1, 4);
+      int data_a = rg_.random_int(0, 255);
+      connector_->updateSubscriberData(s_id, bit_1, sf_type, data_a);
+
+    } else if (transaction_type < 96) {
+      // UPDATE_LOCATION
+      // Probability: 14%
+      std::string sub_nbr = leading_zero_pad(15, std::to_string(s_id));
+      int vlr_location = rg_.random_int(INT_MIN, INT_MAX);
+      connector_->updateLocation(sub_nbr, vlr_location);
+
+    } else if (transaction_type < 98) {
+      // INSERT_CALL_FORWARDING
+      // Probability: 2%
+      std::string sub_nbr = leading_zero_pad(15, std::to_string(s_id));
+      int sf_type = rg_.random_int(1, 4);
+      int start_times_possible[] = {0, 8, 16};
+      int start_time = start_times_possible[rg_.random_int(0, 2)];
+      int end_time = rg_.random_int(1, 24);
+      std::string numberx =
+          leading_zero_pad(15, std::to_string(rg_.random_int(1, n_rows_)));
+      connector_->insertCallForwarding(sub_nbr, sf_type, start_time, end_time,
+                                       numberx);
+
+    } else {
+      // DELETE_CALL_FORWARDING
+      // Probability: 2%
+      std::string sub_nbr = leading_zero_pad(15, std::to_string(s_id));
+      int sf_type = rg_.random_int(1, 4);
+      int start_times_possible[] = {0, 8, 16};
+      int start_time = start_times_possible[rg_.random_int(0, 2)];
+      connector_->deleteCallForwarding(sub_nbr, sf_type, start_time);
+    }
+
+    commit_count++;
+  }
+}

--- a/src/txbench/benchmarks/tatp/tatp_worker.h
+++ b/src/txbench/benchmarks/tatp/tatp_worker.h
@@ -1,51 +1,47 @@
 #ifndef TXBENCH__TATP_WORKER_H
 #define TXBENCH__TATP_WORKER_H
 
-#include "txbench/random_generator.h"
-#include "tatp_connector.h"
-#include "txbench/worker.h"
 #include <memory>
 #include <random>
+
+#include "tatp_connector.h"
+#include "txbench/random_generator.h"
+#include "txbench/worker.h"
 
 namespace txbench {
 
 class TATPWorker : public Worker {
-public:
+ public:
   explicit TATPWorker(int n_rows, std::unique_ptr<TATPConnector> connector);
 
-  void run(std::atomic_bool &terminate, std::atomic_int &commit_count) override;
+  void run(std::atomic_bool& terminate, std::atomic_int& commit_count) override;
 
   void print(int commit_count) override;
 
-  double getTime1() override { return (1.0*time_1_)/s_trans_count; }
-  
-  double getTime2() override { return (1.0*time_2_)/s_trans_count; }
-  
-  double getTime3() override { return (1.0*time_3_)/s_trans_count; }
-  
-  double getTime4() override { return (1.0*time_4_)/s_trans_count; }
+  double getTime(int query_id) override {
+    return (1.0 * query_time_[query_id]) / s_trans_count_[query_id];
+  }
 
-  double getTime5() override { return (1.0*time_5_)/s_trans_count; }
+  ~TATPWorker() {
+    free(query_time_);
+    free(s_trans_count_);
+  }
 
-  double getTime6() override { return (1.0*time_6_)/s_trans_count; }
-
-  double getTime7() override { return (1.0*time_7_)/s_trans_count; }
-
-private:
+ private:
   int n_rows_;
 
   int a_val_;
 
   int w_trans_count;
-  int s_trans_count;
+  int* s_trans_count_;
 
-  double time_1_, time_2_, time_3_, time_4_, time_5_, time_6_, time_7_;
+  double* query_time_;
 
   std::unique_ptr<TATPConnector> connector_;
 
   RandomGenerator rg_;
 };
 
-} // namespace txbench
+}  // namespace txbench
 
-#endif // TXBENCH__TATP_WORKER_H
+#endif  // TXBENCH__TATP_WORKER_H

--- a/src/txbench/benchmarks/tatp/tatp_worker.h
+++ b/src/txbench/benchmarks/tatp/tatp_worker.h
@@ -15,10 +15,30 @@ public:
 
   void run(std::atomic_bool &terminate, std::atomic_int &commit_count) override;
 
+  void print(int commit_count) override;
+
+  double getTime1() override { return (1.0*time_1_)/w_trans_count; }
+  
+  double getTime2() override { return (1.0*time_2_)/w_trans_count; }
+  
+  double getTime3() override { return (1.0*time_3_)/w_trans_count; }
+  
+  double getTime4() override { return (1.0*time_4_)/w_trans_count; }
+
+  double getTime5() override { return (1.0*time_5_)/w_trans_count; }
+
+  double getTime6() override { return (1.0*time_6_)/w_trans_count; }
+
+  double getTime7() override { return (1.0*time_7_)/w_trans_count; }
+
 private:
   int n_rows_;
 
   int a_val_;
+
+  int w_trans_count;
+
+  double time_1_, time_2_, time_3_, time_4_, time_5_, time_6_, time_7_;
 
   std::unique_ptr<TATPConnector> connector_;
 

--- a/src/txbench/benchmarks/tatp/tatp_worker.h
+++ b/src/txbench/benchmarks/tatp/tatp_worker.h
@@ -17,19 +17,19 @@ public:
 
   void print(int commit_count) override;
 
-  double getTime1() override { return (1.0*time_1_)/w_trans_count; }
+  double getTime1() override { return (1.0*time_1_)/s_trans_count; }
   
-  double getTime2() override { return (1.0*time_2_)/w_trans_count; }
+  double getTime2() override { return (1.0*time_2_)/s_trans_count; }
   
-  double getTime3() override { return (1.0*time_3_)/w_trans_count; }
+  double getTime3() override { return (1.0*time_3_)/s_trans_count; }
   
-  double getTime4() override { return (1.0*time_4_)/w_trans_count; }
+  double getTime4() override { return (1.0*time_4_)/s_trans_count; }
 
-  double getTime5() override { return (1.0*time_5_)/w_trans_count; }
+  double getTime5() override { return (1.0*time_5_)/s_trans_count; }
 
-  double getTime6() override { return (1.0*time_6_)/w_trans_count; }
+  double getTime6() override { return (1.0*time_6_)/s_trans_count; }
 
-  double getTime7() override { return (1.0*time_7_)/w_trans_count; }
+  double getTime7() override { return (1.0*time_7_)/s_trans_count; }
 
 private:
   int n_rows_;
@@ -37,6 +37,7 @@ private:
   int a_val_;
 
   int w_trans_count;
+  int s_trans_count;
 
   double time_1_, time_2_, time_3_, time_4_, time_5_, time_6_, time_7_;
 

--- a/src/txbench/benchmarks/tatp/tatp_worker.h
+++ b/src/txbench/benchmarks/tatp/tatp_worker.h
@@ -1,0 +1,30 @@
+#ifndef TXBENCH__TATP_WORKER_H
+#define TXBENCH__TATP_WORKER_H
+
+#include "txbench/random_generator.h"
+#include "tatp_connector.h"
+#include "txbench/worker.h"
+#include <memory>
+#include <random>
+
+namespace txbench {
+
+class TATPWorker : public Worker {
+public:
+  explicit TATPWorker(int n_rows, std::unique_ptr<TATPConnector> connector);
+
+  void run(std::atomic_bool &terminate, std::atomic_int &commit_count) override;
+
+private:
+  int n_rows_;
+
+  int a_val_;
+
+  std::unique_ptr<TATPConnector> connector_;
+
+  RandomGenerator rg_;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__TATP_WORKER_H

--- a/src/txbench/benchmarks/tatp_hustle/CMakeLists.txt
+++ b/src/txbench/benchmarks/tatp_hustle/CMakeLists.txt
@@ -24,4 +24,15 @@ target_link_libraries(
         tatp_hustle
         txbench
         tatp
+	hustleDB
+        hustle_src_catalog
+        hustle_src_storage
+        hustle_src_parser
+        hustle_src_resolver
+        hustle_src_operators
+        hustle_src_scheduler_Scheduler
+        hustle_src_optimizer_ExecutionPlan
+        ${ARROW_SHARED_LIB}
+        ${GFLAGS_LIB_NAME}
+        glog
 )

--- a/src/txbench/benchmarks/tatp_hustle/CMakeLists.txt
+++ b/src/txbench/benchmarks/tatp_hustle/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_executable(
+        tatp_hustle
+        tatp_hustle.cc
+        tatp_hustle_benchmark.h tatp_hustle_benchmark.cc
+        tatp_hustle_loader.h tatp_hustle_loader.cc
+        tatp_hustle_connector.h tatp_hustle_connector.cc
+)
+
+target_include_directories(
+        tatp_hustle
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        hustle_src_catalog
+        hustle_src_storage
+        hustle_src_operators
+        hustle_src_scheduler_Scheduler
+        hustle_src_optimizer_ExecutionPlan
+        hustle_src_utils_EventProfiler
+        hustle_src_utils_skew
+        hustle_src_utils_Config
+)
+
+target_link_libraries(
+        tatp_hustle
+        txbench
+        tatp
+)

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 
 int main(int argc, char **argv) {
-  int n_workers = 1;
+  int n_workers = 7;
   int warmup_duration = 5;
   int measurement_duration = 15;
   int n_rows = 100000;

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
@@ -4,8 +4,8 @@
 int main(int argc, char **argv) {
   int n_workers = 1;
   int warmup_duration = 5;
-  int measurement_duration = 10;
-  int n_rows = 1000;
+  int measurement_duration = 15;
+  int n_rows = 100000;
 
   if (argc == 5) {
     n_workers = std::stoi(argv[1]);

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
@@ -1,0 +1,26 @@
+#include "tatp_hustle_benchmark.h"
+#include <iostream>
+
+int main(int argc, char **argv) {
+  int n_workers = 1;
+  int warmup_duration = 5;
+  int measurement_duration = 10;
+  int n_rows = 1000;
+
+  if (argc == 5) {
+    n_workers = std::stoi(argv[1]);
+    warmup_duration = std::stoi(argv[2]);
+    measurement_duration = std::stoi(argv[3]);
+    n_rows = std::stoi(argv[4]);
+  }
+
+   std::cout << "n_workers: " << n_workers << "\n"
+	     << "warmup_duration: " << warmup_duration << "\n"
+             << "measurement_duration: " << measurement_duration << "\n"
+	     << "n_rows: " << n_rows << "\n";
+
+  txbench::TATPHustleBenchmark benchmark(n_workers, warmup_duration,
+                                        measurement_duration, n_rows);
+  double tps = benchmark.run();
+  std::cout << "tps: " << tps << std::endl;
+}

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 
 int main(int argc, char **argv) {
-  int n_workers = 7;
+  int n_workers = 1;
   int warmup_duration = 5;
   int measurement_duration = 15;
   int n_rows = 100000;

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.cc
@@ -1,0 +1,28 @@
+#include "tatp_hustle_benchmark.h"
+#include "txbench/benchmarks/tatp/tatp_worker.h"
+#include "tatp_hustle_connector.h"
+#include "tatp_hustle_loader.h"
+
+std::shared_ptr<hustle::HustleDB> txbench::TATPHustleBenchmark::hustle_db {nullptr};
+txbench::TATPHustleBenchmark::TATPHustleBenchmark(int n_workers,
+                                                int warmup_duration,
+                                                int measurement_duration,
+                                                int n_rows)
+    : Benchmark(n_workers, warmup_duration, measurement_duration),
+      n_rows_(n_rows) {
+         std::cout << "Start scheduler" << std::endl;
+         hustle::HustleDB::startScheduler();
+      }
+
+
+std::unique_ptr<txbench::Loader> txbench::TATPHustleBenchmark::make_loader() {
+  return std::make_unique<TATPHustleLoader>(n_rows_, "localhost", 33060,
+                                           "txbench");
+}
+
+std::unique_ptr<txbench::Worker> txbench::TATPHustleBenchmark::make_worker() {
+  auto connector =
+      std::make_unique<TATPHustleConnector>("localhost", 33060, "txbench");
+  auto worker = std::make_unique<TATPWorker>(n_rows_, std::move(connector));
+  return worker;
+}

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.h
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.h
@@ -1,0 +1,40 @@
+#ifndef TXBENCH_BENCHMARKS_TATP_HUSTLE_BENCHMARK_H_
+#define TXBENCH_BENCHMARKS_TATP_HUSTLE_BENCHMARK_H_
+
+#include "txbench/benchmark.h"
+#include "txbench/loader.h"
+#include "api/hustle_db.h"
+#include <memory>
+
+namespace txbench {
+
+class TATPHustleBenchmark : public Benchmark {
+public:
+  TATPHustleBenchmark(int n_workers, int warmup_duration,
+                     int measurement_duration, int n_rows);
+  static std::shared_ptr<hustle::HustleDB> getHustleDB() { 
+    if (hustle_db == nullptr) {
+       hustle_db = std::make_shared<hustle::HustleDB>("db_directory2");
+       std::cout << "create hustldb" << std::endl;
+    }
+    std::cout << hustle_db << std::endl;
+    return hustle_db; 
+    }
+
+~TATPHustleBenchmark() {
+  std::cout << "Stop scheduler" << std::endl;
+  hustle::HustleDB::stopScheduler();
+}
+private:
+  int n_rows_;
+
+  static std::shared_ptr<hustle::HustleDB> hustle_db;
+
+  std::unique_ptr<Loader> make_loader() override;
+
+  std::unique_ptr<Worker> make_worker() override;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH_BENCHMARKS_TATP_Hustle_BENCHMARK_H_

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
@@ -30,7 +30,9 @@ double txbench::TATPHustleConnector::getSubscriberData(
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
   const auto before = clock1::now();
-  hustle_db->executeQuery(query);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
   // std::cout << "query done - select - 1" << std::endl;
@@ -58,7 +60,9 @@ double txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
       "AND end_time>" +
       std::to_string(end_time) + ");";
   const auto before = clock1::now();
-  hustle_db->executeQuery(query);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
 }
@@ -73,7 +77,9 @@ double txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
       "WHERE s_id=" +
       std::to_string(s_id) + " AND ai_type=" + std::to_string(ai_type) + ";";
   const auto before = clock1::now();
-  hustle_db->executeQuery(query);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
   // std::cout << "query done - select - 3" << std::endl;
@@ -81,15 +87,16 @@ double txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
 
 double txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
                                                         int sf_type,
-                                                    int data_a) {
-  std::string query1 =
+                                                   int data_a) {
+  std::string query = "BEGIN;";
+  query +=
       "UPDATE Subscriber "
       "SET bit_1=" +
       std::to_string(bit_1) +
       " "
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
-  std::string query2 =
+   query  +=
       "UPDATE Special_Facility "
       "SET data_a=" +
       std::to_string(data_a) +
@@ -99,9 +106,11 @@ double txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
       " "
       "AND sf_sf_type=" +
       std::to_string(sf_type) + ";";
+  query += "COMMIT;";
   const auto before = clock1::now();
-  hustle_db->executeQuery(query1);
-  hustle_db->executeQuery(query2);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
   // std::cout << "query done - update - 4" << std::endl;
@@ -117,7 +126,9 @@ double txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
       "WHERE sub_nbr='" +
       sub_nbr + "';";
   const auto before = clock1::now();
-  hustle_db->executeQuery(query);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
   // std::cout << "query done - update" << std::endl;
@@ -133,7 +144,9 @@ double txbench::TATPHustleConnector::insertCallForwarding(
       std::to_string(start_time) + "," + std::to_string(end_time) + "," +
       std::to_string(end_time) + ");";
   const auto before = clock1::now();
-  hustle_db->executeQuery(query);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
   // std::cout << "query done - insert" << std::endl;
@@ -151,7 +164,9 @@ double txbench::TATPHustleConnector::deleteCallForwarding(
       std::to_string(start_time) + ";";
 
   const auto before = clock1::now();
-  hustle_db->executeQuery(query);
+  if(!hustle_db->executeNoOutputQuery(query)) {
+    return -1;
+  }
   const sec duration = clock1::now() - before;
   return duration.count();
   // std::cout << "query done - delete" << std::endl;

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
@@ -1,0 +1,133 @@
+#include "txbench/benchmarks/tatp_hustle/tatp_hustle_connector.h"
+
+#include <iostream>
+#include <memory>
+
+txbench::TATPHustleConnector::TATPHustleConnector(const std::string &host,
+                                                  int port,
+                                                  const std::string &user) {
+  hustle_db = txbench::TATPHustleBenchmark::getHustleDB();
+}
+
+void txbench::TATPHustleConnector::getSubscriberData(
+    int s_id, std::string *sub_nbr, std::array<bool, 10> &bit,
+    std::array<int, 10> &hex, std::array<int, 10> &byte2, int *msc_location,
+    int *vlr_location) {
+  std::string query =
+      "SELECT s_id, sub_nbr,"
+      "bit_1, bit_2, bit_3, bit_4, bit_5, bit_6, bit_7,"
+      "bit_8, bit_9, bit_10,"
+      "hex_1, hex_2, hex_3, hex_4, hex_5, hex_6, hex_7,"
+      "hex_8, hex_9, hex_10,"
+      "byte2_1, byte2_2, byte2_3, byte2_4, byte2_5,"
+      "byte2_6, byte2_7, byte2_8, byte2_9, byte2_10,"
+      "msc_location, vlr_location "
+      "FROM Subscriber "
+      "WHERE s_id=" +
+      std::to_string(s_id) + ";";
+   hustle_db->executeQuery(query);
+   std::cout << "query done - select - 1" << std::endl;
+}
+
+void txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
+                                                     int start_time,
+                                                     int end_time,
+                                                     std::string *numberx) {
+  std::string query =
+      "SELECT numberx "
+      "FROM Special_Facility, Call_Forwarding "
+      "WHERE "
+      "cf_s_id=sf_s_id "
+      "AND cf_sf_type=sf_sf_type "
+      "AND sf_s_id=" +
+      std::to_string(s_id) +
+      " "
+      "AND sf_sf_type=" +
+      std::to_string(sf_type) +
+      " "
+      "AND is_active=1 "
+      "AND start_time<=" +
+      std::to_string(start_time) +
+      " "
+      "AND end_time>" +
+      std::to_string(end_time) + ";";
+     //hustle_db->executeQuery(query);
+}
+
+void txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
+                                                 int *data1, int *data2,
+                                                 std::string *data3,
+                                                 std::string *data4) {
+  std::string query =
+      "SELECT data1, data2, data3, data4 "
+      "FROM Access_Info "
+      "WHERE s_id=" +
+      std::to_string(s_id) + " AND ai_type=" + std::to_string(ai_type) + ";";
+   hustle_db->executeQuery(query);
+  std::cout << "query done - select - 3" << std::endl;
+}
+
+void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
+                                                        int sf_type,
+                                                        int data_a) {
+  std::string query1 =
+      "UPDATE Subscriber "
+      "SET bit_1=" +
+      std::to_string(bit_1) +
+      " "
+      "WHERE s_id=" +
+      std::to_string(s_id) + ";";
+   hustle_db->executeQuery(query1);
+  std::string query2 =
+      "UPDATE Special_Facility "
+      "SET data_a=" +
+      std::to_string(data_a) +
+      " "
+      "WHERE sf_s_id=" +
+      std::to_string(s_id) +
+      " "
+      "AND sf_type=" +
+      std::to_string(sf_type) + ";";
+       hustle_db->executeQuery(query2);
+       std::cout << "query done - update - 4" << std::endl;
+}
+
+void txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
+                                                  int vlr_location) {
+  std::string query =
+      "UPDATE Subscriber "
+      "SET vlr_location=" +
+      std::to_string(vlr_location) +
+      " "
+      "WHERE sub_nbr='" +
+      sub_nbr + "';";
+   hustle_db->executeQuery(query);
+   std::cout << "query done - update" << std::endl;
+}
+
+void txbench::TATPHustleConnector::insertCallForwarding(
+    const std::string &sub_nbr, int sf_type, int start_time, int end_time,
+    const std::string &numberx) {
+  std::string query =
+      "INSERT INTO Call_Forwarding "
+      "VALUES ('" +
+      sub_nbr + "', " + std::to_string(sf_type) + "," +
+      std::to_string(start_time) + "," + std::to_string(end_time) + "," +
+      std::to_string(end_time) + ");";
+   hustle_db->executeQuery(query);
+   std::cout << "query done - insert" << std::endl;
+}
+
+void txbench::TATPHustleConnector::deleteCallForwarding(
+    const std::string &sub_nbr, int sf_type, int start_time) {
+  std::string query =
+      "DELETE FROM Call_Forwarding "
+      "WHERE cf_s_id=10 "
+      "AND cf_sf_type=" +
+      std::to_string(sf_type) +
+      ""
+      " AND start_time=" +
+      std::to_string(start_time) + ";";
+   hustle_db->executeQuery(query);
+   std::cout << "query done - delete" << std::endl;
+}

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
@@ -25,8 +25,8 @@ void txbench::TATPHustleConnector::getSubscriberData(
       "FROM Subscriber "
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
-   hustle_db->executeQuery(query);
-   std::cout << "query done - select - 1" << std::endl;
+  hustle_db->executeQuery(query);
+  // std::cout << "query done - select - 1" << std::endl;
 }
 
 void txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
@@ -38,20 +38,19 @@ void txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
       "FROM Special_Facility, Call_Forwarding "
       "WHERE "
       "cf_s_id=sf_s_id "
-      "AND cf_sf_type=sf_sf_type "
-      "AND sf_s_id=" +
+      "AND (sf_s_id=" +
       std::to_string(s_id) +
       " "
       "AND sf_sf_type=" +
       std::to_string(sf_type) +
       " "
-      "AND is_active=1 "
-      "AND start_time<=" +
+      "AND is_active=1) "
+      "AND (start_time<=" +
       std::to_string(start_time) +
       " "
       "AND end_time>" +
-      std::to_string(end_time) + ";";
-     //hustle_db->executeQuery(query);
+      std::to_string(end_time) + ");";
+  hustle_db->executeQuery(query);
 }
 
 void txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
@@ -63,8 +62,8 @@ void txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
       "FROM Access_Info "
       "WHERE s_id=" +
       std::to_string(s_id) + " AND ai_type=" + std::to_string(ai_type) + ";";
-   hustle_db->executeQuery(query);
-  std::cout << "query done - select - 3" << std::endl;
+  hustle_db->executeQuery(query);
+  // std::cout << "query done - select - 3" << std::endl;
 }
 
 void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
@@ -77,7 +76,7 @@ void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
       " "
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
-   hustle_db->executeQuery(query1);
+  hustle_db->executeQuery(query1);
   std::string query2 =
       "UPDATE Special_Facility "
       "SET data_a=" +
@@ -86,10 +85,10 @@ void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
       "WHERE sf_s_id=" +
       std::to_string(s_id) +
       " "
-      "AND sf_type=" +
+      "AND sf_sf_type=" +
       std::to_string(sf_type) + ";";
-       hustle_db->executeQuery(query2);
-       std::cout << "query done - update - 4" << std::endl;
+  hustle_db->executeQuery(query2);
+  // std::cout << "query done - update - 4" << std::endl;
 }
 
 void txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
@@ -101,8 +100,8 @@ void txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
       " "
       "WHERE sub_nbr='" +
       sub_nbr + "';";
-   hustle_db->executeQuery(query);
-   std::cout << "query done - update" << std::endl;
+  hustle_db->executeQuery(query);
+  // std::cout << "query done - update" << std::endl;
 }
 
 void txbench::TATPHustleConnector::insertCallForwarding(
@@ -114,8 +113,8 @@ void txbench::TATPHustleConnector::insertCallForwarding(
       sub_nbr + "', " + std::to_string(sf_type) + "," +
       std::to_string(start_time) + "," + std::to_string(end_time) + "," +
       std::to_string(end_time) + ");";
-   hustle_db->executeQuery(query);
-   std::cout << "query done - insert" << std::endl;
+  hustle_db->executeQuery(query);
+  // std::cout << "query done - insert" << std::endl;
 }
 
 void txbench::TATPHustleConnector::deleteCallForwarding(
@@ -128,6 +127,6 @@ void txbench::TATPHustleConnector::deleteCallForwarding(
       ""
       " AND start_time=" +
       std::to_string(start_time) + ";";
-   hustle_db->executeQuery(query);
-   std::cout << "query done - delete" << std::endl;
+  hustle_db->executeQuery(query);
+  // std::cout << "query done - delete" << std::endl;
 }

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <memory>
+#include <chrono>
 
 txbench::TATPHustleConnector::TATPHustleConnector(const std::string &host,
                                                   int port,
@@ -9,7 +10,10 @@ txbench::TATPHustleConnector::TATPHustleConnector(const std::string &host,
   hustle_db = txbench::TATPHustleBenchmark::getHustleDB();
 }
 
-void txbench::TATPHustleConnector::getSubscriberData(
+using clock1 = std::chrono::system_clock;
+using sec = std::chrono::duration<double>;
+
+double txbench::TATPHustleConnector::getSubscriberData(
     int s_id, std::string *sub_nbr, std::array<bool, 10> &bit,
     std::array<int, 10> &hex, std::array<int, 10> &byte2, int *msc_location,
     int *vlr_location) {
@@ -25,11 +29,14 @@ void txbench::TATPHustleConnector::getSubscriberData(
       "FROM Subscriber "
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
+  const auto before = clock1::now();
   hustle_db->executeQuery(query);
+  const sec duration = clock1::now() - before;
+  return duration.count();
   // std::cout << "query done - select - 1" << std::endl;
 }
 
-void txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
+double txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
                                                      int start_time,
                                                      int end_time,
                                                      std::string *numberx) {
@@ -50,10 +57,13 @@ void txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
       " "
       "AND end_time>" +
       std::to_string(end_time) + ");";
+  const auto before = clock1::now();
   hustle_db->executeQuery(query);
+  const sec duration = clock1::now() - before;
+  return duration.count();
 }
 
-void txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
+double txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
                                                  int *data1, int *data2,
                                                  std::string *data3,
                                                  std::string *data4) {
@@ -62,13 +72,16 @@ void txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
       "FROM Access_Info "
       "WHERE s_id=" +
       std::to_string(s_id) + " AND ai_type=" + std::to_string(ai_type) + ";";
+  const auto before = clock1::now();
   hustle_db->executeQuery(query);
+  const sec duration = clock1::now() - before;
+  return duration.count();
   // std::cout << "query done - select - 3" << std::endl;
 }
 
-void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
+double txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
                                                         int sf_type,
-                                                        int data_a) {
+                                                    int data_a) {
   std::string query1 =
       "UPDATE Subscriber "
       "SET bit_1=" +
@@ -76,7 +89,6 @@ void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
       " "
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
-  hustle_db->executeQuery(query1);
   std::string query2 =
       "UPDATE Special_Facility "
       "SET data_a=" +
@@ -87,11 +99,15 @@ void txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
       " "
       "AND sf_sf_type=" +
       std::to_string(sf_type) + ";";
+  const auto before = clock1::now();
+  hustle_db->executeQuery(query1);
   hustle_db->executeQuery(query2);
+  const sec duration = clock1::now() - before;
+  return duration.count();
   // std::cout << "query done - update - 4" << std::endl;
 }
 
-void txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
+double txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
                                                   int vlr_location) {
   std::string query =
       "UPDATE Subscriber "
@@ -100,11 +116,14 @@ void txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
       " "
       "WHERE sub_nbr='" +
       sub_nbr + "';";
+  const auto before = clock1::now();
   hustle_db->executeQuery(query);
+  const sec duration = clock1::now() - before;
+  return duration.count();
   // std::cout << "query done - update" << std::endl;
 }
 
-void txbench::TATPHustleConnector::insertCallForwarding(
+double txbench::TATPHustleConnector::insertCallForwarding(
     const std::string &sub_nbr, int sf_type, int start_time, int end_time,
     const std::string &numberx) {
   std::string query =
@@ -113,11 +132,14 @@ void txbench::TATPHustleConnector::insertCallForwarding(
       sub_nbr + "', " + std::to_string(sf_type) + "," +
       std::to_string(start_time) + "," + std::to_string(end_time) + "," +
       std::to_string(end_time) + ");";
+  const auto before = clock1::now();
   hustle_db->executeQuery(query);
+  const sec duration = clock1::now() - before;
+  return duration.count();
   // std::cout << "query done - insert" << std::endl;
 }
 
-void txbench::TATPHustleConnector::deleteCallForwarding(
+double txbench::TATPHustleConnector::deleteCallForwarding(
     const std::string &sub_nbr, int sf_type, int start_time) {
   std::string query =
       "DELETE FROM Call_Forwarding "
@@ -127,6 +149,10 @@ void txbench::TATPHustleConnector::deleteCallForwarding(
       ""
       " AND start_time=" +
       std::to_string(start_time) + ";";
+
+  const auto before = clock1::now();
   hustle_db->executeQuery(query);
+  const sec duration = clock1::now() - before;
+  return duration.count();
   // std::cout << "query done - delete" << std::endl;
 }

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.h
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.h
@@ -1,0 +1,42 @@
+#ifndef TXBENCH__TATP_MYSQL_CONNECTOR_H
+#define TXBENCH__TATP_MYSQL_CONNECTOR_H
+
+#include "txbench/benchmarks/tatp/tatp_connector.h"
+#include "txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.h"
+
+namespace txbench {
+
+class TATPHustleConnector : public TATPConnector {
+private:
+ std::shared_ptr<hustle::HustleDB> hustle_db;
+public:
+  TATPHustleConnector(const std::string &host, int port,
+                     const std::string &user);
+
+  void getSubscriberData(int s_id, std::string *sub_nbr,
+                         std::array<bool, 10> &bit, std::array<int, 10> &hex,
+                         std::array<int, 10> &byte2, int *msc_location,
+                         int *vlr_location) override;
+
+  void getNewDestination(int s_id, int sf_type, int start_time, int end_time,
+                         std::string *numberx) override;
+
+  void getAccessData(int s_id, int ai_type, int *data1, int *data2,
+                     std::string *data3, std::string *data4) override;
+
+  void updateSubscriberData(int s_id, bool bit_1, int sf_type,
+                            int data_a) override;
+
+  void updateLocation(const std::string &sub_nbr, int vlr_location) override;
+
+  void insertCallForwarding(const std::string &sub_nbr, int sf_type,
+                            int start_time, int end_time,
+                            const std::string &numberx) override;
+
+  void deleteCallForwarding(const std::string &sub_nbr, int sf_type,
+                            int start_time) override;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__TATP_MYSQL_CONNECTOR_H

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.h
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.h
@@ -13,27 +13,27 @@ public:
   TATPHustleConnector(const std::string &host, int port,
                      const std::string &user);
 
-  void getSubscriberData(int s_id, std::string *sub_nbr,
+  double getSubscriberData(int s_id, std::string *sub_nbr,
                          std::array<bool, 10> &bit, std::array<int, 10> &hex,
                          std::array<int, 10> &byte2, int *msc_location,
                          int *vlr_location) override;
 
-  void getNewDestination(int s_id, int sf_type, int start_time, int end_time,
+  double getNewDestination(int s_id, int sf_type, int start_time, int end_time,
                          std::string *numberx) override;
 
-  void getAccessData(int s_id, int ai_type, int *data1, int *data2,
+  double getAccessData(int s_id, int ai_type, int *data1, int *data2,
                      std::string *data3, std::string *data4) override;
 
-  void updateSubscriberData(int s_id, bool bit_1, int sf_type,
+  double updateSubscriberData(int s_id, bool bit_1, int sf_type,
                             int data_a) override;
 
-  void updateLocation(const std::string &sub_nbr, int vlr_location) override;
+  double updateLocation(const std::string &sub_nbr, int vlr_location) override;
 
-  void insertCallForwarding(const std::string &sub_nbr, int sf_type,
+  double insertCallForwarding(const std::string &sub_nbr, int sf_type,
                             int start_time, int end_time,
                             const std::string &numberx) override;
 
-  void deleteCallForwarding(const std::string &sub_nbr, int sf_type,
+  double deleteCallForwarding(const std::string &sub_nbr, int sf_type,
                             int start_time) override;
 };
 

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_loader.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_loader.cc
@@ -1,0 +1,300 @@
+#include "tatp_hustle_loader.h"
+
+#include <algorithm>
+#include <climits>
+#include <iostream>
+#include <random>
+
+#include "tatp_hustle_benchmark.h"
+#include "txbench/benchmarks/tatp/tatp_util.h"
+#include "txbench/random_generator.h"
+
+txbench::TATPHustleLoader::TATPHustleLoader(int n_rows, const std::string &host,
+                                            int port, const std::string &user)
+    : n_rows_(n_rows) {}
+
+void txbench::TATPHustleLoader::load() {
+  std::random_device rd;
+  std::mt19937 mt(rd());
+
+  RandomGenerator rg;
+  hustle::HustleDB::startScheduler();
+  std::shared_ptr<arrow::Schema> s_schema, ai_schema, sf_schema, cf_schema;
+  std::shared_ptr<hustle::HustleDB> hustle_db =
+      txbench::TATPHustleBenchmark::getHustleDB();
+  hustle::catalog::TableSchema subscriber("Subscriber");
+  hustle::catalog::ColumnSchema s_id(
+      "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema sub_nbr(
+      "sub_nbr", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+  hustle::catalog::ColumnSchema bit_1(
+      "bit_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_2(
+      "bit_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_3(
+      "bit_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_4(
+      "bit_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_5(
+      "bit_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_6(
+      "bit_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_7(
+      "bit_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_8(
+      "bit_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_9(
+      "bit_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema bit_10(
+      "bit_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_1(
+      "hex_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_2(
+      "hex_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_3(
+      "hex_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_4(
+      "hex_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_5(
+      "hex_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_6(
+      "hex_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_7(
+      "hex_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_8(
+      "hex_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_9(
+      "hex_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema hex_10(
+      "hex_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_1(
+      "byte2_1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_2(
+      "byte2_2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_3(
+      "byte2_3", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_4(
+      "byte2_4", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+  hustle::catalog::ColumnSchema byte2_5(
+      "byte2_5", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_6(
+      "byte2_6", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_7(
+      "byte2_7", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_8(
+      "byte2_8", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_9(
+      "byte2_9", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema byte2_10(
+      "byte2_10", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema msc_location(
+      "msc_location", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema vlr_location(
+      "vlr_location", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+  subscriber.addColumn(s_id);
+  subscriber.addColumn(sub_nbr);
+  subscriber.addColumn(bit_1);
+  subscriber.addColumn(bit_2);
+  subscriber.addColumn(bit_3);
+  subscriber.addColumn(bit_4);
+  subscriber.addColumn(bit_5);
+  subscriber.addColumn(bit_6);
+  subscriber.addColumn(bit_7);
+  subscriber.addColumn(bit_8);
+  subscriber.addColumn(bit_9);
+  subscriber.addColumn(bit_10);
+  subscriber.addColumn(hex_1);
+  subscriber.addColumn(hex_2);
+  subscriber.addColumn(hex_3);
+  subscriber.addColumn(hex_4);
+  subscriber.addColumn(hex_5);
+  subscriber.addColumn(hex_6);
+  subscriber.addColumn(hex_7);
+  subscriber.addColumn(hex_8);
+  subscriber.addColumn(hex_9);
+  subscriber.addColumn(hex_10);
+  subscriber.addColumn(byte2_1);
+  subscriber.addColumn(byte2_2);
+  subscriber.addColumn(byte2_3);
+  subscriber.addColumn(byte2_4);
+  subscriber.addColumn(byte2_5);
+  subscriber.addColumn(byte2_6);
+  subscriber.addColumn(byte2_7);
+  subscriber.addColumn(byte2_8);
+  subscriber.addColumn(byte2_9);
+  subscriber.addColumn(byte2_10);
+  subscriber.addColumn(msc_location);
+  subscriber.addColumn(vlr_location);
+  subscriber.setPrimaryKey({});
+  s_schema = subscriber.getArrowSchema();
+
+  hustle::catalog::TableSchema access_info("Access_Info");
+  /* hustle::catalog::ColumnSchema s_id(
+       "s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);*/
+  hustle::catalog::ColumnSchema ai_type(
+      "ai_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data1(
+      "data1", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data2(
+      "data2", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data3(
+      "data3", {hustle::catalog::HustleType::CHAR, 3}, true, false);
+  hustle::catalog::ColumnSchema data4(
+      "data4", {hustle::catalog::HustleType::CHAR, 5}, true, false);
+  access_info.addColumn(s_id);
+  access_info.addColumn(ai_type);
+  access_info.addColumn(data1);
+  access_info.addColumn(data2);
+  access_info.addColumn(data3);
+  access_info.addColumn(data4);
+
+  access_info.setPrimaryKey({});
+  ai_schema = access_info.getArrowSchema();
+
+  hustle::catalog::TableSchema special_facility("Special_Facility");
+  hustle::catalog::ColumnSchema sf_s_id(
+      "sf_s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema sf_sf_type(
+      "sf_sf_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema is_active(
+      "is_active", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema error_cntrl(
+      "error_cntrl", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data_a(
+      "data_a", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema data_b(
+      "data_b", {hustle::catalog::HustleType::CHAR, 5}, true, false);
+  special_facility.addColumn(sf_s_id);
+  special_facility.addColumn(sf_sf_type);
+  special_facility.addColumn(is_active);
+  special_facility.addColumn(error_cntrl);
+  special_facility.addColumn(data_a);
+  special_facility.addColumn(data_b);
+  special_facility.setPrimaryKey({});
+  sf_schema = special_facility.getArrowSchema();
+
+  hustle::catalog::TableSchema call_forwarding("Call_Forwarding");
+  hustle::catalog::ColumnSchema cf_s_id(
+      "cf_s_id", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema cf_sf_type(
+      "cf_sf_type", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema start_time(
+      "start_time", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema end_time(
+      "end_time", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema numberx(
+      "numberx", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+  call_forwarding.addColumn(cf_s_id);
+  call_forwarding.addColumn(cf_sf_type);
+  call_forwarding.addColumn(start_time);
+  call_forwarding.addColumn(end_time);
+  call_forwarding.addColumn(numberx);
+  call_forwarding.setPrimaryKey({});
+  cf_schema = call_forwarding.getArrowSchema();
+
+  std::shared_ptr<DBTable> s, ai, sf, cf;
+
+  s = std::make_shared<hustle::storage::DBTable>("table", s_schema, BLOCK_SIZE);
+  ai = std::make_shared<hustle::storage::DBTable>("table", ai_schema,
+                                                  BLOCK_SIZE);
+  sf = std::make_shared<hustle::storage::DBTable>("table", sf_schema,
+                                                  BLOCK_SIZE);
+  cf = std::make_shared<hustle::storage::DBTable>("table", cf_schema,
+                                                  BLOCK_SIZE);
+
+  hustle_db->createTable(subscriber, s);
+
+  hustle_db->createTable(access_info, ai);
+
+  hustle_db->createTable(special_facility, sf);
+  hustle_db->createTable(call_forwarding, cf);
+
+  std::vector<int> subscriber_ids(n_rows_);
+  std::iota(subscriber_ids.begin(), subscriber_ids.end(), 1);
+  std::shuffle(subscriber_ids.begin(), subscriber_ids.end(), mt);
+
+  std::string s_query = "BEGIN TRANSACTION; ";
+  std::string ac_query = "BEGIN TRANSACTION; ";
+  std::string sf_query = "BEGIN TRANSACTION; ";
+  std::string cf_query = "BEGIN TRANSACTION; ";
+  for (int subscriber_id : subscriber_ids) {
+    s_query += "INSERT INTO Subscriber VALUES (";
+    s_query +=  std::to_string(subscriber_id) + ",";
+    s_query += leading_zero_pad(15, std::to_string(subscriber_id)) + ",";
+
+    for (int i = 0; i < 10; ++i) {
+      s_query += std::to_string(rg.random_bool()) + ",";
+    }
+
+    for (int i = 0; i < 10; ++i) {
+      s_query +=  std::to_string(rg.random_int(0, 15)) + ",";
+    }
+
+    for (int i = 0; i < 10; ++i) {
+      s_query +=  std::to_string(rg.random_int(0, 255)) + ",";
+    }
+
+    s_query +=  std::to_string(rg.random_int(INT_MIN, INT_MAX)) + ",";
+    s_query +=  std::to_string(rg.random_int(INT_MIN, INT_MAX));
+    s_query += ");";
+
+    int access_info_rows = rg.random_int(1, 4);
+    std::vector<int> ai_types_possible = {1, 2, 3, 4};
+    std::vector<int> ai_types;
+    std::sample(ai_types_possible.begin(), ai_types_possible.end(),
+                std::back_inserter(ai_types), access_info_rows, mt);
+
+    for (int ai_type : ai_types) {
+      ac_query += "INSERT INTO Access_Info VALUES (" +
+                  std::to_string(subscriber_id) + ", " + std::to_string(ai_type) +
+                  ","
+                  "" +
+                  std::to_string(rg.random_int(0, 255)) + "," + std::to_string(rg.random_int(0, 255)) +
+                  ","
+                  "'" +
+                  uppercase_string(3, rg) + "', '" + uppercase_string(5, rg) +
+                  "');";
+    }
+
+    int special_facility_rows = rg.random_int(1, 4);
+    std::vector<int> sf_types_possible = {1, 2, 3, 4};
+    std::vector<int> sf_types;
+    std::sample(sf_types_possible.begin(), sf_types_possible.end(),
+                std::back_inserter(sf_types), special_facility_rows, mt);
+
+    for (int sf_type : sf_types) {
+      sf_query += "INSERT INTO Special_Facility VALUES (" +
+                  std::to_string(subscriber_id) + ", " + std::to_string(sf_type) + ", " +
+                  std::to_string((int)(rg.random_int(0, 99) < 85)) + ", " +
+                  std::to_string(rg.random_int(0, 255)) + ", " + std::to_string(rg.random_int(0, 255)) + ", '" +
+                  uppercase_string(5, rg) + "');";
+
+      int call_forwarding_rows = rg.random_int(0, 3);
+      std::vector<int> start_times_possible = {0, 8, 16};
+      std::vector<int> start_times;
+      std::sample(start_times_possible.begin(), start_times_possible.end(),
+                  std::back_inserter(start_times), call_forwarding_rows, mt);
+
+      for (int start_time : start_times) {
+        cf_query += "INSERT INTO Call_Forwarding VALUES (" +
+                    std::to_string(subscriber_id) + ", " + std::to_string(sf_type) + ", " +
+                    std::to_string(start_time) + ", " + std::to_string(start_time + rg.random_int(1, 8)) +
+                    ", '" + uppercase_string(15, rg) + "');";
+      }
+    }
+  }
+
+  s_query += "COMMIT;";
+  ac_query += "COMMIT;";
+  sf_query += "COMMIT;";
+  cf_query += "COMMIT;";
+  hustle_db->executeQuery(s_query);
+  hustle_db->executeQuery(ac_query);
+  hustle_db->executeQuery(sf_query);
+  hustle_db->executeQuery(cf_query);
+
+  //hustle::HustleDB::stopScheduler();
+  std::cout << "loaded the values" << std::endl;
+}

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_loader.h
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_loader.h
@@ -1,0 +1,28 @@
+#ifndef TXBENCH_BENCHMARKS_TATP_HUSTLE_LOADER_H_
+#define TXBENCH_BENCHMARKS_TATP_HUSTLE_LOADER_H_
+
+#include "txbench/loader.h"
+#include "api/hustle_db.h"
+#include "catalog/catalog.h"
+#include "catalog/column_schema.h"
+#include "catalog/table_schema.h"
+#include "parser/parser.h"
+#include "sqlite3/sqlite3.h"
+#include "storage/util.h"
+
+namespace txbench {
+
+class TATPHustleLoader : public Loader {
+public:
+  TATPHustleLoader(int n_rows, const std::string &host, int port,
+                  const std::string &user);
+
+  void load() override;
+
+private:
+  int n_rows_;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH_BENCHMARKS_TATP_HUSTLE_LOADER_H_

--- a/src/txbench/benchmarks/tatp_mysql/CMakeLists.txt
+++ b/src/txbench/benchmarks/tatp_mysql/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_executable(
+        tatp_mysql
+        tatp_mysql.cpp
+        tatp_mysql_benchmark.h tatp_mysql_benchmark.cpp
+        tatp_mysql_loader.h tatp_mysql_loader.cpp
+        tatp_mysql_connector.h tatp_mysql_connector.cpp
+)
+
+target_include_directories(
+        tatp_mysql
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        /usr/include/mysql-cppconn-8
+)
+
+target_link_libraries(
+        tatp_mysql
+        txbench
+        tatp
+        /usr/lib/x86_64-linux-gnu/libmysqlcppconn8.so.2.8.0.19
+)

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql.cpp
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql.cpp
@@ -1,0 +1,26 @@
+#include "tatp_mysql_benchmark.h"
+#include <iostream>
+
+int main(int argc, char **argv) {
+  int n_workers = 1;
+  int warmup_duration = 5;
+  int measurement_duration = 10;
+  int n_rows = 1000;
+
+  if (argc == 5) {
+    n_workers = std::stoi(argv[1]);
+    warmup_duration = std::stoi(argv[2]);
+    measurement_duration = std::stoi(argv[3]);
+    n_rows = std::stoi(argv[4]);
+  }
+
+   std::cout << "n_workers: " << n_workers << "\n"
+	     << "warmup_duration: " << warmup_duration << "\n"
+             << "measurement_duration: " << measurement_duration << "\n"
+	     << "n_rows: " << n_rows << "\n";
+
+  txbench::TATPMySQLBenchmark benchmark(n_workers, warmup_duration,
+                                        measurement_duration, n_rows);
+  double tps = benchmark.run();
+  std::cout << "tps: " << tps << std::endl;
+}

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql_benchmark.cpp
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql_benchmark.cpp
@@ -1,0 +1,23 @@
+#include "tatp_mysql_benchmark.h"
+#include "benchmarks/tatp/tatp_worker.h"
+#include "tatp_mysql_connector.h"
+#include "tatp_mysql_loader.h"
+
+txbench::TATPMySQLBenchmark::TATPMySQLBenchmark(int n_workers,
+                                                int warmup_duration,
+                                                int measurement_duration,
+                                                int n_rows)
+    : Benchmark(n_workers, warmup_duration, measurement_duration),
+      n_rows_(n_rows) {}
+
+std::unique_ptr<txbench::Loader> txbench::TATPMySQLBenchmark::make_loader() {
+  return std::make_unique<TATPMySQLLoader>(n_rows_, "localhost", 33060,
+                                           "txbench");
+}
+
+std::unique_ptr<txbench::Worker> txbench::TATPMySQLBenchmark::make_worker() {
+  auto connector =
+      std::make_unique<TATPMySQLConnector>("localhost", 33060, "txbench");
+  auto worker = std::make_unique<TATPWorker>(n_rows_, std::move(connector));
+  return worker;
+}

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql_benchmark.h
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql_benchmark.h
@@ -1,0 +1,24 @@
+#ifndef TXBENCH_BENCHMARKS_TATP_MYSQL_TATP_MYSQL_BENCHMARK_H_
+#define TXBENCH_BENCHMARKS_TATP_MYSQL_TATP_MYSQL_BENCHMARK_H_
+
+#include "benchmark.h"
+#include "loader.h"
+
+namespace txbench {
+
+class TATPMySQLBenchmark : public Benchmark {
+public:
+  TATPMySQLBenchmark(int n_workers, int warmup_duration,
+                     int measurement_duration, int n_rows);
+
+private:
+  int n_rows_;
+
+  std::unique_ptr<Loader> make_loader() override;
+
+  std::unique_ptr<Worker> make_worker() override;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH_BENCHMARKS_TATP_MYSQL_TATP_MYSQL_BENCHMARK_H_

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql_connector.cpp
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql_connector.cpp
@@ -1,0 +1,172 @@
+#include "tatp_mysql_connector.h"
+#include <iostream>
+
+txbench::TATPMySQLConnector::TATPMySQLConnector(const std::string &host,
+                                                int port,
+                                                const std::string &user)
+    : session_(host, port, user),
+
+      select_subscriber_data_(session_.sql("SELECT * "
+                                           "FROM tatp.Subscriber "
+                                           "WHERE s_id = ?;")),
+
+      select_call_forwarding_number_(
+          session_.sql("SELECT cf.numberx "
+                       "FROM tatp.Special_Facility sf, tatp.Call_Forwarding cf "
+                       "WHERE sf.s_id = ? "
+                       "AND sf.sf_type = ? "
+                       "AND sf.is_active = 1 "
+                       "AND cf.s_id = sf.s_id "
+                       "AND cf.sf_type = sf.sf_type "
+                       "AND cf.start_time <= ? "
+                       "AND cf.end_time > ?;")),
+
+      select_access_data_(session_.sql("SELECT data1, data2, data3, data4 "
+                                       "FROM tatp.Access_Info "
+                                       "WHERE s_id = ? AND ai_type = ?;")),
+
+      update_subscriber_bit_(session_.sql("UPDATE tatp.Subscriber "
+                                          "SET bit_1 = ? "
+                                          "WHERE s_id = ?;")),
+
+      update_special_facility_data_(session_.sql("UPDATE tatp.Special_Facility "
+                                                 "SET data_a = ? "
+                                                 "WHERE s_id = ? "
+                                                 "AND sf_type = ?;")),
+
+      update_subscriber_location_(session_.sql("UPDATE tatp.Subscriber "
+                                               "SET vlr_location = ? "
+                                               "WHERE s_id = ?;")),
+
+      select_subscriber_id_(session_.sql("SELECT s_id "
+                                         "FROM tatp.Subscriber "
+                                         "WHERE sub_nbr = ?;")),
+
+      select_special_facility_type_(session_.sql("SELECT sf_type "
+                                                 "FROM tatp.Special_Facility "
+                                                 "WHERE s_id = ?;")),
+
+      insert_into_call_forwarding_(
+          session_.sql("INSERT INTO tatp.Call_Forwarding "
+                       "VALUES (?, ?, ?, ?, ?);")),
+
+      delete_from_call_forwarding_(
+          session_.sql("DELETE FROM tatp.Call_Forwarding "
+                       "WHERE s_id = ? "
+                       "AND sf_type = ? "
+                       "AND start_time = ?;")) {}
+
+void txbench::TATPMySQLConnector::getSubscriberData(
+    int s_id, std::string *sub_nbr, std::array<bool, 10> &bit,
+    std::array<int, 10> &hex, std::array<int, 10> &byte2, int *msc_location,
+    int *vlr_location) {
+  session_.startTransaction();
+
+  mysqlx::SqlResult result = select_subscriber_data_.bind(s_id).execute();
+  mysqlx::Row row = result.fetchOne();
+
+  *sub_nbr = row[1].get<std::string>();
+
+  for (int i = 0; i < 10; ++i) {
+    bit[i] = row[2 + i].get<bool>();
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    hex[i] = row[12 + i].get<int>();
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    byte2[i] = row[22 + i].get<int>();
+  }
+
+  *msc_location = row[32].get<int>();
+  *vlr_location = row[33].get<int>();
+
+  session_.commit();
+}
+
+void txbench::TATPMySQLConnector::getNewDestination(int s_id, int sf_type,
+                                                    int start_time,
+                                                    int end_time,
+                                                    std::string *numberx) {
+  session_.startTransaction();
+
+  mysqlx::SqlResult result =
+      select_call_forwarding_number_.bind(s_id, sf_type, start_time, end_time)
+          .execute();
+
+  if (mysqlx::Row row = result.fetchOne()) {
+    *numberx = row[0].get<std::string>();
+  }
+
+  session_.commit();
+}
+
+void txbench::TATPMySQLConnector::getAccessData(int s_id, int ai_type,
+                                                int *data1, int *data2,
+                                                std::string *data3,
+                                                std::string *data4) {
+  session_.startTransaction();
+
+  mysqlx::SqlResult result = select_access_data_.bind(s_id, ai_type).execute();
+
+  if (mysqlx::Row row = result.fetchOne()) {
+    *data1 = row[0].get<int>();
+    *data2 = row[1].get<int>();
+    *data3 = row[2].get<std::string>();
+    *data4 = row[3].get<std::string>();
+  }
+
+  session_.commit();
+}
+
+void txbench::TATPMySQLConnector::updateSubscriberData(int s_id, bool bit_1,
+                                                       int sf_type,
+                                                       int data_a) {
+  session_.startTransaction();
+
+  update_subscriber_bit_.bind(bit_1, s_id).execute();
+  update_special_facility_data_.bind(data_a, s_id, sf_type).execute();
+
+  session_.commit();
+}
+
+void txbench::TATPMySQLConnector::updateLocation(const std::string &sub_nbr,
+                                                 int vlr_location) {
+  session_.startTransaction();
+
+  update_subscriber_location_.bind(vlr_location, sub_nbr).execute();
+
+  session_.commit();
+}
+
+void txbench::TATPMySQLConnector::insertCallForwarding(
+    const std::string &sub_nbr, int sf_type, int start_time, int end_time,
+    const std::string &numberx) {
+  session_.startTransaction();
+
+  int s_id =
+      select_subscriber_id_.bind(sub_nbr).execute().fetchOne()[0].get<int>();
+  select_special_facility_type_.bind(s_id).execute();
+
+  try {
+    insert_into_call_forwarding_
+        .bind(s_id, sf_type, start_time, end_time, numberx)
+        .execute();
+
+    session_.commit();
+  } catch (mysqlx::Error &e) {
+    session_.rollback();
+  }
+}
+
+void txbench::TATPMySQLConnector::deleteCallForwarding(
+    const std::string &sub_nbr, int sf_type, int start_time) {
+  session_.startTransaction();
+
+  int s_id =
+      select_subscriber_id_.bind(sub_nbr).execute().fetchOne()[0].get<int>();
+  delete_from_call_forwarding_.bind(s_id, sf_type, start_time).execute();
+
+  session_.commit();
+}

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql_connector.h
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql_connector.h
@@ -1,0 +1,54 @@
+#ifndef TXBENCH__TATP_MYSQL_CONNECTOR_H
+#define TXBENCH__TATP_MYSQL_CONNECTOR_H
+
+#include "benchmarks/tatp/tatp_connector.h"
+#include <mysqlx/xdevapi.h>
+
+namespace txbench {
+
+class TATPMySQLConnector : public TATPConnector {
+public:
+  TATPMySQLConnector(const std::string &host, int port,
+                     const std::string &user);
+
+  void getSubscriberData(int s_id, std::string *sub_nbr,
+                         std::array<bool, 10> &bit, std::array<int, 10> &hex,
+                         std::array<int, 10> &byte2, int *msc_location,
+                         int *vlr_location) override;
+
+  void getNewDestination(int s_id, int sf_type, int start_time, int end_time,
+                         std::string *numberx) override;
+
+  void getAccessData(int s_id, int ai_type, int *data1, int *data2,
+                     std::string *data3, std::string *data4) override;
+
+  void updateSubscriberData(int s_id, bool bit_1, int sf_type,
+                            int data_a) override;
+
+  void updateLocation(const std::string &sub_nbr, int vlr_location) override;
+
+  void insertCallForwarding(const std::string &sub_nbr, int sf_type,
+                            int start_time, int end_time,
+                            const std::string &numberx) override;
+
+  void deleteCallForwarding(const std::string &sub_nbr, int sf_type,
+                            int start_time) override;
+
+private:
+  mysqlx::Session session_;
+
+  mysqlx::SqlStatement select_subscriber_data_;
+  mysqlx::SqlStatement select_call_forwarding_number_;
+  mysqlx::SqlStatement select_access_data_;
+  mysqlx::SqlStatement update_subscriber_bit_;
+  mysqlx::SqlStatement update_special_facility_data_;
+  mysqlx::SqlStatement update_subscriber_location_;
+  mysqlx::SqlStatement select_subscriber_id_;
+  mysqlx::SqlStatement select_special_facility_type_;
+  mysqlx::SqlStatement insert_into_call_forwarding_;
+  mysqlx::SqlStatement delete_from_call_forwarding_;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__TATP_MYSQL_CONNECTOR_H

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql_loader.cpp
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql_loader.cpp
@@ -1,0 +1,141 @@
+#include "tatp_mysql_loader.h"
+#include "benchmarks/tatp/tatp_util.h"
+#include "random_generator.h"
+#include <algorithm>
+#include <climits>
+#include <random>
+#include <iostream>
+
+txbench::TATPMySQLLoader::TATPMySQLLoader(int n_rows, const std::string &host,
+                                          int port, const std::string &user)
+    : n_rows_(n_rows), session_(host, port, user) {}
+
+void txbench::TATPMySQLLoader::load() {
+  std::random_device rd;
+  std::mt19937 mt(rd());
+
+  RandomGenerator rg;
+
+  session_.startTransaction();
+
+  mysqlx::Schema schema = session_.createSchema("tatp", true);
+
+  session_.sql("DROP TABLE IF EXISTS tatp.Call_Forwarding;").execute();
+  session_.sql("DROP TABLE IF EXISTS tatp.Special_Facility;").execute();
+  session_.sql("DROP TABLE IF EXISTS tatp.Access_Info;").execute();
+  session_.sql("DROP TABLE IF EXISTS tatp.Subscriber;").execute();
+
+  session_
+      .sql("CREATE TABLE tatp.Subscriber (s_id INTEGER, sub_nbr CHAR(15), "
+           "bit_1 BOOLEAN, bit_2 BOOLEAN, bit_3 BOOLEAN, bit_4 BOOLEAN, "
+           "bit_5 BOOLEAN, bit_6 BOOLEAN, bit_7 BOOLEAN, bit_8 BOOLEAN, "
+           "bit_9 BOOLEAN, bit_10 BOOLEAN, "
+           "hex_1 TINYINT, hex_2 TINYINT, hex_3 TINYINT, hex_4 TINYINT, "
+           "hex_5 TINYINT, hex_6 TINYINT, hex_7 TINYINT, hex_8 TINYINT, "
+           "hex_9 TINYINT, hex_10 TINYINT, "
+           "byte2_1 SMALLINT, byte2_2 SMALLINT, byte2_3 SMALLINT, "
+           "byte2_4 SMALLINT, byte2_5 SMALLINT, byte2_6 SMALLINT, "
+           "byte2_7 SMALLINT, byte2_8 SMALLINT, byte2_9 SMALLINT, "
+           "byte2_10 SMALLINT, "
+           "msc_location INTEGER, vlr_location INTEGER, "
+           "PRIMARY KEY (s_id));")
+      .execute();
+
+  session_
+      .sql("CREATE TABLE tatp.Access_Info (s_id INTEGER, ai_type TINYINT, "
+           "data1 SMALLINT, data2 SMALLINT, data3 CHAR(3), data4 CHAR(5), "
+           "PRIMARY KEY (s_id, ai_type), "
+           "FOREIGN KEY (s_id) REFERENCES tatp.Subscriber (s_id));")
+      .execute();
+
+  session_
+      .sql("CREATE TABLE tatp.Special_Facility (s_id INTEGER, sf_type TINYINT, "
+           "is_active BOOLEAN, error_cntrl SMALLINT, "
+           "data_a SMALLINT, data_b CHAR(5), "
+           "PRIMARY KEY (s_id, sf_type), "
+           "FOREIGN KEY (s_id) REFERENCES tatp.Subscriber (s_id));")
+      .execute();
+
+  session_
+      .sql("CREATE TABLE tatp.Call_Forwarding (s_id INTEGER, sf_type TINYINT, "
+           "start_time TINYINT, end_time TINYINT, numberx CHAR(15), "
+           "PRIMARY KEY (s_id, sf_type, start_time), "
+           "FOREIGN KEY (s_id, sf_type) "
+           "REFERENCES tatp.Special_Facility(s_id, sf_type));")
+      .execute();
+
+  std::vector<int> subscriber_ids(n_rows_);
+  std::iota(subscriber_ids.begin(), subscriber_ids.end(), 1);
+  std::shuffle(subscriber_ids.begin(), subscriber_ids.end(), mt);
+
+  for (int subscriber_id : subscriber_ids) {
+    mysqlx::Row row;
+
+    row.set(0, subscriber_id);
+    row.set(1, leading_zero_pad(15, std::to_string(subscriber_id)));
+
+    for (int i = 0; i < 10; ++i) {
+      row.set(2 + i, rg.random_bool());
+    }
+
+    for (int i = 0; i < 10; ++i) {
+      row.set(12 + i, rg.random_int(0, 15));
+    }
+
+    for (int i = 0; i < 10; ++i) {
+      row.set(22 + i, rg.random_int(0, 255));
+    }
+
+    row.set(32, rg.random_int(INT_MIN, INT_MAX));
+    row.set(33, rg.random_int(INT_MIN, INT_MAX));
+
+    schema.getTable("Subscriber").insert().values(row).execute();
+
+    int access_info_rows = rg.random_int(1, 4);
+    std::vector<int> ai_types_possible = {1, 2, 3, 4};
+    std::vector<int> ai_types;
+    std::sample(ai_types_possible.begin(), ai_types_possible.end(),
+                std::back_inserter(ai_types), access_info_rows, mt);
+
+    for (int ai_type : ai_types) {
+      schema.getTable("Access_Info")
+          .insert()
+          .values(subscriber_id, ai_type, rg.random_int(0, 255),
+                  rg.random_int(0, 255), uppercase_string(3, rg),
+                  uppercase_string(5, rg))
+          .execute();
+    }
+
+    int special_facility_rows = rg.random_int(1, 4);
+    std::vector<int> sf_types_possible = {1, 2, 3, 4};
+    std::vector<int> sf_types;
+    std::sample(sf_types_possible.begin(), sf_types_possible.end(),
+                std::back_inserter(sf_types), special_facility_rows, mt);
+
+    for (int sf_type : sf_types) {
+      schema.getTable("Special_Facility")
+          .insert()
+          .values(subscriber_id, sf_type, (int)(rg.random_int(0, 99) < 85),
+                  rg.random_int(0, 255), rg.random_int(0, 255),
+                  uppercase_string(5, rg))
+          .execute();
+
+      int call_forwarding_rows = rg.random_int(0, 3);
+      std::vector<int> start_times_possible = {0, 8, 16};
+      std::vector<int> start_times;
+      std::sample(start_times_possible.begin(), start_times_possible.end(),
+                  std::back_inserter(start_times), call_forwarding_rows, mt);
+
+      for (int start_time : start_times) {
+        schema.getTable("Call_Forwarding")
+            .insert()
+            .values(subscriber_id, sf_type, start_time,
+                    start_time + rg.random_int(1, 8), uppercase_string(15, rg))
+            .execute();
+      }
+    }
+  }
+
+  session_.commit();
+  session_.close();
+}

--- a/src/txbench/benchmarks/tatp_mysql/tatp_mysql_loader.h
+++ b/src/txbench/benchmarks/tatp_mysql/tatp_mysql_loader.h
@@ -1,0 +1,24 @@
+#ifndef TXBENCH_BENCHMARKS_TATP_MYSQL_TATP_MYSQL_LOADER_H_
+#define TXBENCH_BENCHMARKS_TATP_MYSQL_TATP_MYSQL_LOADER_H_
+
+#include "loader.h"
+#include <mysqlx/xdevapi.h>
+
+namespace txbench {
+
+class TATPMySQLLoader : public Loader {
+public:
+  TATPMySQLLoader(int n_rows, const std::string &host, int port,
+                  const std::string &user);
+
+  void load() override;
+
+private:
+  int n_rows_;
+
+  mysqlx::Session session_;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH_BENCHMARKS_TATP_MYSQL_TATP_MYSQL_LOADER_H_

--- a/src/txbench/loader.h
+++ b/src/txbench/loader.h
@@ -1,0 +1,13 @@
+#ifndef TXBENCH__LOADER_H_
+#define TXBENCH__LOADER_H_
+
+namespace txbench {
+
+class Loader {
+public:
+  virtual void load() = 0;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__LOADER_H_

--- a/src/txbench/random_generator.cpp
+++ b/src/txbench/random_generator.cpp
@@ -1,0 +1,8 @@
+#include "random_generator.h"
+
+int txbench::RandomGenerator::random_int(int a, int b) {
+  std::uniform_int_distribution<int> dis(a, b);
+  return dis(mt_);
+}
+
+bool txbench::RandomGenerator::random_bool() { return random_int(0, 1); }

--- a/src/txbench/random_generator.h
+++ b/src/txbench/random_generator.h
@@ -1,0 +1,22 @@
+#ifndef TXBENCH__RANDOM_GENERATOR_H_
+#define TXBENCH__RANDOM_GENERATOR_H_
+
+#include <random>
+
+namespace txbench {
+
+class RandomGenerator {
+public:
+  int random_int(int a, int b);
+
+  bool random_bool();
+
+private:
+  std::random_device rd_;
+
+  std::mt19937 mt_;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__RANDOM_GENERATOR_H_

--- a/src/txbench/worker.h
+++ b/src/txbench/worker.h
@@ -1,0 +1,18 @@
+#ifndef TXBENCH__WORKER_H
+#define TXBENCH__WORKER_H
+
+#include <atomic>
+
+namespace txbench {
+
+class Worker {
+public:
+  virtual ~Worker() = default;
+
+  virtual void run(std::atomic_bool &terminate,
+                   std::atomic_int &commit_count) = 0;
+};
+
+} // namespace txbench
+
+#endif // TXBENCH__WORKER_H

--- a/src/txbench/worker.h
+++ b/src/txbench/worker.h
@@ -11,6 +11,15 @@ public:
 
   virtual void run(std::atomic_bool &terminate,
                    std::atomic_int &commit_count) = 0;
+  virtual void print(int commit_count) = 0;
+
+  virtual double getTime1() = 0;
+  virtual double getTime2() = 0;
+  virtual double getTime3() = 0;
+  virtual double getTime4() = 0;
+  virtual double getTime5() = 0;
+  virtual double getTime6() = 0;
+  virtual double getTime7() = 0;
 };
 
 } // namespace txbench

--- a/src/txbench/worker.h
+++ b/src/txbench/worker.h
@@ -13,13 +13,7 @@ public:
                    std::atomic_int &commit_count) = 0;
   virtual void print(int commit_count) = 0;
 
-  virtual double getTime1() = 0;
-  virtual double getTime2() = 0;
-  virtual double getTime3() = 0;
-  virtual double getTime4() = 0;
-  virtual double getTime5() = 0;
-  virtual double getTime6() = 0;
-  virtual double getTime7() = 0;
+  virtual double getTime(int query_id) = 0;
 };
 
 } // namespace txbench

--- a/src/utils/bit_utils.h
+++ b/src/utils/bit_utils.h
@@ -66,6 +66,7 @@ static void pack(int64_t length, const uint8_t *arr,
 }
 
 static uint8_t* reverse_bytes(uint8_t* arr, int num_bytes) {
+    if (num_bytes == 0) return arr;
     uint8_t temp_value;
     uint32_t start_index = 0, end_index = num_bytes - 1;
     while (start_index < end_index) {

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -95,7 +95,7 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
             sqlite3_errmsg(db));
     return false;
   }
-  sqlite3_busy_timeout(db, 1000);
+  sqlite3_busy_timeout(db, 2000);
   rc = sqlite3_exec(db, sql.c_str(), nullptr, 0, &zErrMsg);
 
   if (rc != SQLITE_OK) {

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -43,8 +43,8 @@ static int callback_print_plan(void *result, int argc, char **argv,
 void initialize_sqlite3() {
   int rc = sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
   if (rc != SQLITE_OK) {
-    fprintf(stderr, "SQL config initialization error\n");
-    exit(1);
+    fprintf(stderr, "SQL config already in use and initialized.\n");
+    return;
   }
   sqlite3_initialize();
 }

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -88,13 +88,14 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
 
   rc = sqlite3_open_v2(
       sqlitePath.c_str(), &db,
-      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_CONFIG_MULTITHREAD,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX,
       nullptr);
   if (rc) {
     fprintf(stderr, "Can't open sqlite catalog database: %s\n",
             sqlite3_errmsg(db));
     return false;
   }
+  sqlite3_busy_timeout(db, 1000);
   rc = sqlite3_exec(db, sql.c_str(), nullptr, 0, &zErrMsg);
 
   if (rc != SQLITE_OK) {

--- a/src/utils/sqlite_utils.h
+++ b/src/utils/sqlite_utils.h
@@ -21,6 +21,8 @@
 namespace hustle {
 namespace utils {
 
+void initialize_sqlite3();
+
 // Executes the sql query specified in sql on the database at sqlitePath,
 // no output is returned.
 bool executeSqliteNoOutput(const std::string &sqlitePath,

--- a/third_party/sqlite3/CMakeLists.txt
+++ b/third_party/sqlite3/CMakeLists.txt
@@ -3,6 +3,5 @@ add_library(
         sqlite3.c
 		sqlite3.h
 )
-set(CMAKE_CXX_FLAGS "-DSQLITE_THREADSAFE=0")
 
 target_link_libraries(sqlite3 PUBLIC ${CMAKE_DL_LIBS} hustle_src_resolver hustle_src_storage)

--- a/third_party/sqlite3/CMakeLists.txt
+++ b/third_party/sqlite3/CMakeLists.txt
@@ -3,5 +3,6 @@ add_library(
         sqlite3.c
 		sqlite3.h
 )
+set(CMAKE_CXX_FLAGS "-DSQLITE_THREADSAFE=0")
 
 target_link_libraries(sqlite3 PUBLIC ${CMAKE_DL_LIBS} hustle_src_resolver hustle_src_storage)


### PR DESCRIPTION
### Summary

* Added the in-place update to arrow arrays for primitive column types.
* Added TATP Benchmark suite and added module for the hustle.
* Sqlite3 DB Open Config - Multithreaded and Busy wait handler.
* Added scripts to run the TATP benchmark.
* Updated Readme to run the benchmark and the argument options

Many files in  **src/txbench/** are moved from the dibs repo, some are modified and a new TATP submodule for hustle is added.