### PR TITLE
Hustle Load Tables from database file and other improvements

### DIFF
--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -82,8 +82,8 @@ bool HustleDB::dropTable(const std::string &name) {
   return catalog_->dropTable(name);
 }
 
-bool HustleDB::deleteTable(const std::string &name) {
-  return catalog_->deleteTable(name);
+bool HustleDB::clearMemTable(const std::string &name) {
+  return catalog_->clearMemTable(name);
 }
 
 bool HustleDB::insert() {

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -67,7 +67,7 @@ bool HustleDB::createTable(const TableSchema ts,
 }
 
 void HustleDB::loadTables() {
-  utils::loadTables(SqliteDBPath_);
+  utils::loadTables(SqliteDBPath_, hustle::HustleDB::catalogs[SqliteDBPath_]->getTables());
 }
 
 std::string HustleDB::executeQuery(const std::string &sql) {

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -82,8 +82,8 @@ bool HustleDB::dropTable(const std::string &name) {
   return catalog_->dropTable(name);
 }
 
-bool HustleDB::clearMemTable(const std::string &name) {
-  return catalog_->clearMemTable(name);
+bool HustleDB::dropMemTable(const std::string &name) {
+  return catalog_->dropMemTable(name);
 }
 
 bool HustleDB::insert() {

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -66,6 +66,10 @@ bool HustleDB::createTable(const TableSchema ts,
   return catalog_->addTable(ts, table_ref);
 }
 
+void HustleDB::loadTables() {
+  utils::loadTables(SqliteDBPath_);
+}
+
 std::string HustleDB::executeQuery(const std::string &sql) {
   return utils::executeSqliteReturnOutputString(SqliteDBPath_, sql);
 }

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -82,6 +82,10 @@ bool HustleDB::dropTable(const std::string &name) {
   return catalog_->dropTable(name);
 }
 
+bool HustleDB::deleteTable(const std::string &name) {
+  return catalog_->deleteTable(name);
+}
+
 bool HustleDB::insert() {
   // TODO(nicholas) once arrow is integrated
   return true;

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -50,7 +50,7 @@ class HustleDB {
 
   bool dropTable(const std::string &name);
 
-  bool deleteTable(const std::string &name);
+  bool clearMemTable(const std::string &name);
 
   std::string executeQuery(const std::string &sql);
 

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -50,6 +50,8 @@ class HustleDB {
 
   bool dropTable(const std::string &name);
 
+  bool deleteTable(const std::string &name);
+
   std::string executeQuery(const std::string &sql);
 
   bool executeNoOutputQuery(const std::string &sql);

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -50,7 +50,7 @@ class HustleDB {
 
   bool dropTable(const std::string &name);
 
-  bool clearMemTable(const std::string &name);
+  bool dropMemTable(const std::string &name);
 
   std::string executeQuery(const std::string &sql);
 

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -46,6 +46,8 @@ class HustleDB {
 
   bool createTable(const TableSchema ts, std::shared_ptr<DBTable> table_ref);
 
+  void loadTables();
+
   bool dropTable(const std::string &name);
 
   std::string executeQuery(const std::string &sql);

--- a/src/api/tests/hustle_db_test.cc
+++ b/src/api/tests/hustle_db_test.cc
@@ -82,15 +82,15 @@ TEST(HustleDB, DropTable) {
   ts.setPrimaryKey({"c1", "c2"});
   EXPECT_TRUE(hustleDB.createTable(ts));
 
-  EXPECT_TRUE(hustleDB.getCatalog()->TableExists(ts.getName()));
+  EXPECT_TRUE(hustle::HustleDB::getCatalog("db_directory/db_dir_nested/hustle_sqlite.db")->TableExists(ts.getName()));
 
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/catalog.json"));
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/hustle_sqlite.db"));
-
+  
   EXPECT_TRUE(hustleDB.dropTable(ts.getName()));
-  EXPECT_FALSE(hustleDB.getCatalog()->TableExists(ts.getName()));
+  EXPECT_FALSE(hustle::HustleDB::getCatalog("db_directory/db_dir_nested/hustle_sqlite.db")->TableExists(ts.getName()));
 
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/catalog.json"));

--- a/src/catalog/catalog.cc
+++ b/src/catalog/catalog.cc
@@ -87,7 +87,7 @@ Catalog Catalog::CreateCatalog(std::string CatalogPath,
     }
     // Rebuild the sqlite db catalog.
     for (const auto &t : catalog.tables_) {
-      utils::executeSqliteNoOutput(SqlitePath, createCreateSql(t));
+      utils::executeSqliteNoOutput(SqlitePath, createCreateSql(t.second.table_schema));
     }
     return catalog;
   } else {
@@ -106,14 +106,11 @@ std::shared_ptr<DBTable> Catalog::getTable(size_t table_id) {
 }
 
 std::shared_ptr<DBTable> Catalog::getTable(std::string name) {
-  auto search = name_to_id_.find(name);
-  if (search == name_to_id_.end()) {
+  auto search = tables_.find(name);
+  if (search == tables_.end()) {
     return nullptr;
   }
-  if (name_to_id_[name] < table_refs_.size()) {
-    return table_refs_[name_to_id_[name]];
-  }
-  return nullptr;
+  return tables_[name].table;
 }
 
 void Catalog::SaveToFile() {
@@ -129,57 +126,43 @@ void Catalog::SaveToFile() {
 }
 
 bool Catalog::dropTable(std::string name) {
-  auto search = name_to_id_.find(name);
-  if (search == name_to_id_.end()) {
-    return false;
-  }
-
   if (!utils::executeSqliteNoOutput(SqlitePath_,
                                     absl::StrCat("DROP TABLE ", name, ";"))) {
     std::cerr << "SqliteDB catalog out of sync" << std::endl;
   }
+  return this->deleteTable(name);
+}
 
-  tables_.erase(tables_.begin());
-  name_to_id_.erase(search);
+bool Catalog::deleteTable(std::string name) {
+  auto search = tables_.find(name);
+  if (search == tables_.end()) {
+    return false;
+  }
+  tables_.erase(search);
   SaveToFile();
   return true;
 }
 
 std::optional<TableSchema *> Catalog::TableExists(std::string name) {
-  auto search = name_to_id_.find(name);
-  if (search == name_to_id_.end()) {
+  auto search = tables_.find(name);
+  if (search == tables_.end()) {
     return std::nullopt;
   }
 
-  return &tables_[name_to_id_[name]];
+  return &tables_[name].table_schema;
 }
 
 bool Catalog::addTable(TableSchema t) {
-  auto search = name_to_id_.find(t.getName());
-  if (search != name_to_id_.end()) {
-    return false;
-  }
-
-  tables_.push_back(t);
-  name_to_id_[t.getName()] = tables_.size() - 1;
-  SaveToFile();
-
-  if (!utils::executeSqliteNoOutput(SqlitePath_, createCreateSql(t))) {
-    std::cerr << "SqliteDB catalog out of sync" << std::endl;
-  }
-  return true;
+  return this->addTable(t, nullptr);
 }
 
 bool Catalog::addTable(TableSchema t, std::shared_ptr<DBTable> table_ref) {
-  auto search = name_to_id_.find(t.getName());
-  if (search != name_to_id_.end()) {
+ auto search = tables_.find(t.getName());
+  if (search != tables_.end()) {
     return false;
   }
 
-  tables_.push_back(t);
-  table_refs_.push_back(table_ref);
-  name_to_id_[t.getName()] = tables_.size() - 1;
-
+  tables_[t.getName()] = {t, table_ref};
   SaveToFile();
 
   if (!utils::executeSqliteNoOutput(SqlitePath_, createCreateSql(t))) {
@@ -193,7 +176,7 @@ void Catalog::print() const {
   std::cout << "Catalog File Path: " << CatalogPath_ << std::endl;
   std::cout << "Sqlite Catalog File Path: " << SqlitePath_ << std::endl;
   for (const auto &t : tables_) {
-    t.print();
+    t.second.table_schema.print();
   }
   std::cout << "----------- ----------- --------" << std::endl;
 }

--- a/src/catalog/catalog.cc
+++ b/src/catalog/catalog.cc
@@ -129,11 +129,12 @@ bool Catalog::dropTable(std::string name) {
   if (!utils::executeSqliteNoOutput(SqlitePath_,
                                     absl::StrCat("DROP TABLE ", name, ";"))) {
     std::cerr << "SqliteDB catalog out of sync" << std::endl;
+    return false;
   }
-  return this->deleteTable(name);
+  return true;
 }
 
-bool Catalog::deleteTable(std::string name) {
+bool Catalog::clearMemTable(std::string name) {
   auto search = tables_.find(name);
   if (search == tables_.end()) {
     return false;

--- a/src/catalog/catalog.cc
+++ b/src/catalog/catalog.cc
@@ -134,7 +134,7 @@ bool Catalog::dropTable(std::string name) {
   return true;
 }
 
-bool Catalog::clearMemTable(std::string name) {
+bool Catalog::dropMemTable(std::string name) {
   auto search = tables_.find(name);
   if (search == tables_.end()) {
     return false;

--- a/src/catalog/catalog.h
+++ b/src/catalog/catalog.h
@@ -63,6 +63,8 @@ class Catalog {
   std::shared_ptr<DBTable> getTable(size_t table_id);
   std::shared_ptr<DBTable> getTable(std::string table_name);
 
+  std::map<std::string, int>& getTables(){ return name_to_id_; }
+
   int getTableIdbyName(const std::string& name) { return name_to_id_[name]; }
 
   // Used by cereal for serialization/deserialization

--- a/src/catalog/catalog.h
+++ b/src/catalog/catalog.h
@@ -65,7 +65,7 @@ class Catalog {
   bool addTable(TableSchema t);
   bool addTable(TableSchema t, std::shared_ptr<DBTable> table_ref);
 
-  bool deleteTable(std::string name);
+  bool clearMemTable(std::string name);
 
   bool dropTable(std::string name);
 

--- a/src/catalog/catalog.h
+++ b/src/catalog/catalog.h
@@ -65,7 +65,7 @@ class Catalog {
   bool addTable(TableSchema t);
   bool addTable(TableSchema t, std::shared_ptr<DBTable> table_ref);
 
-  bool clearMemTable(std::string name);
+  bool dropMemTable(std::string name);
 
   bool dropTable(std::string name);
 

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -46,10 +46,10 @@ void memlog_remove_table_mapping(int db_id, char* db_name, char *tbl_name) {
   auto table_itr = table_map[db_id].begin();
   std::string tbl_name_str = std::string(tbl_name);
   while (table_itr != table_map[db_id].end()) {
-
     if (table_itr->second.compare(tbl_name_str) == 0) {
       table_map[db_id].erase(table_itr->first);
-      catalog->dropTable(tbl_name_str);
+      catalog->clearMemTable(tbl_name_str);
+      break;
     }
     table_itr++;
   }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -48,7 +48,7 @@ void memlog_remove_table_mapping(int db_id, char* db_name, char *tbl_name) {
   while (table_itr != table_map[db_id].end()) {
     if (table_itr->second.compare(tbl_name_str) == 0) {
       table_map[db_id].erase(table_itr->first);
-      catalog->clearMemTable(tbl_name_str);
+      catalog->dropMemTable(tbl_name_str);
       break;
     }
     table_itr++;

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -218,11 +218,9 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
           }
           // Insert record to the arrow table
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
-            // std::cout << "Insert record " << std::endl;
             table->insert_record_table(head->rowId, record_data + hdrLen,
                                        widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
-            std::cout << "Update record " << std::endl;
             table->update_record_table(head->rowId, head->nUpdateMetaInfo,
                                        head->updateMetaInfo,
                                        record_data + hdrLen, widths);

--- a/src/storage/cmemlog.h
+++ b/src/storage/cmemlog.h
@@ -88,6 +88,8 @@ Status hustle_memlog_initialize(HustleMemLog **mem_log, char *db_name,
 
 void memlog_add_table_mapping(int db_id, int root_page_id, char *table_name);
 
+void memlog_remove_table_mapping(int db_id, char* db_name, char *table_name);
+
 /**
  * Create a DBRecord - each node in the linkedlist.
  * data - SQLite's data record format with header in the begining

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -229,6 +229,7 @@ class DBTable {
 
 template <typename Functor>
 void DBTable::ForEachBatch(const Functor &functor) const {
+  if (this->get_num_blocks() == 0) return;
   size_t batch_size =
       this->get_num_blocks() / std::thread::hardware_concurrency();
   if (batch_size == 0) batch_size = this->get_num_blocks();

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -229,7 +229,7 @@ class DBTable {
 
 template <typename Functor>
 void DBTable::ForEachBatch(const Functor &functor) const {
-  if (this->get_num_blocks() == 0) return;
+  //if (this->get_num_blocks() == 0) return;
   size_t batch_size =
       this->get_num_blocks() / std::thread::hardware_concurrency();
   if (batch_size == 0) batch_size = this->get_num_blocks();

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -389,3 +389,67 @@ TEST_F(HustleTableTest, Delete) {
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
 }
 
+
+
+
+TEST_F(HustleTableTest, Load) {
+  std::filesystem::remove("catalog.json");
+  std::filesystem::remove("hustle_sqlite.db");
+  std::filesystem::remove_all("db_directory");
+  std::filesystem::remove_all("db_directory5");
+  // Create table customer
+  hustle::catalog::TableSchema customer("customer_table_test");
+  hustle::catalog::ColumnSchema c_suppkey(
+      "c_custkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+  hustle::catalog::ColumnSchema c_name(
+      "c_name", {hustle::catalog::HustleType::CHAR, 25}, true, false);
+  hustle::catalog::ColumnSchema c_address(
+      "c_address", {hustle::catalog::HustleType::CHAR, 25}, true, false);
+  hustle::catalog::ColumnSchema c_city(
+      "c_city", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+  hustle::catalog::ColumnSchema c_nation(
+      "c_nation", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+  hustle::catalog::ColumnSchema c_region(
+      "c_region", {hustle::catalog::HustleType::CHAR, 12}, true, false);
+  hustle::catalog::ColumnSchema c_phone(
+      "c_phone", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+  hustle::catalog::ColumnSchema c_mktsegment(
+      "c_mktsegment", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+  customer.addColumn(c_suppkey);
+  customer.addColumn(c_name);
+  customer.addColumn(c_address);
+  customer.addColumn(c_city);
+  customer.addColumn(c_nation);
+  customer.addColumn(c_region);
+  customer.addColumn(c_phone);
+  customer.addColumn(c_mktsegment);
+  customer.setPrimaryKey({});
+  std::shared_ptr<arrow::Schema> c_schema = customer.getArrowSchema();
+
+  std::string query =
+      "BEGIN TRANSACTION; "
+      "INSERT INTO customer_table_test VALUES (800224, 'James', "
+      " 'good',"
+      "'Houston', 'Great',"
+      "         'best', 'fit', 'done');"
+       "INSERT INTO customer_table_test VALUES (800225, 'James1', "
+      " 'good1',"
+      "'Houston1', 'Great1',"
+      "         'best', 'fit', 'done');"
+      "COMMIT;";
+  std::shared_ptr<DBTable> c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
+  hustle::HustleDB hustleDB("db_directory5");
+  hustleDB.createTable(customer, c); 
+  hustleDB.executeQuery(query);
+  EXPECT_EQ(c->get_num_rows(), 2);
+  EXPECT_EQ(c->get_num_cols(), 8);
+
+  hustleDB.deleteTable("customer_table_test");
+  c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
+  hustleDB.createTable(customer, c); 
+  hustleDB.loadTables();
+  EXPECT_EQ(c->get_num_rows(), 2);
+
+}
+
+

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -445,7 +445,7 @@ TEST_F(HustleTableTest, Load) {
   EXPECT_EQ(c->get_num_rows(), 2);
   EXPECT_EQ(c->get_num_cols(), 8);
 
-  hustleDB.clearMemTable("customer_table_test");
+  hustleDB.dropMemTable("customer_table_test");
   c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
   hustleDB.createTable(customer, c);
   hustleDB.loadTables();

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -466,7 +466,7 @@ TEST_F(HustleTableTest, Load) {
   hustleDB.executeQuery(query);
 
   auto int_col =
-      std::static_pointer_cast<arrow::Int64Array>(c->get_column(7)->chunk(0));
-  EXPECT_EQ(int_col->Value(0), 1123);
+      std::static_pointer_cast<arrow::StringArray>(c->get_column(1)->chunk(0));
+  EXPECT_EQ(int_col->GetString(0), "James1");
   EXPECT_EQ(c->get_num_rows(), 1);
 }

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -16,13 +16,14 @@
 // under the License.
 
 #include "storage/table.h"
-#include "api/hustle_db.h"
+
 #include <arrow/io/api.h>
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 
+#include "api/hustle_db.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "storage/util.h"
@@ -198,7 +199,6 @@ TEST_F(HustleTableTest, ReadTableFromCSV) {
       *table.get_block(1)->get_records()));
 }
 
-
 TEST_F(HustleTableTest, Insert) {
   std::filesystem::remove("catalog.json");
   std::filesystem::remove("hustle_sqlite.db");
@@ -238,14 +238,15 @@ TEST_F(HustleTableTest, Insert) {
       " 'good',"
       "'Houston', 'Great',"
       "         'best', 'fit', 'done');"
-       "INSERT INTO customer_table_test VALUES (800225, 'James1', "
+      "INSERT INTO customer_table_test VALUES (800225, 'James1', "
       " 'good1',"
       "'Houston1', 'Great1',"
       "         'best', 'fit', 'done');"
       "COMMIT;";
-  std::shared_ptr<DBTable> c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
+  std::shared_ptr<DBTable> c =
+      std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory");
-  hustleDB.createTable(customer, c); 
+  hustleDB.createTable(customer, c);
   hustleDB.executeQuery(query);
   EXPECT_EQ(c->get_num_rows(), 2);
   EXPECT_EQ(c->get_num_cols(), 8);
@@ -282,7 +283,8 @@ TEST_F(HustleTableTest, Update) {
   customer_table.addColumn(c_phone);
   customer_table.addColumn(c_mktsegment);
   customer_table.setPrimaryKey({});
-  std::shared_ptr<arrow::Schema> customer_schema = customer_table.getArrowSchema();
+  std::shared_ptr<arrow::Schema> customer_schema =
+      customer_table.getArrowSchema();
 
   std::string query =
       "BEGIN TRANSACTION; "
@@ -291,9 +293,10 @@ TEST_F(HustleTableTest, Update) {
       "'Houston', 'Great',"
       "         'best', 'fit', 12);"
       "COMMIT;";
-  std::shared_ptr<DBTable> customer_table_ptr = std::make_shared<DBTable>("customer_table", customer_schema, BLOCK_SIZE);
+  std::shared_ptr<DBTable> customer_table_ptr =
+      std::make_shared<DBTable>("customer_table", customer_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory2");
-  hustleDB.createTable(customer_table, customer_table_ptr); 
+  hustleDB.createTable(customer_table, customer_table_ptr);
   hustleDB.executeQuery(query);
 
   query =
@@ -302,8 +305,8 @@ TEST_F(HustleTableTest, Update) {
       "COMMIT;";
 
   hustleDB.executeQuery(query);
-  auto col = std::static_pointer_cast<arrow::StringArray>(customer_table_ptr->
-                                                          get_column(5)->chunk(0));
+  auto col = std::static_pointer_cast<arrow::StringArray>(
+      customer_table_ptr->get_column(5)->chunk(0));
 
   EXPECT_EQ(col->GetString(0), "fine");
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 1);
@@ -311,8 +314,8 @@ TEST_F(HustleTableTest, Update) {
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
 
-  auto int_col = std::static_pointer_cast<arrow::Int64Array>(customer_table_ptr->
-                                                          get_column(7)->chunk(0));
+  auto int_col = std::static_pointer_cast<arrow::Int64Array>(
+      customer_table_ptr->get_column(7)->chunk(0));
   EXPECT_EQ(int_col->Value(0), 12);
   query =
       "BEGIN TRANSACTION;"
@@ -325,9 +328,7 @@ TEST_F(HustleTableTest, Update) {
 
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
-
 }
-
 
 TEST_F(HustleTableTest, Delete) {
   std::filesystem::remove("catalog.json");
@@ -360,7 +361,8 @@ TEST_F(HustleTableTest, Delete) {
   customer_table.addColumn(c_phone);
   customer_table.addColumn(c_mktsegment);
   customer_table.setPrimaryKey({});
-  std::shared_ptr<arrow::Schema> customer_schema = customer_table.getArrowSchema();
+  std::shared_ptr<arrow::Schema> customer_schema =
+      customer_table.getArrowSchema();
 
   std::string query =
       "BEGIN TRANSACTION; "
@@ -369,9 +371,10 @@ TEST_F(HustleTableTest, Delete) {
       "'Houston', 'Great',"
       "         'best', 'fit', 'done');"
       "COMMIT;";
-  std::shared_ptr<DBTable> customer_table_ptr = std::make_shared<DBTable>("customer_table_d", customer_schema, BLOCK_SIZE);
+  std::shared_ptr<DBTable> customer_table_ptr = std::make_shared<DBTable>(
+      "customer_table_d", customer_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory3");
-  hustleDB.createTable(customer_table, customer_table_ptr); 
+  hustleDB.createTable(customer_table, customer_table_ptr);
   hustleDB.executeQuery(query);
 
   query =
@@ -380,8 +383,8 @@ TEST_F(HustleTableTest, Delete) {
       "COMMIT;";
 
   hustleDB.executeQuery(query);
-  auto col = std::static_pointer_cast<arrow::StringArray>(customer_table_ptr->
-                                                          get_column(5)->chunk(0));
+  auto col = std::static_pointer_cast<arrow::StringArray>(
+      customer_table_ptr->get_column(5)->chunk(0));
 
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 0);
 
@@ -429,24 +432,41 @@ TEST_F(HustleTableTest, Load) {
       " 'good',"
       "'Houston', 'Great',"
       "         'best', 'fit', 'done');"
-       "INSERT INTO customer_table_test VALUES (800225, 'James1', "
+      "INSERT INTO customer_table_test VALUES (800225, 'James1', "
       " 'good1',"
       "'Houston1', 'Great1',"
       "         'best', 'fit', 'done');"
       "COMMIT;";
-  std::shared_ptr<DBTable> c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
+  std::shared_ptr<DBTable> c =
+      std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory5");
-  hustleDB.createTable(customer, c); 
+  hustleDB.createTable(customer, c);
   hustleDB.executeQuery(query);
   EXPECT_EQ(c->get_num_rows(), 2);
   EXPECT_EQ(c->get_num_cols(), 8);
 
   hustleDB.clearMemTable("customer_table_test");
   c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
-  hustleDB.createTable(customer, c); 
+  hustleDB.createTable(customer, c);
   hustleDB.loadTables();
   EXPECT_EQ(c->get_num_rows(), 2);
 
+  query =
+      "BEGIN TRANSACTION;"
+      "DELETE FROM customer_table_test where c_custkey=800224;"
+      "COMMIT;";
+  hustleDB.executeQuery(query);
+  EXPECT_EQ(c->get_num_rows(), 1);
+
+  query =
+      "BEGIN TRANSACTION;"
+      "UPDATE customer_table_test set c_mktsegment = 1123 where "
+      "c_custkey=800225;"
+      "COMMIT;";
+  hustleDB.executeQuery(query);
+
+  auto int_col =
+      std::static_pointer_cast<arrow::Int64Array>(c->get_column(7)->chunk(0));
+  EXPECT_EQ(int_col->Value(0), 1123);
+  EXPECT_EQ(c->get_num_rows(), 1);
 }
-
-

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -389,9 +389,6 @@ TEST_F(HustleTableTest, Delete) {
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
 }
 
-
-
-
 TEST_F(HustleTableTest, Load) {
   std::filesystem::remove("catalog.json");
   std::filesystem::remove("hustle_sqlite.db");
@@ -444,7 +441,7 @@ TEST_F(HustleTableTest, Load) {
   EXPECT_EQ(c->get_num_rows(), 2);
   EXPECT_EQ(c->get_num_cols(), 8);
 
-  hustleDB.deleteTable("customer_table_test");
+  hustleDB.clearMemTable("customer_table_test");
   c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
   hustleDB.createTable(customer, c); 
   hustleDB.loadTables();

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -52,15 +52,15 @@ void initialize_sqlite3() {
 }
 
 void loadTables(const std::string &sqlitePath,
-                std::map<std::string, int> &tables) {
+                std::vector<std::string> tables) {
   sqlite3 *db;
   int rc = sqlite3_open_v2(
       sqlitePath.c_str(), &db,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_CONFIG_MULTITHREAD,
       nullptr);
-  for (auto const &table_elem : tables) {
-    std::cout << "table elem: " << table_elem.first << std::endl;
-    sqlite3_load_hustle(db, table_elem.first.c_str());
+  for (auto const &table_name : tables) {
+    std::cout << "table elem: " << table_name << std::endl;
+    sqlite3_load_hustle(db, table_name.c_str());
   }
   sqlite3_close(db);
 }

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -17,8 +17,8 @@
 
 #include <iostream>
 
-#include "absl/strings/str_cat.h"
 #include "sqlite3/sqlite3.h"
+#include "absl/strings/str_cat.h"
 
 namespace hustle {
 namespace utils {
@@ -48,6 +48,17 @@ void initialize_sqlite3() {
   }
   sqlite3_initialize();
 }
+
+void loadTables(const std::string &sqlitePath) {
+  sqlite3 *db;
+  int rc = sqlite3_open_v2(
+      sqlitePath.c_str(), &db,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_CONFIG_MULTITHREAD,
+      nullptr);
+  sqlite3_load_hustle(db);
+  sqlite3_close(db);
+}
+
 // Executes the sql statement on sqlite database at the sqlitePath path.
 // Returns
 std::string executeSqliteReturnOutputString(const std::string &sqlitePath,
@@ -67,7 +78,8 @@ std::string executeSqliteReturnOutputString(const std::string &sqlitePath,
             sqlite3_errmsg(db));
   }
 
-  rc = sqlite3_exec(db, "PRAGMA journal_mode=WAL;", callback_print_plan, &result, &zErrMsg);
+  rc = sqlite3_exec(db, "PRAGMA journal_mode=WAL;", callback_print_plan,
+                    &result, &zErrMsg);
 
   if (rc != SQLITE_OK) {
     fprintf(stderr, "SQL error: %s\n", zErrMsg);
@@ -105,7 +117,8 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
   }
   sqlite3_busy_timeout(db, 2000);
 
-  rc = sqlite3_exec(db, "PRAGMA journal_mode=WAL;", callback_print_plan, &result, &zErrMsg);
+  rc = sqlite3_exec(db, "PRAGMA journal_mode=WAL;", callback_print_plan,
+                    &result, &zErrMsg);
 
   if (rc != SQLITE_OK) {
     fprintf(stderr, "SQL error: %s\n", zErrMsg);

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -15,10 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "utils/sqlite_utils.h"
+
 #include <iostream>
 
-#include "sqlite3/sqlite3.h"
 #include "absl/strings/str_cat.h"
+#include "sqlite3/sqlite3.h"
 
 namespace hustle {
 namespace utils {
@@ -49,13 +51,17 @@ void initialize_sqlite3() {
   sqlite3_initialize();
 }
 
-void loadTables(const std::string &sqlitePath) {
+void loadTables(const std::string &sqlitePath,
+                std::map<std::string, int> &tables) {
   sqlite3 *db;
   int rc = sqlite3_open_v2(
       sqlitePath.c_str(), &db,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_CONFIG_MULTITHREAD,
       nullptr);
-  sqlite3_load_hustle(db);
+  for (auto const &table_elem : tables) {
+    std::cout << "table elem: " << table_elem.first << std::endl;
+    sqlite3_load_hustle(db, table_elem.first.c_str());
+  }
   sqlite3_close(db);
 }
 

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -30,8 +30,7 @@ namespace {
 // The callback function used by sqlite
 static int callback_print_plan(void *result, int argc, char **argv,
                                char **azColName) {
-  int i;
-  for (i = 0; i < argc; i++) {
+  for (int i = 0; i < argc; i++) {
     if (std::strcmp(azColName[i], "detail") == 0) {
       absl::StrAppend((std::string *)result, argv[i]);
       absl::StrAppend((std::string *)result, "\n");

--- a/src/utils/sqlite_utils.cc
+++ b/src/utils/sqlite_utils.cc
@@ -67,6 +67,13 @@ std::string executeSqliteReturnOutputString(const std::string &sqlitePath,
             sqlite3_errmsg(db));
   }
 
+  rc = sqlite3_exec(db, "PRAGMA journal_mode=WAL;", callback_print_plan, &result, &zErrMsg);
+
+  if (rc != SQLITE_OK) {
+    fprintf(stderr, "SQL error: %s\n", zErrMsg);
+    sqlite3_free(zErrMsg);
+  }
+
   rc = sqlite3_exec(db, sql.c_str(), callback_print_plan, &result, &zErrMsg);
 
   if (rc != SQLITE_OK) {
@@ -85,6 +92,7 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
   sqlite3 *db;
   char *zErrMsg = 0;
   int rc;
+  std::string result;
 
   rc = sqlite3_open_v2(
       sqlitePath.c_str(), &db,
@@ -96,6 +104,14 @@ bool executeSqliteNoOutput(const std::string &sqlitePath,
     return false;
   }
   sqlite3_busy_timeout(db, 2000);
+
+  rc = sqlite3_exec(db, "PRAGMA journal_mode=WAL;", callback_print_plan, &result, &zErrMsg);
+
+  if (rc != SQLITE_OK) {
+    fprintf(stderr, "SQL error: %s\n", zErrMsg);
+    sqlite3_free(zErrMsg);
+  }
+
   rc = sqlite3_exec(db, sql.c_str(), nullptr, 0, &zErrMsg);
 
   if (rc != SQLITE_OK) {

--- a/src/utils/sqlite_utils.h
+++ b/src/utils/sqlite_utils.h
@@ -19,6 +19,7 @@
 #define HUSTLE_SQLITE_UTILS_H
 
 #include <map>
+#include <vector>
 
 namespace hustle {
 namespace utils {

--- a/src/utils/sqlite_utils.h
+++ b/src/utils/sqlite_utils.h
@@ -23,6 +23,8 @@ namespace utils {
 
 void initialize_sqlite3();
 
+void loadTables(const std::string &sqlitePath);
+
 // Executes the sql query specified in sql on the database at sqlitePath,
 // no output is returned.
 bool executeSqliteNoOutput(const std::string &sqlitePath,

--- a/src/utils/sqlite_utils.h
+++ b/src/utils/sqlite_utils.h
@@ -18,12 +18,14 @@
 #ifndef HUSTLE_SQLITE_UTILS_H
 #define HUSTLE_SQLITE_UTILS_H
 
+#include <map>
+
 namespace hustle {
 namespace utils {
 
 void initialize_sqlite3();
 
-void loadTables(const std::string &sqlitePath);
+void loadTables(const std::string &sqlitePath, std::map<std::string, int>& tables);
 
 // Executes the sql query specified in sql on the database at sqlitePath,
 // no output is returned.

--- a/src/utils/sqlite_utils.h
+++ b/src/utils/sqlite_utils.h
@@ -25,7 +25,7 @@ namespace utils {
 
 void initialize_sqlite3();
 
-void loadTables(const std::string &sqlitePath, std::map<std::string, int>& tables);
+void loadTables(const std::string &sqlitePath, std::vector<std::string> tables);
 
 // Executes the sql query specified in sql on the database at sqlitePath,
 // no output is returned.

--- a/third_party/sqlite3/sqlite3.h
+++ b/third_party/sqlite3/sqlite3.h
@@ -415,7 +415,7 @@ SQLITE_API int sqlite3_exec(
   char **errmsg                              /* Error msg written here */
 );
 
-SQLITE_API int sqlite3_load_hustle(sqlite3 *db);
+SQLITE_API int sqlite3_load_hustle(sqlite3 *db, const char* tblName);
 
 
 // @suryadev - Added to get parse tree for the SQL query. (For Resolver tests)

--- a/third_party/sqlite3/sqlite3.h
+++ b/third_party/sqlite3/sqlite3.h
@@ -415,6 +415,9 @@ SQLITE_API int sqlite3_exec(
   char **errmsg                              /* Error msg written here */
 );
 
+SQLITE_API int sqlite3_load_hustle(sqlite3 *db);
+
+
 // @suryadev - Added to get parse tree for the SQL query. (For Resolver tests)
 typedef struct Select Select;
 


### PR DESCRIPTION
### Summary

* Added a new vdbe opcode in sqlite3 to load tables from the database files to the arrow arrays.
* Added capability to the query execution to execute in WAL mode.
* Handled Drop table query in SQLite3 to remove the arrow memory table and other meta-data mappings.
* Unit Tests and utility functions in the catalog module to handle addition and deletion of mapping. 

The core changes are in the file, **third_party/sqlite3/sqlite3.c**
