### PR TITLE
Resolve SQL Agg Operators containing expression 

### DIFF
--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -413,6 +413,10 @@ void Aggregate::ComputeAggregates(Task* ctx) {
         // TODO(nicholas): For now, we only perform one aggregate.
         auto table = aggregate_refs_[0].col_ref.table;
         auto col_name = aggregate_refs_[0].col_ref.col_name;
+
+        if (table == nullptr) {
+          throw std::runtime_error("Non-supported aggregation");
+        }
         agg_lazy_table_ = prev_result_->get_table(table);
         agg_lazy_table_.get_column_by_name(internal, col_name, agg_col_);
       }),

--- a/src/operators/aggregate_const.h
+++ b/src/operators/aggregate_const.h
@@ -58,6 +58,7 @@ struct AggregateReference {
   AggregateKernel kernel;
   std::string agg_name;
   ColumnReference col_ref;
+  std::shared_ptr<ExprReference> expr_ref = nullptr;
 };
 
 }

--- a/src/operators/utils/lazy_table.h
+++ b/src/operators/utils/lazy_table.h
@@ -42,6 +42,13 @@ struct ColumnReference {
   std::string col_name;
 };
 
+struct ExprReference {
+  uint16_t op;
+  std::shared_ptr<ExprReference> left_expr;
+  std::shared_ptr<ExprReference> right_expr;
+  std::shared_ptr<ColumnReference> column_ref;
+};
+
 /**
  * A LazyTable associates a table pointer with a boolean filter and an array
  * of indices. The filter and indices determine which rows of the table are

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -223,7 +223,6 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
             std::make_shared<ProjectReference>(ProjectReference{colRef, zName});
         project_references_->emplace_back(projRef);
       } else {
-        std::cout << "end" << std::endl;
         std::shared_ptr<ExprReference> expr_ref = ResolveAggExpr(expr);
         if (expr_ref == nullptr) {
           return false;
@@ -236,7 +235,6 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
         std::shared_ptr<ProjectReference> projRef =
             std::make_shared<ProjectReference>(ProjectReference{colRef, zName});
         project_references_->emplace_back(projRef);
-        std::cout << "end - time" << std::endl;
         // TODO (suryadev): Support the expression evaluation in aggregate
         // operator
         return false;  // change to true after support in operators

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -235,9 +235,6 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
         std::shared_ptr<ProjectReference> projRef =
             std::make_shared<ProjectReference>(ProjectReference{colRef, zName});
         project_references_->emplace_back(projRef);
-        // TODO (suryadev): Support the expression evaluation in aggregate
-        // operator
-        return false;  // change to true after support in operators
       }
     } else if (pEList->a[k].pExpr->op == TK_COLUMN ||
                pEList->a[k].pExpr->op == TK_AGG_COLUMN) {

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -83,7 +83,7 @@ std::shared_ptr<ExprReference> SelectResolver::ResolveAggExpr(Expr* expr) {
     case TK_COLUMN:
     case TK_AGG_COLUMN: {
       expr_ref->op = expr->op;
-      if (expr->op == TK_COLUMN) {
+      if (expr->op == TK_COLUMN || expr->op == TK_AGG_COLUMN) {
         expr_ref->column_ref = std::make_shared<ColumnReference>();
         expr_ref->column_ref->table = catalog_->getTable(expr->y.pTab->zName);
         expr_ref->column_ref->col_name =

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -248,7 +248,6 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
           std::make_shared<ProjectReference>(ProjectReference{colRef});
       project_references_->emplace_back(projRef);
     }
-    std::cout << "zName" << std::endl;
   }
 
   // Resolve predicates

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -70,6 +70,37 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
   }
 }
 
+std::shared_ptr<ExprReference> SelectResolver::ResolveAggExpr(Expr* expr) {
+  if (expr == NULL) {
+    return nullptr;
+  }
+  std::shared_ptr<ExprReference> expr_ref = std::make_shared<ExprReference>();
+  switch (expr->op) {
+    case TK_STAR:
+    case TK_PLUS:
+    case TK_MINUS:
+    case TK_SLASH:
+    case TK_COLUMN:
+    case TK_AGG_COLUMN: {
+      expr_ref->op = expr->op;
+      if (expr->op == TK_COLUMN) {
+        expr_ref->column_ref = std::make_shared<ColumnReference>();
+        expr_ref->column_ref->table = catalog_->getTable(expr->y.pTab->zName);
+        expr_ref->column_ref->col_name =
+            expr->y.pTab->aCol[expr->iColumn].zName;
+      }
+      expr_ref->left_expr = this->ResolveAggExpr(expr->pLeft);
+      expr_ref->right_expr = this->ResolveAggExpr(expr->pRight);
+      break;
+    }
+    default: {
+      // Contains operator that is not supported
+      return nullptr;
+    }
+  }
+  return expr_ref;
+}
+
 std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
   if (pExpr == NULL) {
     return nullptr;
@@ -176,13 +207,14 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
   for (int k = 0; k < pEList->nExpr; k++) {
     if (pEList->a[k].pExpr->op == TK_AGG_FUNCTION) {
       Expr* expr = pEList->a[k].pExpr->x.pList->a[0].pExpr;
+      char* zName = NULL;
+      if (pEList->a[k].zEName != NULL) {
+        zName = pEList->a[k].zEName;
+      }
+
       if (expr->iColumn > 0) {
         ColumnReference colRef = {catalog_->getTable(expr->y.pTab->zName),
                                   expr->y.pTab->aCol[expr->iColumn].zName};
-        char* zName = NULL;
-        if (pEList->a[k].zEName != NULL) {
-          zName = pEList->a[k].zEName;
-        }
         AggregateReference aggRef = {
             aggregate_kernels_[pEList->a[k].pExpr->u.zToken],
             pEList->a[k].zEName, colRef};
@@ -190,6 +222,24 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
         std::shared_ptr<ProjectReference> projRef =
             std::make_shared<ProjectReference>(ProjectReference{colRef, zName});
         project_references_->emplace_back(projRef);
+      } else {
+        std::cout << "end" << std::endl;
+        std::shared_ptr<ExprReference> expr_ref = ResolveAggExpr(expr);
+        if (expr_ref == nullptr) {
+          return false;
+        }
+        ColumnReference colRef = {};
+        AggregateReference aggRef = {
+            aggregate_kernels_[pEList->a[k].pExpr->u.zToken],
+            pEList->a[k].zEName, colRef, expr_ref};
+        agg_references_->emplace_back(aggRef);
+        std::shared_ptr<ProjectReference> projRef =
+            std::make_shared<ProjectReference>(ProjectReference{colRef, zName});
+        project_references_->emplace_back(projRef);
+        std::cout << "end - time" << std::endl;
+        // TODO (suryadev): Support the expression evaluation in aggregate
+        // operator
+        return false;  // change to true after support in operators
       }
     } else if (pEList->a[k].pExpr->op == TK_COLUMN ||
                pEList->a[k].pExpr->op == TK_AGG_COLUMN) {
@@ -200,6 +250,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
           std::make_shared<ProjectReference>(ProjectReference{colRef});
       project_references_->emplace_back(projRef);
     }
+    std::cout << "zName" << std::endl;
   }
 
   // Resolve predicates

--- a/src/resolver/select_resolver.h
+++ b/src/resolver/select_resolver.h
@@ -120,6 +120,8 @@ class SelectResolver {
     return project_references_;
   }
 
+  std::shared_ptr<ExprReference> ResolveAggExpr(Expr *expr);
+
   bool ResolveSelectTree(Sqlite3Select* queryTree);
   bool ResolveSelectTree() { return true; }
 };

--- a/src/resolver/tests/resolver_test.cc
+++ b/src/resolver/tests/resolver_test.cc
@@ -29,7 +29,6 @@
 
 using namespace testing;
 using namespace hustle::resolver;
-//using nlohmann::json;
 
 class ResolverTest : public Test {
  public:
@@ -866,4 +865,53 @@ TEST_F(ResolverTest, q13) {
   EXPECT_EQ(select_resolver.orderby_references()->size(), 3);
 
   EXPECT_EQ(select_resolver.project_references()->size(), 4);
+}
+
+TEST_F(ResolverTest, queryAggExpr) {
+  std::filesystem::remove_all("db_directory");
+  hustle::HustleDB hustleDB("db_directory");
+
+  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
+  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
+  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
+  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
+  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+
+  std::string query =
+      "select sum(lo_extendedprice*lo_discount) as "
+      "revenue\n"
+      "from lineorder, ddate\n"
+      "where lo_orderdate = d_datekey\n"
+      "and d_yearmonthnum = 199401\n"
+      "and lo_discount < 6\n"
+      "and lo_quantity < 35;";
+
+  Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
+      hustleDB.getSqliteDBPath(), query);
+  SelectResolver select_resolver(hustleDB.getCatalog());
+  select_resolver.ResolveSelectTree(queryTree);
+
+  EXPECT_EQ(select_resolver.join_predicates().size(), 1);
+
+  EXPECT_EQ(select_resolver.agg_references()->size(), 1);
+  EXPECT_TRUE((*select_resolver.agg_references())[0].expr_ref != nullptr);
+  EXPECT_EQ(select_resolver.groupby_references()->size(), 0);
+  EXPECT_EQ(select_resolver.orderby_references()->size(), 0);
+
+  EXPECT_EQ(select_resolver.project_references()->size(), 1);
+
+  query =
+      "select sum(lo_extendedprice) as "
+      "revenue\n"
+      "from lineorder, ddate\n"
+      "where lo_orderdate = d_datekey\n"
+      "and d_yearmonthnum = 199401\n"
+      "and lo_discount < 6\n"
+      "and lo_quantity < 35;";
+  queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
+      hustleDB.getSqliteDBPath(), query);
+  
+  SelectResolver select_resolver2(hustleDB.getCatalog());
+  select_resolver2.ResolveSelectTree(queryTree);
+  EXPECT_TRUE((*select_resolver2.agg_references())[0].expr_ref == nullptr);
 }

--- a/src/resolver/tests/resolver_test.cc
+++ b/src/resolver/tests/resolver_test.cc
@@ -895,6 +895,14 @@ TEST_F(ResolverTest, queryAggExpr) {
 
   EXPECT_EQ(select_resolver.agg_references()->size(), 1);
   EXPECT_TRUE((*select_resolver.agg_references())[0].expr_ref != nullptr);
+  EXPECT_EQ((*select_resolver.agg_references())[0]
+                .expr_ref->left_expr->column_ref->col_name,
+            "lo_extendedprice");
+  EXPECT_EQ((*select_resolver.agg_references())[0]
+                .expr_ref->right_expr->column_ref->col_name,
+            "lo_discount");
+  EXPECT_EQ((*select_resolver.agg_references())[0]
+                .expr_ref->op, TK_STAR);
   EXPECT_EQ(select_resolver.groupby_references()->size(), 0);
   EXPECT_EQ(select_resolver.orderby_references()->size(), 0);
 


### PR DESCRIPTION
### Summary

Contains code to resolve the parse tree containing arithmetic expression with columns inside the aggregate function.
 Also, a simple unit test is added.

Example,
```
Select sum(lo_extendedprice*lo_discount) as 
      revenue from ...
```

(As the next steps, the code to evaluate the expression on query execution will be done)

