### PR TITLE
Clean Up of Table/Block

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,182 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/src/benchmark/aggregate_workload.cc
+++ b/src/benchmark/aggregate_workload.cc
@@ -62,7 +62,7 @@ void AggregateWorkload::prepareData() {
   inputTable = std::make_shared<hustle::storage::DBTable>(
     "table", schema, BLOCK_SIZE);
 
-  inputTable->insert_records(inputData);
+  inputTable->InsertRecords(inputData);
 }
 
 std::string

--- a/src/operators/aggregate.cc
+++ b/src/operators/aggregate.cc
@@ -619,7 +619,7 @@ void Aggregate::Finish() {
   }
   output_table_data.push_back(aggregates.make_array()->data());
 
-  output_table_->insert_records(output_table_data);
+  output_table_->InsertRecords(output_table_data);
   output_result_->append(output_table_);
 
   free(aggregate_data_);

--- a/src/operators/hash_aggregate.cc
+++ b/src/operators/hash_aggregate.cc
@@ -771,7 +771,7 @@ void HashAggregate::Finish(Task* ctx) {
   }
   output_table_data.push_back(aggregates.make_array()->data());
 
-  output_table_->insert_records(output_table_data);
+  output_table_->InsertRecords(output_table_data);
   output_result_->append(output_table_);
 
 }

--- a/src/operators/utils/operator_result.cc
+++ b/src/operators/utils/operator_result.cc
@@ -104,7 +104,7 @@ std::shared_ptr<DBTable> OperatorResult::materialize(
     for (auto& col : out_cols) {
       out_block_data.push_back(col->chunk(i)->data());
     }
-    out_table->insert_records(out_block_data);
+    out_table->InsertRecords(out_block_data);
     out_block_data.clear();
   }
 

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -267,7 +267,7 @@ void Block::print() {
   }
 }
 
-// Note that this funciton assumes that the valid column is in column_data
+// Note that this function assumes that the valid column is in column_data
 int Block::InsertRecords(
     std::map<int, BlockInfo>& block_map,
     std::map<int, int>& row_map,
@@ -300,7 +300,7 @@ int Block::InsertRecords(
   return num_rows - 1;
 }
 
-// Note that this funciton assumes that the valid column is in column_data
+// Note that this function assumes that the valid column is in column_data
 int Block::InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> column_data) {
   if (column_data[0]->length == 0) {
     return -1;

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -19,8 +19,10 @@
 #define HUSTLE_OFFLINE_BLOCK_H
 
 #include <arrow/api.h>
-#include <map>
+
 #include <iostream>
+#include <map>
+
 #include "utils/bit_utils.h"
 
 #define BLOCK_SIZE (1 << 20)
@@ -82,14 +84,14 @@ class Block {
    *
    * @return The Block's ID
    */
-  inline int get_id() const {return id;}
+  inline int get_id() const { return id; }
 
   /**
    * Return the block's schema, including the valid column.
    *
    * @return the block's schema
    */
-  inline std::shared_ptr<arrow::Schema> get_schema() {return schema;}
+  inline std::shared_ptr<arrow::Schema> get_schema() { return schema; }
 
   /**
    * Get a column from the Block by index. The indexing of columns is defined
@@ -107,7 +109,9 @@ class Block {
    *
    * @return all columns in the block
    */
-  inline std::vector<std::shared_ptr<arrow::ArrayData>> get_columns() {return columns;}
+  inline std::vector<std::shared_ptr<arrow::ArrayData>> get_columns() {
+    return columns;
+  }
 
   /**
    * Get a column from the Block by name. Column names are defined by the
@@ -116,7 +120,8 @@ class Block {
    * @param name Name of the column
    * @return A read-only pointer to the column.
    */
-  inline std::shared_ptr<arrow::Array> get_column_by_name(const std::string &name) const {
+  inline std::shared_ptr<arrow::Array> get_column_by_name(
+      const std::string &name) const {
     return arrow::MakeArray(columns[schema->GetFieldIndex(name)]);
   }
 
@@ -125,7 +130,9 @@ class Block {
    *
    * @return valid-bit column
    */
-  inline std::shared_ptr<arrow::Array> get_valid_column() const {return arrow::MakeArray(valid);}
+  inline std::shared_ptr<arrow::Array> get_valid_column() const {
+    return arrow::MakeArray(valid);
+  }
 
   /**
    * Return the valid bit of a particular row.
@@ -146,7 +153,8 @@ class Block {
    * @param row_index Row index.
    * @return True if the given row is valid, false otherwise.
    */
-  inline bool get_valid(const std::shared_ptr<arrow::ArrayData> validArray, unsigned int row_index) const {
+  inline bool get_valid(const std::shared_ptr<arrow::ArrayData> validArray,
+                        unsigned int row_index) const {
     auto *data = validArray->GetMutableValues<uint8_t>(1, 0);
     uint8_t byte = data[row_index / 8];
     return ((byte >> (row_index % 8u)) & 1u) == 1u;
@@ -164,7 +172,7 @@ class Block {
     if (val) {
       data[row_index / 8] |= (1u << (row_index % 8u));
     } else {
-      data[row_index / 8] &=  ~(1u << (row_index % 8u));
+      data[row_index / 8] &= ~(1u << (row_index % 8u));
     }
   }
 
@@ -186,7 +194,8 @@ class Block {
   inline int get_bytes_left() { return capacity - num_bytes; }
 
   /**
-   * Print the contents of the block delimited by tabs, including the valid column.
+   * Print the contents of the block delimited by tabs, including the valid
+   * column.
    */
   void print();
 
@@ -195,35 +204,35 @@ class Block {
    *
    * @return Number of rows in the Block
    */
-  inline int get_num_rows() const {return num_rows;}
+  inline int get_num_rows() const { return num_rows; }
 
   /**
    * Get the number of columns in the Block.
    *
    * @return number of columns
    */
-  inline int get_num_cols() const { return num_cols;}
+  inline int get_num_cols() const { return num_cols; }
 
   /**
    * Get the width of all fixed width columns.
    *
    * @return width
    */
-  inline int get_fixed_record_width() const {return fixed_record_width;}
+  inline int get_fixed_record_width() const { return fixed_record_width; }
 
   /**
    * Get the maximum capacity of the Block.
    *
    * @return block capacity
    */
-  inline int get_capacity() const {return capacity;}
+  inline int get_capacity() const { return capacity; }
 
   /**
    * Get the row ID Mapping of the block.
    *
    * @return row ID map
    */
-  std::map<int, int>& get_row_id_map() {return row_id_map;}
+  std::map<int, int> &get_row_id_map() { return row_id_map; }
 
   /**
    * Insert a record into the Block.
@@ -233,7 +242,8 @@ class Block {
    * should not be separated by e.g. null characters.
    * @param byte_widths Byte width of each value to be inserted. Byte widths
    * should be listed in the same order as they appear in the Block's schema.
-   * @return -1 if the insertion failed, otherwise the highest row index now present in the block.
+   * @return -1 if the insertion failed, otherwise the highest row index now
+   * present in the block.
    */
   int InsertRecord(uint8_t *record, int32_t *byte_widths);
 
@@ -242,7 +252,8 @@ class Block {
    *
    * @param record Values to be inserted into each column.
    * @param byte_widths Byte width of each value to be inserted.
-   * @return -1 if the insertion failed, otherwise the highest row index now present in the block.
+   * @return -1 if the insertion failed, otherwise the highest row index now
+   * present in the block.
    */
   int InsertRecord(std::vector<std::string_view> record, int32_t *byte_widths);
 
@@ -256,24 +267,26 @@ class Block {
    * appear in the Block's schema. The length of column_data must match the
    * length of the Block's schema. All ArrayData must contain the same
    * number of elements.
-   * @return -1 if the insertion failed, otherwise the highest row index now present in the block.
+   * @return -1 if the insertion failed, otherwise the highest row index now
+   * present in the block.
    */
   int InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
 
   /**
-   * Insert one or more records into the Block using BlockInfo from a different block.
+   * Insert one or more records into the Block using BlockInfo from a different
+   * block.
    *
    * @param block_map BlockInfo Map
    * @param row_map Row Map
    * @param valid_column Valid-bit column
    * @param column_data Vector of column datas.
-   * @return -1 if the insertion failed, otherwise the highest row index now present in the block.
+   * @return -1 if the insertion failed, otherwise the highest row index now
+   * present in the block.
    */
-  int InsertRecords(
-      std::map<int, BlockInfo>& block_map,
-      std::map<int, int>& row_map,
-      std::shared_ptr<arrow::Array> valid_column,
-      std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
+  int InsertRecords(std::map<int, BlockInfo> &block_map,
+                    std::map<int, int> &row_map,
+                    std::shared_ptr<arrow::Array> valid_column,
+                    std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
 
   /**
    * Update a value in a column.
@@ -285,10 +298,12 @@ class Block {
    * @param byte_width width of field
    */
   template <typename field_size>
-  inline void UpdateColumnValue(int col_num, int row_num, uint8_t *record_value, int byte_width) {
+  inline void UpdateColumnValue(int col_num, int row_num, uint8_t *record_value,
+                                int byte_width) {
     auto *dest = columns[col_num]->GetMutableValues<field_size>(1, row_num);
     uint8_t *value = (uint8_t *)calloc(sizeof(field_size), sizeof(uint8_t));
-    std::memcpy(value, utils::reverse_bytes(record_value, byte_width), byte_width);
+    std::memcpy(value, utils::reverse_bytes(record_value, byte_width),
+                byte_width);
     std::memcpy(dest, value, sizeof(field_size));
     free(value);
   }
@@ -335,7 +350,8 @@ class Block {
   std::map<int, int> row_id_map;
 
   /**
-   * Total number of data bytes stored in the block, excluding the valid column data.
+   * Total number of data bytes stored in the block, excluding the valid column
+   * data.
    */
   int num_bytes;
 
@@ -375,7 +391,8 @@ class Block {
    * @return
    */
   template <typename field_size>
-  std::shared_ptr<arrow::ArrayData> AllocateColumnData(std::shared_ptr<arrow::DataType> type, int init_rows);
+  std::shared_ptr<arrow::ArrayData> AllocateColumnData(
+      std::shared_ptr<arrow::DataType> type, int init_rows);
 
   /**
    * Insert a value into a column.
@@ -387,7 +404,8 @@ class Block {
    * @param byte_width width of field
    */
   template <typename field_size>
-  void InsertValue(int col_num, int &head, uint8_t *record_value, int byte_width);
+  void InsertValue(int col_num, int &head, uint8_t *record_value,
+                   int byte_width);
 
   /**
    * Insert values into a column
@@ -399,7 +417,8 @@ class Block {
    * @param num_vals number of values to insert
    */
   template <typename field_size>
-  void InsertValues(int col_num, int offset, std::shared_ptr<arrow::ArrayData> vals, int num_vals);
+  void InsertValues(int col_num, int offset,
+                    std::shared_ptr<arrow::ArrayData> vals, int num_vals);
 
   /**
    * Insert value from CSV string

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -224,7 +224,7 @@ class Block {
    * should be listed in the same order as they appear in the Block's schema.
    * @return True if insertion was successful, false otherwise.
    */
-  bool InsertRecord(uint8_t *record, int32_t *byte_widths);
+  int InsertRecord(uint8_t *record, int32_t *byte_widths);
 
   /**
    *
@@ -232,7 +232,7 @@ class Block {
    * @param byte_widths
    * @return
    */
-  bool InsertRecord(std::vector<std::string_view> record, int32_t *byte_widths);
+  int InsertRecord(std::vector<std::string_view> record, int32_t *byte_widths);
 
   /**
    * Insert one or more records into the Block as a vector of ArrayData.
@@ -246,7 +246,7 @@ class Block {
    * number of elements.
    * @return True if insertion was successful, false otherwise.
    */
-  bool InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
+  int InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
 
   /**
    *
@@ -256,7 +256,7 @@ class Block {
    * @param column_data
    * @return
    */
-  bool InsertRecords(
+  int InsertRecords(
       std::map<int, BlockInfo>& block_map,
       std::map<int, int>& row_map,
       std::shared_ptr<arrow::Array> valid_column,

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -203,7 +203,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
       tmp_record = head;
 
       if (head->mode == MEMLOG_HUSTLE_DELETE) {
-        table->delete_record_table(head->rowId);
+        table->DeleteRecordTable(head->rowId);
       } else {
         u32 hdrLen;
         // Read header len in the record
@@ -230,10 +230,10 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
           }
           // Insert record to the arrow table
           if (head->mode == MEMLOG_HUSTLE_INSERT) {
-            table->insert_record_table(head->rowId, record_data + hdrLen,
+            table->InsertRecordTable(head->rowId, record_data + hdrLen,
                                        widths);
           } else if (head->mode == MEMLOG_HUSTLE_UPDATE) {
-            table->update_record_table(head->rowId, head->nUpdateMetaInfo,
+            table->UpdateRecordTable(head->rowId, head->nUpdateMetaInfo,
                                        head->updateMetaInfo,
                                        record_data + hdrLen, widths);
           }

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -164,7 +164,7 @@ void DBTable::InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> colum
   num_rows += l;
 }
 
-int DBTable::GetRecordSize(int32_t *byte_widths) {
+int DBTable::get_record_size(int32_t *byte_widths) {
   int record_size = 0;
   int num_cols = get_num_cols();
   for (int i = 0; i < num_cols; i++) {
@@ -200,7 +200,7 @@ int DBTable::GetRecordSize(int32_t *byte_widths) {
 // Tuple is passed in as an array of bytes which must be parsed.
 BlockInfo DBTable::InsertRecord(uint8_t *record, int32_t *byte_widths) {
   std::shared_ptr<Block> block = GetBlockForInsert();
-  int32_t record_size = this->GetRecordSize(byte_widths);
+  int32_t record_size = this->get_record_size(byte_widths);
   if (block->get_bytes_left() < record_size) {
     block = CreateBlock();
   }

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -81,8 +81,7 @@ void DBTable::InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> colum
   auto block = GetBlockForInsert();
   int offset = 0;
   int length = l;
-  // TODO(nicholas): Optimize this. Calls to schema->field(i) is non-
-  //  neglible since we call it once for each column of each record.
+  // optimize?
   int column_types[num_cols];
   for (int i = 0; i < num_cols; i++) {
     column_types[i] = schema->field(i)->type()->id();
@@ -92,7 +91,7 @@ void DBTable::InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> colum
     for (int i = 0; i < num_cols; i++) {
       switch (column_types[i]) {
         case arrow::Type::STRING: {
-          // TODO(nicholas) schema offsets!!!!
+          // optimize with offsets per schema?
           auto *offsets = column_data[i]->GetValues<int32_t>(1, 0);
           record_size += offsets[row + 1] - offsets[row];
           break;
@@ -270,8 +269,8 @@ void DBTable::DeleteRecordTable(uint32_t row_id) {
   std::shared_ptr<Block> block = this->get_block(block_info.block_id);
   block->set_valid(block_info.row_num, false);
   auto updatedBlock = std::make_shared<Block>(block_info.block_id, schema, block->get_capacity());
-  updatedBlock->InsertRecords(block_map, block->get_row_id_map(),
-                               block->get_valid_column(), block->get_columns());
+  updatedBlock->InsertRecords(
+      block_map, block->get_row_id_map(), block->get_valid_column(), block->get_columns());
   blocks[block_info.block_id] = updatedBlock;
   num_rows--;
   if (insert_pool.find(block_info.block_id) != insert_pool.end()) {

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -28,34 +28,22 @@
 
 namespace hustle::storage {
 
-DBTable::DBTable(std::string name, const std::shared_ptr<arrow::Schema> &schema,
-                 int block_capacity)
-    : table_name(std::move(name)),
-      schema(schema),
-      block_counter(0),
-      num_rows(0),
-      block_capacity(block_capacity),
-      block_row_offsets({}) {
+DBTable::DBTable(std::string name, const std::shared_ptr<arrow::Schema> &schema, int block_capacity)
+: table_name(std::move(name)), schema(schema), block_counter(0), num_rows(0),
+  block_capacity(block_capacity), block_row_offsets({}) {
+  //
   fixed_record_width = compute_fixed_record_width(schema);
   num_cols = schema->num_fields();
 }
 
-DBTable::DBTable(
-    std::string name,
-    std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches,
-    int block_capacity)
-    : table_name(std::move(name)),
-      block_counter(0),
-      num_rows(0),
-      block_capacity(block_capacity),
-      block_row_offsets({0}) {
-  // TODO(nicholas): Be consistent with how/when block_row_offsets is
-  //  initialized.
+DBTable::DBTable(std::string name, std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches, int block_capacity)
+: table_name(std::move(name)), block_counter(0), num_rows(0),
+  block_capacity(block_capacity), block_row_offsets({0}) {
+  //
   schema = std::move(record_batches[0]->schema());
   num_cols = schema->num_fields();
   // Must be called only after schema is set
   fixed_record_width = compute_fixed_record_width(schema);
-
   for (const auto &batch : record_batches) {
     auto block = std::make_shared<Block>(block_counter, batch, BLOCK_SIZE);
     blocks.emplace(block_counter, block);
@@ -63,113 +51,44 @@ DBTable::DBTable(
     num_rows += batch->num_rows();
     block_row_offsets.push_back(num_rows);
   }
-
   if (blocks[blocks.size() - 1]->get_bytes_left() > fixed_record_width) {
-    mark_block_for_insert(blocks[blocks.size() - 1]);
-    // The final block is not full, so do not include an offset for the
-    // next block.
+    MarkBlockForInsert(blocks[blocks.size() - 1]);
+    // The final block is not full, so do not include an offset for the next block.
     block_row_offsets[block_row_offsets.size() - 1] = -1;
   }
 }
 
-std::shared_ptr<Block> DBTable::create_block() {
-  std::scoped_lock blocks_lock(blocks_mutex);
-  int block_id = block_counter++;
-  auto block = std::make_shared<Block>(block_id, schema, block_capacity);
-  blocks.emplace(block_id, block);
-
-  block_row_offsets.push_back(num_rows);
-
-  return block;
-}
-
-void DBTable::insert_blocks(std::vector<std::shared_ptr<Block>> input_blocks) {
+void DBTable::InsertBlocks(std::vector<std::shared_ptr<Block>> input_blocks) {
   if (input_blocks.empty()) {
     return;
   }
-
   for (auto &block : input_blocks) {
     blocks.emplace(block_counter, block);
     block_counter++;
     num_rows += block->get_num_rows();
     block_row_offsets.push_back(num_rows);
   }
-
   if (blocks[blocks.size() - 1]->get_bytes_left() > fixed_record_width) {
-    mark_block_for_insert(blocks[blocks.size() - 1]);
-    // The final block is not full, so do not include an offset for the
-    // next new block.
+    MarkBlockForInsert(blocks[blocks.size() - 1]);
+    // The final block is not full, so do not include an offset for the next new block.
     block_row_offsets[block_row_offsets.size()] = -1;
   }
 }
 
-int DBTable::get_num_rows() const { return num_rows; }
-
-int DBTable::get_num_cols() const { return num_cols; }
-
-std::shared_ptr<Block> DBTable::get_block(int block_id) const {
-  //  std::scoped_lock blocks_lock(blocks_mutex);
-  return blocks.at(block_id);
-}
-
-std::shared_ptr<Block> DBTable::get_block_for_insert() {
-  std::scoped_lock insert_pool_lock(insert_pool_mutex);
-  if (insert_pool.empty()) {
-    return create_block();
-  }
-
-  auto iter = insert_pool.begin();
-  std::shared_ptr<Block> block = iter->second;
-  insert_pool.erase(iter->first);
-  return block;
-}
-
-void DBTable::mark_block_for_insert(const std::shared_ptr<Block> &block) {
-  std::scoped_lock insert_pool_lock(insert_pool_mutex);
-  assert(block->get_bytes_left() > fixed_record_width);
-
-  insert_pool[block->get_id()] = block;
-}
-
-std::shared_ptr<arrow::Schema> DBTable::get_schema() const { return schema; }
-
-size_t DBTable::get_num_blocks() const { return blocks.size(); }
-
-void DBTable::print() {
-  if (blocks.empty()) {
-    std::cout << "Table is empty." << std::endl;
-  } else {
-    for (int i = 0; i < blocks.size(); i++) {
-      blocks[i]->print();
-    }
-  }
-}
-
-std::unordered_map<int, std::shared_ptr<Block>> DBTable::get_blocks() {
-  return blocks;
-}
-
-void DBTable::insert_records(
-    std::vector<std::shared_ptr<arrow::ArrayData>> column_data) {
+void DBTable::InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> column_data) {
   int l = column_data[0]->length;
   int data_size = 0;
-
-  auto block = get_block_for_insert();
-
+  auto block = GetBlockForInsert();
   int offset = 0;
   int length = l;
-
   // TODO(nicholas): Optimize this. Calls to schema->field(i) is non-
   //  neglible since we call it once for each column of each record.
   int column_types[num_cols];
-
   for (int i = 0; i < num_cols; i++) {
     column_types[i] = schema->field(i)->type()->id();
   }
-
   for (int row = 0; row < l; row++) {
     int record_size = 0;
-
     for (int i = 0; i < num_cols; i++) {
       switch (column_types[i]) {
         case arrow::Type::STRING: {
@@ -212,9 +131,7 @@ void DBTable::insert_records(
         }
       }
     }
-
     std::vector<std::shared_ptr<arrow::ArrayData>> sliced_column_data;
-
     if (data_size + record_size > block->get_bytes_left()) {
       for (int i = 0; i < column_data.size(); i++) {
         // Note that row is equal to the index of the first record we
@@ -222,20 +139,15 @@ void DBTable::insert_records(
         auto sliced_data = column_data[i]->Slice(offset, row - offset);
         sliced_column_data.push_back(sliced_data);
       }
-
-      block->insert_records(sliced_column_data);
+      block->InsertRecords(sliced_column_data);
       //            sliced_column_data.clear(); // no need to clear; a new
       //            vector is declared in each loop.
-
       offset = row;
       data_size = 0;
-
-      block = create_block();
+      block = CreateBlock();
     }
-
     data_size += record_size;
   }
-
   std::vector<std::shared_ptr<arrow::ArrayData>> sliced_column_data;
   // Insert the last of the records
   for (int i = 0; i < column_data.size(); i++) {
@@ -244,18 +156,16 @@ void DBTable::insert_records(
     auto sliced_data = column_data[i]->Slice(offset, l - offset);
     sliced_column_data.push_back(sliced_data);
   }
-  block->insert_records(sliced_column_data);
+  block->InsertRecords(sliced_column_data);
   //    sliced_column_data.clear();
   // no need to clear. We only use this vector once.
-
   if (block->get_bytes_left() > fixed_record_width) {
     insert_pool[block->get_id()] = block;
   }
-
   num_rows += l;
 }
 
-int DBTable::get_record_size(int32_t *byte_widths) {
+int DBTable::GetRecordSize(int32_t *byte_widths) {
   int record_size = 0;
   int num_cols = get_num_cols();
   for (int i = 0; i < num_cols; i++) {
@@ -282,50 +192,39 @@ int DBTable::get_record_size(int32_t *byte_widths) {
         break;
       }
       default:
-        throw std::logic_error(std::string("unsupported type: ") +
-                               schema->field(i)->type()->ToString());
+        throw std::logic_error(std::string("unsupported type: ") + schema->field(i)->type()->ToString());
     }
   }
   return record_size;
 }
 
 // Tuple is passed in as an array of bytes which must be parsed.
-BlockInfo DBTable::insert_record(uint8_t *record, int32_t *byte_widths) {
-  std::shared_ptr<Block> block = get_block_for_insert();
-
-  int32_t record_size = this->get_record_size(byte_widths);
+BlockInfo DBTable::InsertRecord(uint8_t *record, int32_t *byte_widths) {
+  std::shared_ptr<Block> block = GetBlockForInsert();
+  int32_t record_size = this->GetRecordSize(byte_widths);
   if (block->get_bytes_left() < record_size) {
-    block = create_block();
+    block = CreateBlock();
   }
-
-  int32_t rowNum = block->insert_record(record, byte_widths);
+  int32_t row_num = block->InsertRecord(record, byte_widths);
   num_rows++;
-
   if (block->get_bytes_left() > fixed_record_width) {
     insert_pool[block->get_id()] = block;
   }
-
-  return {block->get_id(), rowNum};
+  return {block->get_id(), row_num};
 }
 
-void DBTable::insert_record_table(uint32_t rowId, uint8_t *record,
-                                  int32_t *byte_widths) {
-  block_map[rowId] = insert_record(record, byte_widths);
-}
-
-void DBTable::update_record_table(uint32_t rowId, int nUpdateMetaInfo,
-                                  UpdateMetaInfo *updateMetaInfo,
+void DBTable::UpdateRecordTable(uint32_t row_id, int num_UpdateMetaInfo, UpdateMetaInfo *updateMetaInfo,
                                   uint8_t *record, int32_t *byte_widths) {
-  auto block_map_it = block_map.find(rowId);
+  auto block_map_it = block_map.find(row_id);
   if (block_map_it == block_map.end()) {
     return;
   }
-  BlockInfo blockInfo = block_map_it->second;
-  int row_num = blockInfo.rowNum;
-  std::shared_ptr<Block> block = this->get_block(blockInfo.blockId);
+  BlockInfo block_info = block_map_it->second;
+  int row_num = block_info.row_num;
+  std::shared_ptr<Block> block = this->get_block(block_info.block_id);
   int offset = 0;
   int curr_offset_col = 0;
-  for (int i = 0; i < nUpdateMetaInfo; i++) {
+  for (int i = 0; i < num_UpdateMetaInfo; i++) {
     int col_num = updateMetaInfo[i].colNum;
     while (col_num > curr_offset_col) {
       offset += byte_widths[curr_offset_col];
@@ -333,29 +232,25 @@ void DBTable::update_record_table(uint32_t rowId, int nUpdateMetaInfo,
     }
     switch (schema->field(col_num)->type()->id()) {
       case arrow::Type::STRING: {
-        this->delete_record_table(rowId);
-        this->insert_record_table(rowId, record, byte_widths);
+        this->DeleteRecordTable(row_id);
+        this->InsertRecordTable(row_id, record, byte_widths);
         return;
       }
       case arrow::Type::DOUBLE:
       case arrow::Type::INT64: {
-        block->update_value_in_column<int64_t>(col_num, row_num,
-                                               record + offset, byte_widths[col_num]);
+        block->UpdateColumnValue<int64_t>(col_num, row_num,record + offset, byte_widths[col_num]);
         break;
       }
       case arrow::Type::UINT32: {
-        block->update_value_in_column<uint32_t>(
-            col_num, row_num, record + offset, byte_widths[i]);
+        block->UpdateColumnValue<uint32_t>(col_num, row_num, record + offset, byte_widths[i]);
         break;
       }
       case arrow::Type::UINT16: {
-        block->update_value_in_column<uint32_t>(
-            col_num, row_num, record + offset, byte_widths[i]);
+        block->UpdateColumnValue<uint32_t>(col_num, row_num, record + offset, byte_widths[i]);
         break;
       }
       case arrow::Type::UINT8: {
-        block->update_value_in_column<uint8_t>(col_num, row_num,
-                                               record + offset, byte_widths[i]);
+        block->UpdateColumnValue<uint8_t>(col_num, row_num,record + offset, byte_widths[i]);
         break;
       }
       default:
@@ -366,71 +261,38 @@ void DBTable::update_record_table(uint32_t rowId, int nUpdateMetaInfo,
   }
 }
 
-void DBTable::delete_record_table(uint32_t rowId) {
-  auto block_map_it = block_map.find(rowId);
+void DBTable::DeleteRecordTable(uint32_t row_id) {
+  auto block_map_it = block_map.find(row_id);
   if (block_map_it == block_map.end()) {
     return;
   }
-  BlockInfo blockInfo = block_map_it->second;
-  std::shared_ptr<Block> block = this->get_block(blockInfo.blockId);
-  block->set_valid(blockInfo.rowNum, false);
-  auto updatedBlock =
-      std::make_shared<Block>(blockInfo.blockId, schema, block->get_capacity());
-  updatedBlock->insert_records(block_map, block->get_row_id_map(),
+  BlockInfo block_info = block_map_it->second;
+  std::shared_ptr<Block> block = this->get_block(block_info.block_id);
+  block->set_valid(block_info.row_num, false);
+  auto updatedBlock = std::make_shared<Block>(block_info.block_id, schema, block->get_capacity());
+  updatedBlock->InsertRecords(block_map, block->get_row_id_map(),
                                block->get_valid_column(), block->get_columns());
-  blocks[blockInfo.blockId] = updatedBlock;
+  blocks[block_info.block_id] = updatedBlock;
   num_rows--;
-  if (insert_pool.find(blockInfo.blockId) != insert_pool.end()) {
-    insert_pool[blockInfo.blockId] = updatedBlock;
+  if (insert_pool.find(block_info.block_id) != insert_pool.end()) {
+    insert_pool[block_info.block_id] = updatedBlock;
   }
 }
 
-void DBTable::insert_record(std::vector<std::string_view> values,
-                            int32_t *byte_widths) {
-  std::shared_ptr<Block> block = get_block_for_insert();
-
+void DBTable::InsertRecord(std::vector<std::string_view> values, int32_t *byte_widths) {
+  std::shared_ptr<Block> block = GetBlockForInsert();
   int32_t record_size = 0;
   // record size is incorrectly computed!
   for (int i = 0; i < num_cols; i++) {
     record_size += byte_widths[i];
   }
-
   if (block->get_bytes_left() < record_size) {
-    block = create_block();
+    block = CreateBlock();
   }
-
-  block->insert_record(values, byte_widths);
+  block->InsertRecord(values, byte_widths);
   num_rows++;
-
   if (block->get_bytes_left() > fixed_record_width) {
     insert_pool[block->get_id()] = block;
   }
-}
-
-int DBTable::get_block_row_offset(int i) const { return block_row_offsets[i]; }
-
-std::shared_ptr<arrow::ChunkedArray> DBTable::get_column(int col_index) {
-  if (blocks.empty()) {
-    return nullptr;
-  }
-
-  arrow::ArrayVector array_vector;
-  for (int i = 0; i < blocks.size(); i++) {
-    array_vector.push_back(blocks[i]->get_column(col_index));
-  }
-  return std::make_shared<arrow::ChunkedArray>(array_vector);
-}
-
-std::shared_ptr<arrow::ChunkedArray> DBTable::get_column_by_name(
-    const std::string &name) {
-  return get_column(schema->GetFieldIndex(name));
-}
-
-std::shared_ptr<arrow::ChunkedArray> DBTable::get_valid_column() {
-  arrow::ArrayVector array_vector;
-  for (int i = 0; i < blocks.size(); i++) {
-    array_vector.push_back(blocks[i]->get_valid_column());
-  }
-  return std::make_shared<arrow::ChunkedArray>(array_vector);
 }
 }  // namespace hustle::storage

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -128,7 +128,7 @@ class DBTable {
    * @param byte_widths
    * @return
    */
-  int GetRecordSize(int32_t *byte_widths);
+  int get_record_size(int32_t *byte_widths);
 
   /**
    * Insert a record into a block in the insert pool.

--- a/src/storage/table.h
+++ b/src/storage/table.h
@@ -43,7 +43,8 @@ class DBTable {
    * @param schema Table schema, excluding the valid column
    * @param block_capacity Block size
    */
-  DBTable(std::string name, const std::shared_ptr<arrow::Schema> &schema, int block_capacity);
+  DBTable(std::string name, const std::shared_ptr<arrow::Schema> &schema,
+          int block_capacity);
 
   /**
    * Construct a table from a vector of RecordBatches read from a file.
@@ -52,7 +53,9 @@ class DBTable {
    * @param record_batches Vector of RecordBatches read from a file
    * @param block_capacity Block size
    */
-  DBTable(std::string name, std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches, int block_capacity);
+  DBTable(std::string name,
+          std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches,
+          int block_capacity);
 
   /**
    * Create an empty Block to be added to the Table.
@@ -81,7 +84,9 @@ class DBTable {
    * @param block_id Block ID
    * @return Block with the specified ID
    */
-  inline std::shared_ptr<Block> get_block(int block_id) const {return blocks.at(block_id);}
+  inline std::shared_ptr<Block> get_block(int block_id) const {
+    return blocks.at(block_id);
+  }
 
   /**
    * @return Block from the insert_pool
@@ -113,14 +118,14 @@ class DBTable {
    *
    * @return number of rows
    */
-  inline int get_num_rows() const {return num_rows;}
+  inline int get_num_rows() const { return num_rows; }
 
   /**
    * Get the number of blocks in the table.
    *
    * @return number of blocks
    */
-  inline size_t get_num_blocks() const {return blocks.size();}
+  inline size_t get_num_blocks() const { return blocks.size(); }
 
   /**
    * Get the size of one record in the Table.
@@ -148,7 +153,8 @@ class DBTable {
    * @param record record to insert
    * @param byte_widths widths of fields in record
    */
-  inline void InsertRecordTable(uint32_t rowId, uint8_t *record, int32_t *byte_widths) {
+  inline void InsertRecordTable(uint32_t rowId, uint8_t *record,
+                                int32_t *byte_widths) {
     block_map[rowId] = InsertRecord(record, byte_widths);
   }
 
@@ -162,8 +168,8 @@ class DBTable {
    * @param byte_widths widths of fields in record
    */
   void UpdateRecordTable(uint32_t rowId, int nUpdateMetaInfo,
-                           UpdateMetaInfo *updateMetaInfo, uint8_t *record,
-                           int32_t *byte_widths);
+                         UpdateMetaInfo *updateMetaInfo, uint8_t *record,
+                         int32_t *byte_widths);
 
   /**
    * Delete record by row id
@@ -184,18 +190,21 @@ class DBTable {
    * number of elements.
    * @return True if insertion was successful, false otherwise.
    */
-  void InsertRecords(std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
+  void InsertRecords(
+      std::vector<std::shared_ptr<arrow::ArrayData>> column_data);
 
   /**
    * @return The Table's schema, excluding the valid column of the underlying
    * Blocks
    */
-  inline std::shared_ptr<arrow::Schema> get_schema() const {return schema;}
+  inline std::shared_ptr<arrow::Schema> get_schema() const { return schema; }
 
   /**
    * @return A map storing the Table's Blocks
    */
-  inline std::unordered_map<int, std::shared_ptr<Block>> get_blocks() {return blocks;}
+  inline std::unordered_map<int, std::shared_ptr<Block>> get_blocks() {
+    return blocks;
+  }
 
   /**
    * Return the number of rows that appear before a specific block in the
@@ -204,7 +213,9 @@ class DBTable {
    * @param i Block index
    * @return The number of rows that appear before block i in the table.
    */
-  inline int get_block_row_offset(int block_index) const {return block_row_offsets[block_index];}
+  inline int get_block_row_offset(int block_index) const {
+    return block_row_offsets[block_index];
+  }
 
   /**
    * Return a specific column as a ChunkedArray over all blocks in the table.
@@ -213,7 +224,9 @@ class DBTable {
    * @return a ChunkedArray of column i over all blocks in the table.
    */
   inline std::shared_ptr<arrow::ChunkedArray> get_column(int ColumnIndex) {
-    if (blocks.empty()) {return nullptr;}
+    if (blocks.empty()) {
+      return nullptr;
+    }
     arrow::ArrayVector array_vector;
     for (int i = 0; i < blocks.size(); i++) {
       array_vector.push_back(blocks[i]->get_column(ColumnIndex));
@@ -227,7 +240,8 @@ class DBTable {
    * @param name Column name
    * @return a ChunkedArray of column "name" over all blocks in the table.
    */
-  inline std::shared_ptr<arrow::ChunkedArray> get_column_by_name(const std::string &name) {
+  inline std::shared_ptr<arrow::ChunkedArray> get_column_by_name(
+      const std::string &name) {
     return get_column(schema->GetFieldIndex(name));
   }
 
@@ -249,7 +263,7 @@ class DBTable {
    *
    * @return valid-bit column
    */
-  inline std::shared_ptr<arrow::ChunkedArray> get_valid_column(){
+  inline std::shared_ptr<arrow::ChunkedArray> get_valid_column() {
     arrow::ArrayVector array_vector;
     for (int i = 0; i < blocks.size(); i++) {
       array_vector.push_back(blocks[i]->get_valid_column());
@@ -262,14 +276,14 @@ class DBTable {
    *
    * @return table name
    */
-  inline std::string get_name() const {return table_name;}
+  inline std::string get_name() const { return table_name; }
 
   /**
    * Get the number of columns in the table
    *
    * @return number of columns
    */
-  inline int get_num_cols() const {return num_cols;}
+  inline int get_num_cols() const { return num_cols; }
 
   /**
    * Insert a record into the table
@@ -295,7 +309,8 @@ class DBTable {
   std::string table_name;
 
   /**
-   * Table Schema. Note that this excludes the valid column, which is only visible to the Block class.
+   * Table Schema. Note that this excludes the valid column, which is only
+   * visible to the Block class.
    */
   std::shared_ptr<arrow::Schema> schema;
 
@@ -330,14 +345,15 @@ class DBTable {
   std::mutex insert_pool_mutex;
 
   /**
-   * Block ID of the next block to be created. Equal to the number of blocks in the table.
+   * Block ID of the next block to be created. Equal to the number of blocks in
+   * the table.
    */
   int block_counter;
 
   /**
-   * The byte width of all fields with fixed length. If there are no variable-length fields,
-   * then this is equal to the byte width of a full record.
-   * Used to determine if we can fit another record into the block.
+   * The byte width of all fields with fixed length. If there are no
+   * variable-length fields, then this is equal to the byte width of a full
+   * record. Used to determine if we can fit another record into the block.
    */
   int fixed_record_width;
 
@@ -352,7 +368,8 @@ class DBTable {
   int num_cols;
 
   /**
-   * The value at index i is the number of records before block i. The value at index 0 is always 0.
+   * The value at index i is the number of records before block i. The value at
+   * index 0 is always 0.
    */
   std::vector<int> block_row_offsets;
 };
@@ -360,8 +377,9 @@ class DBTable {
 /// Implementation of ForEachBatch
 template <typename Functor>
 void DBTable::ForEachBatch(const Functor &functor) const {
-  //if (this->get_num_blocks() == 0) return;
-  size_t batch_size = this->get_num_blocks() / std::thread::hardware_concurrency();
+  // if (this->get_num_blocks() == 0) return;
+  size_t batch_size =
+      this->get_num_blocks() / std::thread::hardware_concurrency();
   if (batch_size == 0) batch_size = this->get_num_blocks();
   size_t num_batches = 1 + ((this->get_num_blocks() - 1) / batch_size);
   for (size_t batch_index = 0; batch_index < num_batches; batch_index++) {

--- a/src/storage/tests/block_test.cc
+++ b/src/storage/tests/block_test.cc
@@ -154,7 +154,7 @@ TEST_F(HustleBlockTest, EmptyBlock) {
 TEST_F(HustleBlockTest, OneInsertBlock) {
   Block block(0, schema, BLOCK_SIZE);
   int row_index =
-      block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
+      block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
   valid =
       std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
@@ -177,10 +177,10 @@ TEST_F(HustleBlockTest, OneInsertBlock) {
 
 TEST_F(HustleBlockTest, ManyInsertBlock) {
   Block block(0, schema, BLOCK_SIZE);
-  block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
-  block.insert_record((uint8_t *)record_string_2.data(), byte_widths_2);
-  block.insert_record((uint8_t *)record_string_3.data(), byte_widths_3);
-  block.insert_record((uint8_t *)record_string_4.data(), byte_widths_4);
+  block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  block.InsertRecord((uint8_t *)record_string_2.data(), byte_widths_2);
+  block.InsertRecord((uint8_t *)record_string_3.data(), byte_widths_3);
+  block.InsertRecord((uint8_t *)record_string_4.data(), byte_widths_4);
 
   valid =
       std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
@@ -235,12 +235,12 @@ TEST_F(HustleBlockTest, FullBlock) {
 
   // With 1 KB block size, we can store 8 copies of the first record
   for (int i = 0; i < 8; i++) {
-    block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
+    block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
   }
 
   // This block cannot hold a 9th copy of the first record
   int row_index =
-      block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
+      block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
   EXPECT_EQ(row_index, -1);
   EXPECT_EQ(block.get_bytes_left(), BLOCK_SIZE - 912);
@@ -254,7 +254,7 @@ TEST_F(HustleBlockTest, ArrayInsert) {
   auto record_batch = arrow::RecordBatch::Make(test_schema, 5, column_data);
 
   Block block(0, schema, BLOCK_SIZE);
-  block.insert_records(column_data);
+  block.InsertRecords(column_data);
 
   int row;
   valid =
@@ -298,10 +298,10 @@ TEST_F(HustleBlockTest, ArrayAndSingleInsert) {
   int off = in_offsets_data[0];
 
   Block block(0, schema, BLOCK_SIZE);
-  block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
-  block.insert_records(column_data);
-  block.insert_record((uint8_t *)record_string_1.data(), byte_widths_1);
-  block.insert_records(column_data);
+  block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  block.InsertRecords(column_data);
+  block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  block.InsertRecords(column_data);
 
   int row;
   valid =

--- a/src/storage/tests/block_test.cc
+++ b/src/storage/tests/block_test.cc
@@ -153,9 +153,11 @@ TEST_F(HustleBlockTest, EmptyBlock) {
 
 TEST_F(HustleBlockTest, OneInsertBlock) {
   Block block(0, schema, BLOCK_SIZE);
-  int row_index = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  int row_index =
+      block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
-  valid = std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
+  valid =
+      std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
   column1 = std::static_pointer_cast<arrow::Int64Array>(block.get_column(0));
   column2 = std::static_pointer_cast<arrow::StringArray>(block.get_column(1));
   column3 = std::static_pointer_cast<arrow::StringArray>(block.get_column(2));
@@ -237,7 +239,8 @@ TEST_F(HustleBlockTest, FullBlock) {
   }
 
   // This block cannot hold a 9th copy of the first record
-  int row_index = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  int row_index =
+      block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
   EXPECT_EQ(row_index, -1);
   EXPECT_EQ(block.get_bytes_left(), BLOCK_SIZE - 912);

--- a/src/storage/tests/block_test.cc
+++ b/src/storage/tests/block_test.cc
@@ -153,18 +153,16 @@ TEST_F(HustleBlockTest, EmptyBlock) {
 
 TEST_F(HustleBlockTest, OneInsertBlock) {
   Block block(0, schema, BLOCK_SIZE);
-  int row_index =
-      block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  bool successful_insert = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
-  valid =
-      std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
+  valid = std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
   column1 = std::static_pointer_cast<arrow::Int64Array>(block.get_column(0));
   column2 = std::static_pointer_cast<arrow::StringArray>(block.get_column(1));
   column3 = std::static_pointer_cast<arrow::StringArray>(block.get_column(2));
   column4 = std::static_pointer_cast<arrow::Int64Array>(block.get_column(3));
 
   int row = 0;
-  EXPECT_EQ(row_index, 0);
+  EXPECT_EQ(successful_insert, true);
   EXPECT_EQ(block.get_num_rows(), 1);
   EXPECT_EQ(valid->Value(row), true);
   EXPECT_EQ(column1->Value(row), 4242);
@@ -239,10 +237,9 @@ TEST_F(HustleBlockTest, FullBlock) {
   }
 
   // This block cannot hold a 9th copy of the first record
-  int row_index =
-      block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  int row_index = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
-  EXPECT_EQ(row_index, -1);
+  EXPECT_EQ(row_index, false);
   EXPECT_EQ(block.get_bytes_left(), BLOCK_SIZE - 912);
 }
 

--- a/src/storage/tests/block_test.cc
+++ b/src/storage/tests/block_test.cc
@@ -153,7 +153,7 @@ TEST_F(HustleBlockTest, EmptyBlock) {
 
 TEST_F(HustleBlockTest, OneInsertBlock) {
   Block block(0, schema, BLOCK_SIZE);
-  bool successful_insert = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
+  int row_index = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
   valid = std::static_pointer_cast<arrow::BooleanArray>(block.get_valid_column());
   column1 = std::static_pointer_cast<arrow::Int64Array>(block.get_column(0));
@@ -162,7 +162,7 @@ TEST_F(HustleBlockTest, OneInsertBlock) {
   column4 = std::static_pointer_cast<arrow::Int64Array>(block.get_column(3));
 
   int row = 0;
-  EXPECT_EQ(successful_insert, true);
+  EXPECT_EQ(row_index, 0);
   EXPECT_EQ(block.get_num_rows(), 1);
   EXPECT_EQ(valid->Value(row), true);
   EXPECT_EQ(column1->Value(row), 4242);
@@ -239,7 +239,7 @@ TEST_F(HustleBlockTest, FullBlock) {
   // This block cannot hold a 9th copy of the first record
   int row_index = block.InsertRecord((uint8_t *)record_string_1.data(), byte_widths_1);
 
-  EXPECT_EQ(row_index, false);
+  EXPECT_EQ(row_index, -1);
   EXPECT_EQ(block.get_bytes_left(), BLOCK_SIZE - 912);
 }
 

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -152,12 +152,12 @@ TEST_F(HustleTableTest, TableIO) {
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   write_to_file("table.hsl", table);
   auto table_from_file = read_from_file("table.hsl");
-  EXPECT_TRUE(
-      table_from_file->get_block(0)->get_valid_column()->Equals(*table.get_block(0)->get_valid_column()));
-  EXPECT_TRUE(
-      table_from_file->get_block(0)->get_records()->Equals(*table.get_block(0)->get_records()));
-  EXPECT_TRUE(
-      table_from_file->get_block(1)->get_records()->Equals(*table.get_block(1)->get_records()));
+  EXPECT_TRUE(table_from_file->get_block(0)->get_valid_column()->Equals(
+      *table.get_block(0)->get_valid_column()));
+  EXPECT_TRUE(table_from_file->get_block(0)->get_records()->Equals(
+      *table.get_block(0)->get_records()));
+  EXPECT_TRUE(table_from_file->get_block(1)->get_records()->Equals(
+      *table.get_block(1)->get_records()));
 }
 
 TEST_F(HustleTableTest, ReadTableFromCSV) {
@@ -170,7 +170,8 @@ TEST_F(HustleTableTest, ReadTableFromCSV) {
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
-  auto table_from_csv = read_from_csv_file("table_test.csv", schema, BLOCK_SIZE);
+  auto table_from_csv =
+      read_from_csv_file("table_test.csv", schema, BLOCK_SIZE);
   EXPECT_TRUE(table_from_csv->get_block(0)->get_records()->Equals(
       *table.get_block(0)->get_records()));
   EXPECT_TRUE(table_from_csv->get_block(1)->get_records()->Equals(
@@ -261,7 +262,8 @@ TEST_F(HustleTableTest, Update) {
   customer_table.addColumn(c_phone);
   customer_table.addColumn(c_mktsegment);
   customer_table.setPrimaryKey({});
-  std::shared_ptr<arrow::Schema> customer_schema = customer_table.getArrowSchema();
+  std::shared_ptr<arrow::Schema> customer_schema =
+      customer_table.getArrowSchema();
   std::string query =
       "BEGIN TRANSACTION; "
       "INSERT INTO customer_table VALUES (800224, 'James', "
@@ -332,7 +334,8 @@ TEST_F(HustleTableTest, Delete) {
   customer_table.addColumn(c_phone);
   customer_table.addColumn(c_mktsegment);
   customer_table.setPrimaryKey({});
-  std::shared_ptr<arrow::Schema> customer_schema = customer_table.getArrowSchema();
+  std::shared_ptr<arrow::Schema> customer_schema =
+      customer_table.getArrowSchema();
   std::string query =
       "BEGIN TRANSACTION; "
       "INSERT INTO customer_table_d VALUES (800224, 'James', "
@@ -350,7 +353,8 @@ TEST_F(HustleTableTest, Delete) {
       "DELETE FROM customer_table_d where c_custkey=800224;"
       "COMMIT;";
   hustleDB.executeQuery(query);
-  auto col = std::static_pointer_cast<arrow::StringArray>(customer_table_ptr->get_column(5)->chunk(0));
+  auto col = std::static_pointer_cast<arrow::StringArray>(
+      customer_table_ptr->get_column(5)->chunk(0));
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 0);
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -107,7 +107,7 @@ TEST_F(HustleTableTest, EmptyTable) {
 TEST_F(HustleTableTest, OneBlockTable) {
   DBTable table("table", schema, BLOCK_SIZE);
 
-  table.insert_record((uint8_t *)record_string.data(), byte_widths);
+  table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
 
   EXPECT_EQ(table.get_num_blocks(), 1);
 }
@@ -115,7 +115,7 @@ TEST_F(HustleTableTest, OneBlockTable) {
 TEST_F(HustleTableTest, OneBlockArray) {
   DBTable table("table", schema, BLOCK_SIZE);
 
-  table.insert_records(column_data);
+  table.InsertRecords(column_data);
 
   EXPECT_EQ(table.get_num_blocks(), 1);
 }
@@ -125,11 +125,11 @@ TEST_F(HustleTableTest, TwoBlockArray) {
 
   // Inserting three records 14 times. This fits into one block.
   for (int i = 0; i < 14; i++) {
-    table.insert_records(column_data);
+    table.InsertRecords(column_data);
   }
 
   // Bulk inserting again should allocate a new block
-  table.insert_records(column_data);
+  table.InsertRecords(column_data);
 
   EXPECT_EQ(table.get_num_blocks(), 2);
 }
@@ -140,12 +140,12 @@ TEST_F(HustleTableTest, TwoBlockTable) {
   // With 1 KB block size, we can store 8 copies of the first record in one
   // block.
   for (int i = 0; i < 8; i++) {
-    table.insert_record((uint8_t *)record_string.data(), byte_widths);
+    table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   }
 
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
-  table.insert_record((uint8_t *)record_string.data(), byte_widths);
+  table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
 
   EXPECT_EQ(table.get_num_blocks(), 2);
 }
@@ -153,17 +153,17 @@ TEST_F(HustleTableTest, TwoBlockTable) {
 TEST_F(HustleTableTest, TableIO) {
   DBTable table("table", schema, BLOCK_SIZE);
 
-  table.insert_records(column_data);
-  table.insert_record((uint8_t *)record_string.data(), byte_widths);
-  table.insert_records(column_data);
+  table.InsertRecords(column_data);
+  table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
+  table.InsertRecords(column_data);
 
   for (int i = 0; i < 8; i++) {
-    table.insert_record((uint8_t *)record_string.data(), byte_widths);
+    table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   }
 
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
-  table.insert_record((uint8_t *)record_string.data(), byte_widths);
+  table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
 
   write_to_file("table.hsl", table);
 
@@ -183,12 +183,12 @@ TEST_F(HustleTableTest, ReadTableFromCSV) {
   // With 1 KB block size, we can store 8 copies of the first record in one
   // block.
   for (int i = 0; i < 8; i++) {
-    table.insert_record((uint8_t *)record_string.data(), byte_widths);
+    table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   }
 
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
-  table.insert_record((uint8_t *)record_string.data(), byte_widths);
+  table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
 
   auto table_from_csv =
       read_from_csv_file("table_test.csv", schema, BLOCK_SIZE);

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -100,99 +100,77 @@ class HustleTableTest : public testing::Test {
 
 TEST_F(HustleTableTest, EmptyTable) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   EXPECT_EQ(table.get_num_blocks(), 0);
 }
 
 TEST_F(HustleTableTest, OneBlockTable) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
-
   EXPECT_EQ(table.get_num_blocks(), 1);
 }
 
 TEST_F(HustleTableTest, OneBlockArray) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   table.InsertRecords(column_data);
-
   EXPECT_EQ(table.get_num_blocks(), 1);
 }
 
 TEST_F(HustleTableTest, TwoBlockArray) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   // Inserting three records 14 times. This fits into one block.
   for (int i = 0; i < 14; i++) {
     table.InsertRecords(column_data);
   }
-
   // Bulk inserting again should allocate a new block
   table.InsertRecords(column_data);
-
   EXPECT_EQ(table.get_num_blocks(), 2);
 }
 
 TEST_F(HustleTableTest, TwoBlockTable) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   // With 1 KB block size, we can store 8 copies of the first record in one
   // block.
   for (int i = 0; i < 8; i++) {
     table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   }
-
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
-
   EXPECT_EQ(table.get_num_blocks(), 2);
 }
 
 TEST_F(HustleTableTest, TableIO) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   table.InsertRecords(column_data);
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   table.InsertRecords(column_data);
-
   for (int i = 0; i < 8; i++) {
     table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   }
-
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
-
   write_to_file("table.hsl", table);
-
   auto table_from_file = read_from_file("table.hsl");
-
-  EXPECT_TRUE(table_from_file->get_block(0)->get_valid_column()->Equals(
-      *table.get_block(0)->get_valid_column()));
-  EXPECT_TRUE(table_from_file->get_block(0)->get_records()->Equals(
-      *table.get_block(0)->get_records()));
-  EXPECT_TRUE(table_from_file->get_block(1)->get_records()->Equals(
-      *table.get_block(1)->get_records()));
+  EXPECT_TRUE(
+      table_from_file->get_block(0)->get_valid_column()->Equals(*table.get_block(0)->get_valid_column()));
+  EXPECT_TRUE(
+      table_from_file->get_block(0)->get_records()->Equals(*table.get_block(0)->get_records()));
+  EXPECT_TRUE(
+      table_from_file->get_block(1)->get_records()->Equals(*table.get_block(1)->get_records()));
 }
 
 TEST_F(HustleTableTest, ReadTableFromCSV) {
   DBTable table("table", schema, BLOCK_SIZE);
-
   // With 1 KB block size, we can store 8 copies of the first record in one
   // block.
   for (int i = 0; i < 8; i++) {
     table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
   }
-
   // The first block cannot hold a 9th copy of the first record, so we must
   // create a new block.
   table.InsertRecord((uint8_t *)record_string.data(), byte_widths);
-
-  auto table_from_csv =
-      read_from_csv_file("table_test.csv", schema, BLOCK_SIZE);
-
+  auto table_from_csv = read_from_csv_file("table_test.csv", schema, BLOCK_SIZE);
   EXPECT_TRUE(table_from_csv->get_block(0)->get_records()->Equals(
       *table.get_block(0)->get_records()));
   EXPECT_TRUE(table_from_csv->get_block(1)->get_records()->Equals(
@@ -283,9 +261,7 @@ TEST_F(HustleTableTest, Update) {
   customer_table.addColumn(c_phone);
   customer_table.addColumn(c_mktsegment);
   customer_table.setPrimaryKey({});
-  std::shared_ptr<arrow::Schema> customer_schema =
-      customer_table.getArrowSchema();
-
+  std::shared_ptr<arrow::Schema> customer_schema = customer_table.getArrowSchema();
   std::string query =
       "BEGIN TRANSACTION; "
       "INSERT INTO customer_table VALUES (800224, 'James', "
@@ -307,13 +283,10 @@ TEST_F(HustleTableTest, Update) {
   hustleDB.executeQuery(query);
   auto col = std::static_pointer_cast<arrow::StringArray>(
       customer_table_ptr->get_column(5)->chunk(0));
-
   EXPECT_EQ(col->GetString(0), "fine");
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 1);
-
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
-
   auto int_col = std::static_pointer_cast<arrow::Int64Array>(
       customer_table_ptr->get_column(7)->chunk(0));
   EXPECT_EQ(int_col->Value(0), 12);
@@ -322,10 +295,8 @@ TEST_F(HustleTableTest, Update) {
       "UPDATE customer_table set c_mktsegment = 1123 where c_custkey=800224;"
       "COMMIT;";
   hustleDB.executeQuery(query);
-
   EXPECT_EQ(int_col->Value(0), 1123);
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 1);
-
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
 }
@@ -361,9 +332,7 @@ TEST_F(HustleTableTest, Delete) {
   customer_table.addColumn(c_phone);
   customer_table.addColumn(c_mktsegment);
   customer_table.setPrimaryKey({});
-  std::shared_ptr<arrow::Schema> customer_schema =
-      customer_table.getArrowSchema();
-
+  std::shared_ptr<arrow::Schema> customer_schema = customer_table.getArrowSchema();
   std::string query =
       "BEGIN TRANSACTION; "
       "INSERT INTO customer_table_d VALUES (800224, 'James', "
@@ -376,18 +345,13 @@ TEST_F(HustleTableTest, Delete) {
   hustle::HustleDB hustleDB("db_directory3");
   hustleDB.createTable(customer_table, customer_table_ptr);
   hustleDB.executeQuery(query);
-
   query =
       "BEGIN TRANSACTION;"
       "DELETE FROM customer_table_d where c_custkey=800224;"
       "COMMIT;";
-
   hustleDB.executeQuery(query);
-  auto col = std::static_pointer_cast<arrow::StringArray>(
-      customer_table_ptr->get_column(5)->chunk(0));
-
+  auto col = std::static_pointer_cast<arrow::StringArray>(customer_table_ptr->get_column(5)->chunk(0));
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 0);
-
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_cols(), 8);
 }

--- a/src/storage/util.cc
+++ b/src/storage/util.cc
@@ -212,7 +212,7 @@ void write_to_file(const char* path, hustle::storage::DBTable& table) {
   for (int i = 0; i < blocks.size(); i++) {
     // IMPORTANT: The buffer size must be consistent with the ArrayData
     // length, or else data will not be properly written to file.
-    blocks[i]->truncate_buffers();
+    blocks[i]->TruncateBuffers();
     status = record_batch_writer->WriteRecordBatch(*blocks[i]->get_records());
     evaluate_status(status, __FUNCTION__, __LINE__);
   }
@@ -385,7 +385,7 @@ std::shared_ptr<hustle::storage::DBTable> read_from_csv_file(
       byte_widths[index] = values[index].length();
     }
 
-    out_table->insert_record(values, byte_widths);
+    out_table->InsertRecord(values, byte_widths);
   }
   return out_table;
 }


### PR DESCRIPTION
Changes focus on readability, clean up, and inline'ing of relevant methods. Significant documentation via doc-strings has been added. Tests were slightly modified to match the new behavior of "InsertRecord" and similar methods, which have all been unified to return the same output.