### PR TITLE
Sql - e2e tests and test data generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,5 @@ jobs:
       - run: mkdir build
       - run: (cd build && ../cmake-3.15.5/bin/cmake .. )
       - run: (cd build && make -j 4)
-      - run: (cd test/data && python3 test_generate_data.py)
+      - run: (cd test/data && python test_generate_data.py)
       - run: (cd build && ../cmake-3.15.5/bin/ctest --verbose --output-on-failure)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,5 @@ jobs:
       - run: mkdir build
       - run: (cd build && ../cmake-3.15.5/bin/cmake .. )
       - run: (cd build && make -j 4)
+      - run: (cd test/data && python3 test_generate_data.py)
       - run: (cd build && ../cmake-3.15.5/bin/ctest --verbose --output-on-failure)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ make -j all
 
 To run the test go into the build directory and use:
 ```
-ctest --output-on-failure
+./run_test.sh 
 ```
 
 ## Run Benchmark

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 cd test/data && python3 test_generate_data.py
 cd ../../build && ctest --output-on-failure

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,2 @@
+cd test/data && python3 test_generate_data.py
+cd ../../build && ctest --output-on-failure

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-cd test/data && python3 test_generate_data.py
+cd test/data && python test_generate_data.py
 cd ../../build && ctest --output-on-failure

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -21,3 +21,17 @@ target_link_libraries(hustle_hustleDB_test
         )
 add_test(HustleDB_test hustle_hustleDB_test)
 
+add_executable(hustle_SQL_test "tests/sql_test.cc")
+target_link_libraries(hustle_SQL_test
+        gtest
+        gtest_main
+        gmock
+        hustle_src_catalog
+        sqlite3
+        absl::container absl::hash
+        absl::flat_hash_map
+        hustleDB
+        )
+add_test(SQL_test hustle_SQL_test)
+
+

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -27,8 +27,8 @@ namespace hustle {
 
 std::map<std::string, std::shared_ptr<Catalog>> hustle::HustleDB::catalogs = {};
 
-void HustleDB::addCatalog(std::string db_name,
-                          std::shared_ptr<Catalog> catalog) {
+void HustleDB::add_catalog(std::string db_name,
+                           std::shared_ptr<Catalog> catalog) {
   auto catalog_itr = hustle::HustleDB::catalogs.find(db_name);
   if (catalog_itr != hustle::HustleDB::catalogs.end()) {
     return;
@@ -36,7 +36,7 @@ void HustleDB::addCatalog(std::string db_name,
   hustle::HustleDB::catalogs[db_name] = catalog;
 }
 
-std::shared_ptr<Catalog> HustleDB::getCatalog(std::string db_name) {
+std::shared_ptr<Catalog> HustleDB::get_catalog(std::string db_name) {
   return hustle::HustleDB::catalogs[db_name];
 }
 
@@ -50,50 +50,40 @@ HustleDB::HustleDB(std::string DBpath)
     std::filesystem::create_directories(DBpath);
   }
   utils::initialize_sqlite3();
-  this->addCatalog(SqliteDBPath_, catalog_);
+    this->add_catalog(SqliteDBPath_, catalog_);
 };
 
-std::string HustleDB::getPlan(const std::string &sql) {
+std::string HustleDB::get_plan(const std::string &sql) {
   return utils::executeSqliteReturnOutputString(SqliteDBPath_, sql);
 }
 
-bool HustleDB::createTable(const TableSchema ts) {
+bool HustleDB::create_table(const TableSchema ts) {
   return catalog_->addTable(ts);
 }
 
-bool HustleDB::createTable(const TableSchema ts,
-                           DBTable::TablePtr table_ref) {
+bool HustleDB::create_table(const TableSchema ts,
+                            DBTable::TablePtr table_ref) {
   return catalog_->addTable(ts, table_ref);
 }
 
-void HustleDB::loadTables() {
+void HustleDB::load_tables() {
   utils::loadTables(SqliteDBPath_, hustle::HustleDB::catalogs[SqliteDBPath_]->getTables());
 }
 
-std::string HustleDB::executeQuery(const std::string &sql) {
+std::string HustleDB::execute_query_result(const std::string &sql) {
   return utils::executeSqliteReturnOutputString(SqliteDBPath_, sql);
 }
 
-bool HustleDB::executeNoOutputQuery(const std::string &sql) {
+bool HustleDB::execute_query(const std::string &sql) {
   return utils::executeSqliteNoOutput(SqliteDBPath_, sql);
 }
 
-bool HustleDB::dropTable(const std::string &name) {
+bool HustleDB::drop_table(const std::string &name) {
   return catalog_->dropTable(name);
 }
 
-bool HustleDB::dropMemTable(const std::string &name) {
+bool HustleDB::drop_mem_table(const std::string &name) {
   return catalog_->dropMemTable(name);
-}
-
-bool HustleDB::insert() {
-  // TODO(nicholas) once arrow is integrated
-  return true;
-}
-
-bool HustleDB::select() {
-  // TODO(nicholas) once arrow is integrated
-  return true;
 }
 
 }  // namespace hustle

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -34,38 +34,31 @@ class HustleDB {
  public:
   static std::map<std::string, std::shared_ptr<Catalog>> catalogs;
 
-  static Scheduler &getScheduler() { return Scheduler::GlobalInstance(); }
+  static Scheduler &get_scheduler() { return Scheduler::GlobalInstance(); }
 
-  static void addCatalog(std::string db_name, std::shared_ptr<Catalog> catalog);
+  static void add_catalog(std::string db_name, std::shared_ptr<Catalog> catalog);
 
-  static std::shared_ptr<Catalog> getCatalog(std::string db_name);
+  static std::shared_ptr<Catalog> get_catalog(std::string db_name);
 
   HustleDB(std::string path);
 
-  bool createTable(const TableSchema ts);
+  bool create_table(const TableSchema ts);
 
-  bool createTable(const TableSchema ts, DBTable::TablePtr table_ref);
+  bool create_table(const TableSchema ts, DBTable::TablePtr table_ref);
 
-  void loadTables();
+  void load_tables();
 
-  bool dropTable(const std::string &name);
+  bool drop_table(const std::string &name);
 
-  bool dropMemTable(const std::string &name);
+  bool drop_mem_table(const std::string &name);
 
-  std::string executeQuery(const std::string &sql);
+  std::string execute_query_result(const std::string &sql);
 
-  bool executeNoOutputQuery(const std::string &sql);
+  bool execute_query(const std::string &sql);
 
-  std::string getPlan(const std::string &sql);
+  std::string get_plan(const std::string &sql);
 
-  const std::string getSqliteDBPath() { return SqliteDBPath_; }
-  // Not implemented yet.
-  bool insert();
-
-  // Not implemented yet.
-  bool select();
-
-  static bool startScheduler() {
+  static bool start_scheduler() {
     if (!Scheduler::GlobalInstance().isActive()) {
       Scheduler::GlobalInstance().start();
       return true;
@@ -73,7 +66,7 @@ class HustleDB {
     return false;
   }
 
-  static bool stopScheduler() {
+  static bool stop_scheduler() {
     if (Scheduler::GlobalInstance().isActive()) {
       Scheduler::GlobalInstance().join();
       return true;
@@ -81,7 +74,9 @@ class HustleDB {
     return false;
   }
 
-  Catalog *getCatalog() { return catalog_.get(); }
+  const std::string get_sqlite_path() { return SqliteDBPath_; }
+
+  Catalog *get_catalog() { return catalog_.get(); }
 
    ~HustleDB() {}
 

--- a/src/api/tests/hustle_db_test.cc
+++ b/src/api/tests/hustle_db_test.cc
@@ -44,7 +44,7 @@ TEST(HustleDB, createTable) {
   std::filesystem::remove_all("db_directory");
 
   hustle::HustleDB hustleDB("db_directory/db_dir_nested");
-  hustle::HustleDB::startScheduler();
+    hustle::HustleDB::start_scheduler();
 
   TableSchema ts("Subscriber");
   ColumnSchema c1("c1", {HustleType::INTEGER, 0}, true, false);
@@ -52,10 +52,10 @@ TEST(HustleDB, createTable) {
   ts.addColumn(c1);
   ts.addColumn(c2);
   ts.setPrimaryKey({"c1", "c2"});
-  EXPECT_TRUE(hustleDB.createTable(ts));
+  EXPECT_TRUE(hustleDB.create_table(ts));
 
-  EXPECT_TRUE(hustleDB.getCatalog()->TableExists(ts.getName()));
-  EXPECT_FALSE(hustleDB.createTable(ts));
+  EXPECT_TRUE(hustleDB.get_catalog()->TableExists(ts.getName()));
+  EXPECT_FALSE(hustleDB.create_table(ts));
 
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/catalog.json"));
@@ -63,10 +63,10 @@ TEST(HustleDB, createTable) {
       std::filesystem::exists("db_directory/db_dir_nested/hustle_sqlite.db"));
 
   hustle::HustleDB hustleDB2("db_directory");
-  EXPECT_TRUE(hustleDB.getCatalog()->TableExists(ts.getName()));
+  EXPECT_TRUE(hustleDB.get_catalog()->TableExists(ts.getName()));
 
   std::filesystem::remove_all("db_directory");
-  hustle::HustleDB::stopScheduler();
+    hustle::HustleDB::stop_scheduler();
 }
 
 TEST(HustleDB, DropTable) {
@@ -80,17 +80,17 @@ TEST(HustleDB, DropTable) {
   ts.addColumn(c1);
   ts.addColumn(c2);
   ts.setPrimaryKey({"c1", "c2"});
-  EXPECT_TRUE(hustleDB.createTable(ts));
+  EXPECT_TRUE(hustleDB.create_table(ts));
 
-  EXPECT_TRUE(hustle::HustleDB::getCatalog("db_directory/db_dir_nested/hustle_sqlite.db")->TableExists(ts.getName()));
+  EXPECT_TRUE(hustle::HustleDB::get_catalog("db_directory/db_dir_nested/hustle_sqlite.db")->TableExists(ts.getName()));
 
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/catalog.json"));
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/hustle_sqlite.db"));
   
-  EXPECT_TRUE(hustleDB.dropTable(ts.getName()));
-  EXPECT_FALSE(hustle::HustleDB::getCatalog("db_directory/db_dir_nested/hustle_sqlite.db")->TableExists(ts.getName()));
+  EXPECT_TRUE(hustleDB.drop_table(ts.getName()));
+  EXPECT_FALSE(hustle::HustleDB::get_catalog("db_directory/db_dir_nested/hustle_sqlite.db")->TableExists(ts.getName()));
 
   EXPECT_TRUE(
       std::filesystem::exists("db_directory/db_dir_nested/catalog.json"));
@@ -111,10 +111,10 @@ TEST(HustleDB, getPlan) {
   ts.addColumn(c1);
   ts.addColumn(c2);
   ts.setPrimaryKey({"c1", "c2"});
-  EXPECT_TRUE(hustleDB.createTable(ts));
+  EXPECT_TRUE(hustleDB.create_table(ts));
 
   std::string plan =
-      hustleDB.getPlan("EXPLAIN QUERY PLAN SELECT c1,c2 FROM Subscriber;");
+          hustleDB.get_plan("EXPLAIN QUERY PLAN SELECT c1,c2 FROM Subscriber;");
 
   EXPECT_EQ(plan, "2 | 0 | 0 | SCAN TABLE Subscriber\n");
 

--- a/src/api/tests/sql_test.cc
+++ b/src/api/tests/sql_test.cc
@@ -187,11 +187,11 @@ class SQLTest : public Test {
     SQLTest::d = std::make_shared<hustle::storage::DBTable>(
         "ddate", SQLTest::ddate.getArrowSchema(), BLOCK_SIZE);
 
-    hustle_db->createTable(SQLTest::lineorder, SQLTest::lo);
-    hustle_db->createTable(SQLTest::customer, SQLTest::c);
-    hustle_db->createTable(SQLTest::supplier, SQLTest::s);
-    hustle_db->createTable(SQLTest::part, SQLTest::p);
-    hustle_db->createTable(SQLTest::ddate, SQLTest::d);
+      hustle_db->create_table(SQLTest::lineorder, SQLTest::lo);
+      hustle_db->create_table(SQLTest::customer, SQLTest::c);
+      hustle_db->create_table(SQLTest::supplier, SQLTest::s);
+      hustle_db->create_table(SQLTest::part, SQLTest::p);
+      hustle_db->create_table(SQLTest::ddate, SQLTest::d);
 
     std::cerr << "Create Table " << std::endl;
     // SQLTest::lo = read_from_csv_file("../../../ssb/test/lineorder.tbl",
@@ -219,13 +219,13 @@ class SQLTest : public Test {
       count++;
       if (count == 10000) {
         query += "COMMIT;";
-        hustle_db->executeQuery(query);
+          hustle_db->execute_query_result(query);
         query = "BEGIN TRANSACTION;";
       }
     }
     if (count != 2000) {
       query += "COMMIT;";
-      hustle_db->executeQuery(query);
+        hustle_db->execute_query_result(query);
     }
 
     std::cerr << "lineorder done" << std::endl;
@@ -242,7 +242,7 @@ class SQLTest : public Test {
                StringUtils::trim(std::string(fields[3])) + "');\n";
     }
     query += "COMMIT;";
-    hustle_db->executeQuery(query);
+      hustle_db->execute_query_result(query);
     std::cerr << "part done" << std::endl;
 
     stream = fopen("../../../ssb/test/supplier.tbl", "r");
@@ -258,7 +258,7 @@ class SQLTest : public Test {
                StringUtils::trim(std::string(fields[3])) + "');\n";
     }
     query += "COMMIT;";
-    hustle_db->executeQuery(query);
+      hustle_db->execute_query_result(query);
     std::cerr << "supplier done" << std::endl;
 
     stream = fopen("../../../ssb/test/customer.tbl", "r");
@@ -273,7 +273,7 @@ class SQLTest : public Test {
                StringUtils::trim(std::string(fields[3])) + "');\n";
     }
     query += "COMMIT;";
-    hustle_db->executeQuery(query);
+      hustle_db->execute_query_result(query);
     std::cerr << "customer done" << std::endl;
 
     stream = fopen("../../../ssb/test/date.tbl", "r");
@@ -291,13 +291,13 @@ class SQLTest : public Test {
                StringUtils::trim(std::string(fields[6])) + "');\n";
     }
     query += "COMMIT;";
-    hustle_db->executeQuery(query);
+      hustle_db->execute_query_result(query);
     std::cerr << "date done" << std::endl;
 
-    hustle::HustleDB::startScheduler();
+      hustle::HustleDB::start_scheduler();
   }
 
-  void TearDown() override { hustle::HustleDB::stopScheduler(); }
+  void TearDown() override { hustle::HustleDB::stop_scheduler(); }
 };
 
 hustle::catalog::TableSchema SQLTest::part("part"),
@@ -315,7 +315,7 @@ TEST_F(SQLTest, q1) {
       "from lineorder, ddate "
       "where lo_orderdate = d_datekey and d_year = 1993 and (lo_discount "
       "BETWEEN 0 and 3 and lo_quantity < 25);";
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "3257506\n");
 }
 
@@ -327,7 +327,7 @@ TEST_F(SQLTest, q2) {
       "where lo_orderdate = d_datekey\n"
       "and (lo_discount BETWEEN 5 and 7\n"
       "and lo_quantity BETWEEN 26 and 35);";
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "40305654\n");
 }
 
@@ -341,7 +341,7 @@ TEST_F(SQLTest, q3) {
       "and (lo_discount < 50\n"
       "and lo_quantity < 50);";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "18058284\n");
 }
 
@@ -356,7 +356,7 @@ TEST_F(SQLTest, q4) {
       "and( s_region = 'SREGION12')\n"
       "group by d_year, p_brand1\n"
       "order by d_year, p_brand1;";
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "151764 | 1993 | MFGR#12\n248116 | 1994 | MFGR#12\n");
 }
 
@@ -372,7 +372,7 @@ TEST_F(SQLTest, q5) {
       "\tgroup by d_year, p_brand1\n"
       "\torder by d_year, p_brand1;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "202070 | 1993 | MFGR#24\n313615 | 1994 | MFGR#24\n");
 }
 
@@ -388,7 +388,7 @@ TEST_F(SQLTest, q6) {
       "\tgroup by d_year, p_brand1\n"
       "\torder by d_year, p_brand1;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "226068 | 1993 | MFGR#22\n334290 | 1994 | MFGR#22\n");
 }
 
@@ -406,7 +406,7 @@ TEST_F(SQLTest, q7) {
       "\tgroup by c_nation, s_nation, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output,
             "CNATION55 | SNATION55 | 1993 | 257614\nCNATION55 | SNATION55 | "
             "1994 | 411880\n");
@@ -426,7 +426,7 @@ TEST_F(SQLTest, q8) {
       "\tgroup by c_city, s_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(
       output,
       "CCITY30 | SCITY30 | 1993 | 339688\nCCITY30 | SCITY30 | 1994 | 478056\n");
@@ -446,7 +446,7 @@ TEST_F(SQLTest, q9) {
       "\tgroup by c_city, s_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output,
             "CCITY25 | SCITY25 | 1993 | 327609\nCCITY20 | SCITY20 | 1993 | "
             "407808\nCCITY20 | SCITY20 | 1994 | 499617\nCCITY25 | SCITY25 | "
@@ -467,7 +467,7 @@ TEST_F(SQLTest, q10) {
       "\tgroup by c_city, s_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(
       output,
       "CCITY60 | SCITY60 | 1993 | 398220\nCCITY40 | SCITY40 | 1993 | 411550\n");
@@ -488,7 +488,7 @@ TEST_F(SQLTest, q11) {
       "\tgroup by d_year, c_nation\n"
       "\torder by d_year, c_nation;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "1993 | CNATION71 | 444774\n1994 | CNATION71 | 658856\n");
 }
 
@@ -508,7 +508,7 @@ TEST_F(SQLTest, q12) {
       "\tgroup by d_year, s_nation, p_category\n"
       "\torder by d_year, s_nation, p_category;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output,
             "1993 | SNATION32 | MFGR#32 | 468912\n1994 | SNATION32 | MFGR#32 | "
             "727692\n");
@@ -530,7 +530,7 @@ TEST_F(SQLTest, q13) {
       "\tgroup by d_year, s_city, p_brand1\n"
       "\torder by d_year, s_city, p_brand1;";
 
-  std::string output = hustle_db->executeQuery(query);
+  std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(
       output,
       "1993 | SCITY55 | MFGR#55 | 478426\n1994 | SCITY55 | MFGR#55 | 764920\n");

--- a/src/api/tests/sql_test.cc
+++ b/src/api/tests/sql_test.cc
@@ -1,0 +1,537 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <iostream>
+
+#include "api/hustle_db.h"
+#include "catalog/catalog.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "operators/select/predicate.h"
+#include "resolver/cresolver.h"
+#include "resolver/select_resolver.h"
+#include "sqlite3/sqlite3.h"
+#include "storage/util.h"
+#include "utils/sqlite_utils_parse.h"
+#include "utils/string_utils.h"
+
+using namespace testing;
+using namespace hustle::resolver;
+
+#define BLOCK_SIZE \
+  1024  // Force the block size to small size for the sake of this test
+
+class SQLTest : public Test {
+ public:
+  static hustle::catalog::TableSchema part, supplier, customer, ddate,
+      lineorder;
+  static DBTable::TablePtr lo, d, p, c, s;
+  static std::shared_ptr<hustle::HustleDB> hustle_db;
+
+  char** getfields(char* line, int num) {
+    char** fields = (char**)malloc(num * sizeof(char*));
+    char* field;
+    int index = 0;
+    for (field = strtok(line, "|"); field && *field;
+         field = strtok(NULL, "|\n")) {
+      fields[index++] = field;
+    }
+    return fields;
+  }
+
+  void SetUp() override {
+    std::filesystem::remove_all("db_directory_sql");
+    EXPECT_FALSE(std::filesystem::exists("db_directory_sql"));
+
+    SQLTest::hustle_db = std::make_shared<hustle::HustleDB>("db_directory_sql");
+
+    // Create table part
+    // hustle::catalog::TableSchema part("part");
+    hustle::catalog::ColumnSchema p_partkey(
+        "p_partkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema p_mfgr(
+        "p_mfgr", {hustle::catalog::HustleType::CHAR, 6}, true, false);
+    hustle::catalog::ColumnSchema p_category(
+        "p_category", {hustle::catalog::HustleType::CHAR, 7}, true, false);
+    hustle::catalog::ColumnSchema p_brand1(
+        "p_brand1", {hustle::catalog::HustleType::CHAR, 9}, true, false);
+    SQLTest::part.addColumn(p_partkey);
+    SQLTest::part.addColumn(p_mfgr);
+    SQLTest::part.addColumn(p_category);
+    SQLTest::part.addColumn(p_brand1);
+    SQLTest::part.setPrimaryKey({});
+
+    // Create table supplier
+    // hustle::catalog::TableSchema supplier("supplier");
+    hustle::catalog::ColumnSchema s_suppkey(
+        "s_suppkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema s_city(
+        "s_city", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+    hustle::catalog::ColumnSchema s_nation(
+        "s_nation", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+    hustle::catalog::ColumnSchema s_region(
+        "s_region", {hustle::catalog::HustleType::CHAR, 12}, true, false);
+
+    SQLTest::supplier.addColumn(s_suppkey);
+    SQLTest::supplier.addColumn(s_city);
+    SQLTest::supplier.addColumn(s_nation);
+    SQLTest::supplier.addColumn(s_region);
+    SQLTest::supplier.setPrimaryKey({});
+
+    // Create table customer
+    // hustle::catalog::TableSchema customer("customer");
+    hustle::catalog::ColumnSchema c_suppkey(
+        "c_custkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema c_city(
+        "c_city", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+    hustle::catalog::ColumnSchema c_nation(
+        "c_nation", {hustle::catalog::HustleType::CHAR, 15}, true, false);
+    hustle::catalog::ColumnSchema c_region(
+        "c_region", {hustle::catalog::HustleType::CHAR, 12}, true, false);
+    SQLTest::customer.addColumn(c_suppkey);
+    SQLTest::customer.addColumn(c_city);
+    SQLTest::customer.addColumn(c_nation);
+    SQLTest::customer.addColumn(c_region);
+    SQLTest::customer.setPrimaryKey({});
+
+    // Create table ddate
+    // hustle::catalog::TableSchema ddate("ddate");
+    hustle::catalog::ColumnSchema d_datekey(
+        "d_datekey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema d_dayofweek(
+        "d_dayofweek", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+    hustle::catalog::ColumnSchema d_month(
+        "d_month", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+    hustle::catalog::ColumnSchema d_year(
+        "d_year", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema d_weeknuminyear(
+        "d_weeknuminyear", {hustle::catalog::HustleType::INTEGER, 0}, true,
+        false);
+    hustle::catalog::ColumnSchema d_yearmonthnum(
+        "d_yearmonthnum", {hustle::catalog::HustleType::INTEGER, 0}, true,
+        false);
+    hustle::catalog::ColumnSchema d_yearmonth(
+        "d_yearmonth", {hustle::catalog::HustleType::CHAR, 8}, true, false);
+
+    SQLTest::ddate.addColumn(d_datekey);
+    SQLTest::ddate.addColumn(d_dayofweek);
+    SQLTest::ddate.addColumn(d_month);
+    SQLTest::ddate.addColumn(d_year);
+    SQLTest::ddate.addColumn(d_weeknuminyear);
+    SQLTest::ddate.addColumn(d_yearmonthnum);
+    SQLTest::ddate.addColumn(d_yearmonth);
+    SQLTest::ddate.setPrimaryKey({});
+
+    // Create table lineorder
+    // hustle::catalog::TableSchema lineorder("lineorder");
+    hustle::catalog::ColumnSchema lo_orderkey(
+        "lo_orderkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_linenumber(
+        "lo_linenumber", {hustle::catalog::HustleType::INTEGER, 0}, true,
+        false);
+    hustle::catalog::ColumnSchema lo_custkey(
+        "lo_custkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_partkey(
+        "lo_partkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_suppkey(
+        "lo_suppkey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_orderdate(
+        "lo_orderdate", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_orderpriority(
+        "lo_orderpriority", {hustle::catalog::HustleType::CHAR, 15}, true,
+        false);
+    hustle::catalog::ColumnSchema lo_quantity(
+        "lo_quantity", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_revenue(
+        "lo_revenue", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+    hustle::catalog::ColumnSchema lo_extendedprice(
+        "lo_extendedprice", {hustle::catalog::HustleType::INTEGER, 0}, true,
+        false);
+    hustle::catalog::ColumnSchema lo_discount(
+        "lo_discount", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+    SQLTest::lineorder.addColumn(lo_orderkey);
+    SQLTest::lineorder.addColumn(lo_linenumber);
+    SQLTest::lineorder.addColumn(lo_custkey);
+    SQLTest::lineorder.addColumn(lo_partkey);
+    SQLTest::lineorder.addColumn(lo_suppkey);
+    SQLTest::lineorder.addColumn(lo_orderdate);
+    SQLTest::lineorder.addColumn(lo_quantity);
+    SQLTest::lineorder.addColumn(lo_revenue);
+    SQLTest::lineorder.addColumn(lo_extendedprice);
+    SQLTest::lineorder.addColumn(lo_discount);
+    SQLTest::lineorder.setPrimaryKey({});
+
+    SQLTest::lo = std::make_shared<hustle::storage::DBTable>(
+        "lineorder", SQLTest::lineorder.getArrowSchema(), BLOCK_SIZE);
+    SQLTest::c = std::make_shared<hustle::storage::DBTable>(
+        "customer", SQLTest::customer.getArrowSchema(), BLOCK_SIZE);
+    SQLTest::s = std::make_shared<hustle::storage::DBTable>(
+        "supplier", SQLTest::supplier.getArrowSchema(), BLOCK_SIZE);
+    SQLTest::p = std::make_shared<hustle::storage::DBTable>(
+        "part", SQLTest::part.getArrowSchema(), BLOCK_SIZE);
+    SQLTest::d = std::make_shared<hustle::storage::DBTable>(
+        "ddate", SQLTest::ddate.getArrowSchema(), BLOCK_SIZE);
+
+    hustle_db->createTable(SQLTest::lineorder, SQLTest::lo);
+    hustle_db->createTable(SQLTest::customer, SQLTest::c);
+    hustle_db->createTable(SQLTest::supplier, SQLTest::s);
+    hustle_db->createTable(SQLTest::part, SQLTest::p);
+    hustle_db->createTable(SQLTest::ddate, SQLTest::d);
+
+    std::cerr << "Create Table " << std::endl;
+    // SQLTest::lo = read_from_csv_file("../../../ssb/test/lineorder.tbl",
+    // SQLTest::lineorder.getArrowSchema(),  BLOCK_SIZE);
+    FILE* stream = fopen("../../../ssb/test/lineorder.tbl", "r");
+    char line[2048];
+    std::string query = "BEGIN TRANSACTION;";
+    int count = 0;
+    while (fgets(line, 2048, stream)) {
+      char* tmp = strdup(line);
+      char** fields = getfields(tmp, 10);
+      query += "INSERT INTO lineorder VALUES (" +
+               StringUtils::trim(std::string(fields[0])) + ", " +
+               StringUtils::trim(std::string(fields[1])) + ", " +
+               StringUtils::trim(std::string(fields[2])) + ", " +
+               StringUtils::trim(std::string(fields[3])) +
+               ","
+               "" +
+               StringUtils::trim(std::string(fields[4])) + ", '" +
+               StringUtils::trim(std::string(fields[5])) + "', " +
+               StringUtils::trim(std::string(fields[6])) + ", " +
+               StringUtils::trim(std::string(fields[7])) + ", " +
+               StringUtils::trim(std::string(fields[8])) + "," +
+               StringUtils::trim(std::string(fields[9])) + ");";
+      count++;
+      if (count == 10000) {
+        query += "COMMIT;";
+        hustle_db->executeQuery(query);
+        query = "BEGIN TRANSACTION;";
+      }
+    }
+    if (count != 2000) {
+      query += "COMMIT;";
+      hustle_db->executeQuery(query);
+    }
+
+    std::cerr << "lineorder done" << std::endl;
+
+    stream = fopen("../../../ssb/test/part.tbl", "r");
+    query = "BEGIN TRANSACTION;";
+    while (fgets(line, 2048, stream)) {
+      char* tmp = strdup(line);
+      char** fields = getfields(tmp, 4);
+      query += "INSERT INTO part VALUES (" +
+               StringUtils::trim(std::string(fields[0])) + ", '" +
+               StringUtils::trim(std::string(fields[1])) + "', '" +
+               StringUtils::trim(std::string(fields[2])) + "', '" +
+               StringUtils::trim(std::string(fields[3])) + "');\n";
+    }
+    query += "COMMIT;";
+    hustle_db->executeQuery(query);
+    std::cerr << "part done" << std::endl;
+
+    stream = fopen("../../../ssb/test/supplier.tbl", "r");
+    query = "BEGIN TRANSACTION;";
+    while (fgets(line, 2048, stream)) {
+      char* tmp = strdup(line);
+      // std::cout << line << std::endl;
+      char** fields = getfields(tmp, 4);
+      query += "INSERT INTO supplier VALUES (" +
+               StringUtils::trim(std::string(fields[0])) + ", '" +
+               StringUtils::trim(std::string(fields[1])) + "', '" +
+               StringUtils::trim(std::string(fields[2])) + "', '" +
+               StringUtils::trim(std::string(fields[3])) + "');\n";
+    }
+    query += "COMMIT;";
+    hustle_db->executeQuery(query);
+    std::cerr << "supplier done" << std::endl;
+
+    stream = fopen("../../../ssb/test/customer.tbl", "r");
+    query = "BEGIN TRANSACTION;";
+    while (fgets(line, 2048, stream)) {
+      char* tmp = strdup(line);
+      char** fields = getfields(tmp, 17);
+      query += "INSERT INTO customer VALUES (" +
+               StringUtils::trim(std::string(fields[0])) + ", '" +
+               StringUtils::trim(std::string(fields[1])) + "', '" +
+               StringUtils::trim(std::string(fields[2])) + "', '" +
+               StringUtils::trim(std::string(fields[3])) + "');\n";
+    }
+    query += "COMMIT;";
+    hustle_db->executeQuery(query);
+    std::cerr << "customer done" << std::endl;
+
+    stream = fopen("../../../ssb/test/date.tbl", "r");
+    query = "BEGIN TRANSACTION;";
+    while (fgets(line, 2048, stream)) {
+      char* tmp = strdup(line);
+      char** fields = getfields(tmp, 7);
+      query += "INSERT INTO ddate VALUES (" +
+               StringUtils::trim(std::string(fields[0])) + ", '" +
+               StringUtils::trim(std::string(fields[1])) + "', '" +
+               StringUtils::trim(std::string(fields[2])) + "'," +
+               StringUtils::trim(std::string(fields[3])) + ", " +
+               StringUtils::trim(std::string(fields[4])) + ", " +
+               StringUtils::trim(std::string(fields[5])) + "," + "'" +
+               StringUtils::trim(std::string(fields[6])) + "');\n";
+    }
+    query += "COMMIT;";
+    hustle_db->executeQuery(query);
+    std::cerr << "date done" << std::endl;
+
+    hustle::HustleDB::startScheduler();
+  }
+
+  void TearDown() override { hustle::HustleDB::stopScheduler(); }
+};
+
+hustle::catalog::TableSchema SQLTest::part("part"),
+    SQLTest::supplier("supplier"), SQLTest::customer("customer"),
+    SQLTest::ddate("ddate"), SQLTest::lineorder("lineorder");
+
+DBTable::TablePtr SQLTest::lo, SQLTest::d, SQLTest::p, SQLTest::c, SQLTest::s;
+
+std::shared_ptr<hustle::HustleDB> SQLTest::hustle_db;
+
+TEST_F(SQLTest, q1) {
+  std::string query =
+      "select sum(lo_extendedprice*lo_discount) as "
+      "revenue "
+      "from lineorder, ddate "
+      "where lo_orderdate = d_datekey and d_year = 1993 and (lo_discount "
+      "BETWEEN 0 and 3 and lo_quantity < 25);";
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "3257506\n");
+}
+
+TEST_F(SQLTest, q2) {
+  std::string query =
+      "select sum(lo_extendedprice * lo_discount) as "
+      "revenue\n"
+      "from lineorder, ddate\n"
+      "where lo_orderdate = d_datekey\n"
+      "and (lo_discount BETWEEN 5 and 7\n"
+      "and lo_quantity BETWEEN 26 and 35);";
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "40305654\n");
+}
+
+TEST_F(SQLTest, q3) {
+  std::string query =
+      "select sum(lo_extendedprice) as "
+      "revenue\n"
+      "from lineorder, ddate\n"
+      "where lo_orderdate = d_datekey\n"
+      "and (d_weeknuminyear = 6 and d_year = 1994)\n"
+      "and (lo_discount < 50\n"
+      "and lo_quantity < 50);";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "18058284\n");
+}
+
+TEST_F(SQLTest, q4) {
+  std::string query =
+      "select sum(lo_revenue), d_year, p_brand1\n"
+      "from lineorder, ddate, part, supplier\n"
+      "where lo_partkey = p_partkey\n"
+      "and lo_suppkey = s_suppkey\n"
+      "and lo_orderdate = d_datekey\n"
+      "and (p_category = 'MFGR#12')\n"
+      "and( s_region = 'SREGION12')\n"
+      "group by d_year, p_brand1\n"
+      "order by d_year, p_brand1;";
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "151764 | 1993 | MFGR#12\n248116 | 1994 | MFGR#12\n");
+}
+
+TEST_F(SQLTest, q5) {
+  std::string query =
+      "select sum(lo_revenue), d_year, p_brand1\n"
+      "\tfrom lineorder, ddate, part, supplier\n"
+      "\twhere lo_partkey = p_partkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand (p_brand1 > 'MFGR#22' and p_brand1 < 'MFGR#29')\n"
+      "\t\tand s_region = 'SREGION24'\n"
+      "\tgroup by d_year, p_brand1\n"
+      "\torder by d_year, p_brand1;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "202070 | 1993 | MFGR#24\n313615 | 1994 | MFGR#24\n");
+}
+
+TEST_F(SQLTest, q6) {
+  std::string query =
+      "select sum(lo_revenue), d_year, p_brand1\n"
+      "\tfrom lineorder, ddate, part, supplier\n"
+      "\twhere lo_partkey = p_partkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand p_brand1 = 'MFGR#22'\n"
+      "\t\tand s_region = 'SREGION22'\n"
+      "\tgroup by d_year, p_brand1\n"
+      "\torder by d_year, p_brand1;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "226068 | 1993 | MFGR#22\n334290 | 1994 | MFGR#22\n");
+}
+
+TEST_F(SQLTest, q7) {
+  std::string query =
+      "select c_nation, s_nation, d_year, sum(lo_revenue) "
+      "as revenue\n"
+      "\tfrom customer, lineorder, supplier, ddate\n"
+      "\twhere lo_custkey = c_custkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand c_region = 'CREGION55'\n"
+      "\t\tand s_region = 'SREGION55'\n"
+      "\t\tand (d_year >= 1992 and d_year <= 1997)\n"
+      "\tgroup by c_nation, s_nation, d_year\n"
+      "\torder by d_year asc, revenue desc;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output,
+            "CNATION55 | SNATION55 | 1993 | 257614\nCNATION55 | SNATION55 | "
+            "1994 | 411880\n");
+}
+
+TEST_F(SQLTest, q8) {
+  std::string query =
+      "select c_city, s_city, d_year, sum(lo_revenue) as "
+      "revenue\n"
+      "\tfrom customer, lineorder, supplier, ddate\n"
+      "\twhere lo_custkey = c_custkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand c_nation = 'CNATION30'\n"
+      "\t\tand s_nation = 'SNATION30'\n"
+      "\t\tand (d_year >= 1992 and d_year <= 1997)\n"
+      "\tgroup by c_city, s_city, d_year\n"
+      "\torder by d_year asc, revenue desc;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(
+      output,
+      "CCITY30 | SCITY30 | 1993 | 339688\nCCITY30 | SCITY30 | 1994 | 478056\n");
+}
+
+TEST_F(SQLTest, q9) {
+  std::string query =
+      "select c_city, s_city, d_year, sum(lo_revenue) as "
+      "revenue\n"
+      "\tfrom customer, lineorder, supplier, ddate\n"
+      "\twhere lo_custkey = c_custkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand (c_city='CCITY20' or c_city='CCITY25')\n"
+      "\t\tand (s_city='SCITY20' or s_city='SCITY25')\n"
+      "\t\tand d_year >= 1992 and d_year <= 1997\n"
+      "\tgroup by c_city, s_city, d_year\n"
+      "\torder by d_year asc, revenue desc;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output,
+            "CCITY25 | SCITY25 | 1993 | 327609\nCCITY20 | SCITY20 | 1993 | "
+            "407808\nCCITY20 | SCITY20 | 1994 | 499617\nCCITY25 | SCITY25 | "
+            "1994 | 526320\n");
+}
+
+TEST_F(SQLTest, q10) {
+  std::string query =
+      "select c_city, s_city, d_year, sum(lo_revenue) as "
+      "revenue\n"
+      "\tfrom customer, lineorder, supplier, ddate\n"
+      "\twhere lo_custkey = c_custkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand (c_city='CCITY40' or c_city='CCITY60')\n"
+      "\t\tand (s_city='SCITY40' or s_city='SCITY60')\n"
+      "\t\tand d_yearmonth = 'Dec1993'\n"
+      "\tgroup by c_city, s_city, d_year\n"
+      "\torder by d_year asc, revenue desc;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(
+      output,
+      "CCITY60 | SCITY60 | 1993 | 398220\nCCITY40 | SCITY40 | 1993 | 411550\n");
+}
+
+TEST_F(SQLTest, q11) {
+  std::string query =
+      "select d_year, c_nation, "
+      "sum(lo_revenue) as profit1\n"
+      "\tfrom ddate, customer, supplier, part, lineorder\n"
+      "\twhere lo_partkey = p_partkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_custkey = c_custkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand c_region = 'CREGION71'\n"
+      "\t\tand s_region = 'SREGION71'\n"
+      "\t\tand (p_mfgr = 'MFGR#71' or p_mfgr = 'MFGR#72')\n"
+      "\tgroup by d_year, c_nation\n"
+      "\torder by d_year, c_nation;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output, "1993 | CNATION71 | 444774\n1994 | CNATION71 | 658856\n");
+}
+
+TEST_F(SQLTest, q12) {
+  std::string query =
+      "select d_year, s_nation, p_category, sum(lo_revenue) "
+      "as profit1\n"
+      "\tfrom ddate, customer, supplier, part, lineorder\n"
+      "\twhere lo_partkey = p_partkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_custkey = c_custkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand c_region = 'CREGION32'\n"
+      "\t\tand s_region = 'SREGION32'\n"
+      "\t\tand (d_year = 1993 or d_year = 1994)\n"
+      "\t\tand (p_mfgr = 'MFGR#32' or p_mfgr = 'MFGR#32')\n"
+      "\tgroup by d_year, s_nation, p_category\n"
+      "\torder by d_year, s_nation, p_category;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(output,
+            "1993 | SNATION32 | MFGR#32 | 468912\n1994 | SNATION32 | MFGR#32 | "
+            "727692\n");
+}
+
+TEST_F(SQLTest, q13) {
+  std::string query =
+      "select d_year, s_city, p_brand1, sum(lo_revenue) as "
+      "profit1\n"
+      "\tfrom ddate, customer, supplier, part, lineorder\n"
+      "\twhere lo_partkey = p_partkey\n"
+      "\t\tand lo_suppkey = s_suppkey\n"
+      "\t\tand lo_custkey = c_custkey\n"
+      "\t\tand lo_orderdate = d_datekey\n"
+      "\t\tand c_region = 'CREGION55'\n"
+      "\t\tand s_nation = 'SNATION55'\n"
+      "\t\tand (d_year = 1993 or d_year = 1994)\n"
+      "\t\tand p_category = 'MFGR#55'\n"
+      "\tgroup by d_year, s_city, p_brand1\n"
+      "\torder by d_year, s_city, p_brand1;";
+
+  std::string output = hustle_db->executeQuery(query);
+  EXPECT_EQ(
+      output,
+      "1993 | SCITY55 | MFGR#55 | 478426\n1994 | SCITY55 | MFGR#55 | 764920\n");
+}

--- a/src/benchmark/ssb_queries.cc
+++ b/src/benchmark/ssb_queries.cc
@@ -29,10 +29,10 @@ namespace hustle::operators {
         hustle_db = std::make_shared<HustleDB>("db_directory");
         // it will only start if it is not running.
         CreateTable();
-        hustle::HustleDB::startScheduler();
+        hustle::HustleDB::start_scheduler();
     }
 
-    SSBQueries::~SSBQueries() { hustle::HustleDB::stopScheduler(); }
+    SSBQueries::~SSBQueries() { hustle::HustleDB::stop_scheduler(); }
 
     void SSBQueries::CreateTable() {
         // Create table part
@@ -254,11 +254,11 @@ namespace hustle::operators {
                                                         BLOCK_SIZE);
         s = std::make_shared<hustle::storage::DBTable>("supplier", s_schema,
                                                        BLOCK_SIZE);
-        hustle_db->createTable(supplier, s);
-        hustle_db->createTable(customer, c);
-        hustle_db->createTable(ddate, d);
-        hustle_db->createTable(part, p);
-        hustle_db->createTable(lineorder, lo);
+        hustle_db->create_table(supplier, s);
+        hustle_db->create_table(customer, c);
+        hustle_db->create_table(ddate, d);
+        hustle_db->create_table(part, p);
+        hustle_db->create_table(lineorder, lo);
 
         FILE* stream = fopen("../../../ssb/data/lineorder.tbl", "r");
         char line[2048];
@@ -272,13 +272,13 @@ namespace hustle::operators {
             count++;
             if (count == 10000) {
                 query += "COMMIT;";
-                hustle_db->executeQuery(query);
+                hustle_db->execute_query_result(query);
                 query = "BEGIN TRANSACTION;";
             }
         }
         if (count != 2000) {
             query += "COMMIT;";
-            hustle_db->executeQuery(query);
+            hustle_db->execute_query_result(query);
         }
         std::cout << "lineorder done" << std::endl;
 
@@ -291,7 +291,7 @@ namespace hustle::operators {
         "'"+std::string(fields[4])+"', '"+std::string(fields[5])+"', '"+std::string(fields[6])+"', "+std::string(fields[7])+", '"+std::string(fields[8])+"');\n";
         }
         query += "COMMIT;";
-        hustle_db->executeQuery(query);
+        hustle_db->execute_query_result(query);
         std::cout << "part done" << std::endl;
 
         stream = fopen("../../../ssb/data/supplier.tbl", "r");
@@ -304,7 +304,7 @@ namespace hustle::operators {
         "'"+ std::string(fields[4])+"', '"+ std::string(fields[5])+"', '"+std::string(fields[6])+"');\n";
         }
         query += "COMMIT;";
-        hustle_db->executeQuery(query);
+        hustle_db->execute_query_result(query);
         std::cout << "supplier done" << std::endl;
 
         stream = fopen("../../../ssb/data/customer.tbl", "r");
@@ -314,11 +314,11 @@ namespace hustle::operators {
             char** fields = getfields(tmp, 17);
              query += "INSERT INTO customer VALUES ("+std::string(fields[0])+", '"+ std::string(fields[1])+"', '"+ std::string(fields[2]) +"', '"+ std::string(fields[3]) +"', "\
         "'"+ std::string(fields[4]) +"', '"+std::string(fields[5]) +"', '"+std::string(fields[6])+"', '"+std::string(fields[7])+"');\n";
-            //hustle_db->executeQuery(query);
+            //hustle_db->execute_query_result(query);
 
         }
         query += "COMMIT;";
-        hustle_db->executeQuery(query);
+        hustle_db->execute_query_result(query);
         std::cout << "customer done" << std::endl;
 
         stream = fopen("../../../ssb/data/date.tbl", "r");
@@ -330,7 +330,7 @@ namespace hustle::operators {
         ""+std::string(fields[4])+", "+std::string(fields[5])+", '"+std::string(fields[6])+"', "+std::string(fields[7])+", "+std::string(fields[8])+", "+std::string(fields[9])+", "+std::string(fields[10])+", "+std::string(fields[11])+", '"+ std::string(fields[12]) +"', '"+std::string(fields[13])+"', '"+std::string(fields[14])+"', '"+std::string(fields[15])+"', '"+ std::string(fields[16])+"');\n";
         }
         query += "COMMIT;";
-        hustle_db->executeQuery(query);
+        hustle_db->execute_query_result(query);
         std::cout << "date done" << std::endl;
     }
 
@@ -356,7 +356,7 @@ namespace hustle::operators {
                 "between 1 and 3) "
                 "group by lo_discount "
                 "order by lo_discount";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -373,7 +373,7 @@ namespace hustle::operators {
                 "and lo_quantity >= 26 and lo_quantity <= 35)\n"
                 "group by d_yearmonthnum\n"
                 "order by d_yearmonthnum;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -390,7 +390,7 @@ namespace hustle::operators {
                 "and lo_quantity >= 36 and lo_quantity <= 40)\n"
                 "group by d_year, d_weeknuminyear\n"
                 "order by d_year, d_weeknuminyear;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -407,7 +407,7 @@ namespace hustle::operators {
                 "and s_region = 'AMERICA'\n"
                 "group by d_year, p_brand1\n"
                 "order by d_year, p_brand1;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }    }
@@ -423,7 +423,7 @@ namespace hustle::operators {
                 "\t\tand s_region = 'ASIA'\n"
                 "\tgroup by d_year, p_brand1\n"
                 "\torder by d_year, p_brand1;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -440,7 +440,7 @@ namespace hustle::operators {
                 "\t\tand s_region = 'EUROPE'\n"
                 "\tgroup by d_year, p_brand1\n"
                 "\torder by d_year, p_brand1;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -459,7 +459,7 @@ namespace hustle::operators {
                 "\t\tand (d_year >= 1992 and d_year <= 1997)\n"
                 "\tgroup by c_nation, s_nation, d_year\n"
                 "\torder by d_year, revenue;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -478,7 +478,7 @@ namespace hustle::operators {
                 "\t\tand (d_year >= 1992 and d_year <= 1997)\n"
                 "\tgroup by c_city, s_city, d_year\n"
                 "\torder by d_year, revenue;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -499,7 +499,7 @@ namespace hustle::operators {
                 "\t\tand (d_year >= 1992 and d_year <= 1997)\n"
                 "\tgroup by c_city, s_city, d_year\n"
                 "\torder by d_year, revenue;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -520,7 +520,7 @@ namespace hustle::operators {
                 "\t\tand d_yearmonth = 'Dec1997'\n"
                 "\tgroup by c_city, s_city, d_year\n"
                 "\torder by d_year, revenue;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -540,7 +540,7 @@ namespace hustle::operators {
                 "\t\tand (p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2')\n"
                 "\tgroup by d_year, c_nation\n"
                 "\torder by d_year, c_nation;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -561,7 +561,7 @@ namespace hustle::operators {
                 "\t\tand (p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2')\n"
                 "\tgroup by d_year, s_nation, p_category\n"
                 "\torder by d_year, s_nation, p_category;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }
@@ -582,7 +582,7 @@ namespace hustle::operators {
                 "\t\tand p_category = 'MFGR#14'\n"
                 "\tgroup by d_year, s_city, p_brand1\n"
                 "\torder by d_year, s_city, p_brand1;";
-        std::string result = hustle_db->executeQuery(query);
+        std::string result = hustle_db->execute_query_result(query);
         if (this->is_output_enabled) {
             std::cout << result << std::endl;
         }

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -25,11 +25,11 @@ TATP::TATP() {
   std::filesystem::remove_all("db_directory");
   hustle_db = std::make_shared<HustleDB>("db_directory2");
   // it will only start if it is not running.
-  hustle::HustleDB::startScheduler();
+    hustle::HustleDB::start_scheduler();
   CreateTable();
 }
 
-TATP::~TATP() { hustle::HustleDB::stopScheduler(); }
+TATP::~TATP() { hustle::HustleDB::stop_scheduler(); }
 
 void TATP::CreateTable() {
   std::shared_ptr<arrow::Schema> s_schema, ai_schema, sf_schema, cf_schema;
@@ -215,12 +215,12 @@ void TATP::CreateTable() {
   cf = std::make_shared<hustle::storage::DBTable>("Call_Forwarding", cf_schema,
                                                   BLOCK_SIZE);
 
-  hustle_db->createTable(subscriber, s);
+    hustle_db->create_table(subscriber, s);
 
-  hustle_db->createTable(access_info, ai);
+    hustle_db->create_table(access_info, ai);
 
-  hustle_db->createTable(special_facility, sf);
-  hustle_db->createTable(call_forwarding, cf);
+    hustle_db->create_table(special_facility, sf);
+    hustle_db->create_table(call_forwarding, cf);
 
   std::cout << "Subscriber insert" << std::endl;
   std::string query = "BEGIN TRANSACTION; ";
@@ -237,7 +237,7 @@ void TATP::CreateTable() {
              "131321, 131321, 131321, 131321);";
   }
   query += "COMMIT;";
-  hustle_db->executeQuery(query);
+    hustle_db->execute_query_result(query);
 
   query = "BEGIN TRANSACTION; ";
   for (int i = 9; i < 1000000; i++) {
@@ -247,7 +247,7 @@ void TATP::CreateTable() {
              "'LOW', 'Great');";
   }
   query += "COMMIT;";
-  hustle_db->executeQuery(query);
+    hustle_db->execute_query_result(query);
   std::cout << "access info insert ends" << std::endl;
 
   query = "BEGIN TRANSACTION; ";
@@ -257,10 +257,10 @@ void TATP::CreateTable() {
              ", 131321,"
              "131321, 131321,"
              "'great');";
-    // hustleDB.executeQuery(query);
+    // hustleDB.execute_query_result(query);
   }
   query += "COMMIT;";
-  hustle_db->executeQuery(query);
+    hustle_db->execute_query_result(query);
 
   query = "BEGIN TRANSACTION; ";
   for (int i = 9; i < 1000000; i++) {
@@ -269,10 +269,10 @@ void TATP::CreateTable() {
              ", 131,"
              "131321,"
              "'great');";
-    // hustleDB.executeQuery(query);
+    // hustleDB.execute_query_result(query);
   }
   query += "COMMIT;";
-  hustle_db->executeQuery(query);
+    hustle_db->execute_query_result(query);
 }
 
 void TATP::RunBenchmark() {
@@ -300,7 +300,7 @@ void TATP::RunQuery1() {
       "WHERE s_id=10;";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 1");
-  hustle_db->executeQuery(query1);
+    hustle_db->execute_query_result(query1);
   container->endEvent("tatp - 1");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -321,7 +321,7 @@ void TATP::RunQuery2() {
       "AND end_time > 1000);";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 2");
-  hustle_db->executeQuery(query2);
+    hustle_db->execute_query_result(query2);
   container->endEvent("tatp - 2");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -336,7 +336,7 @@ void TATP::RunQuery3() {
       "AND ai_type=131321;";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 3");
-  hustle_db->executeQuery(query3);
+    hustle_db->execute_query_result(query3);
   container->endEvent("tatp - 3");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -350,7 +350,7 @@ void TATP::RunQuery4() {
       "WHERE s_id=10; ";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 4.1");
-  hustle_db->executeQuery(query4);
+    hustle_db->execute_query_result(query4);
   container->endEvent("tatp - 4.1");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -367,7 +367,7 @@ void TATP::RunQuery4() {
       "msc_location, vlr_location "
       "FROM Subscriber "
       "WHERE s_id=10;";
-  hustle_db->executeQuery(query4);
+    hustle_db->execute_query_result(query4);
 
   std::cout << "Running Query4.2 : " << std::endl;
   query4 =
@@ -377,7 +377,7 @@ void TATP::RunQuery4() {
       "AND sf_sf_type=10";
   container = simple_profiler.getContainer();
   container->startEvent("tatp - 4.2");
-  hustle_db->executeQuery(query4);
+    hustle_db->execute_query_result(query4);
   container->endEvent("tatp - 4.2");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -388,7 +388,7 @@ void TATP::RunQuery4() {
       "data_a "
       "FROM Special_Facility "
       "WHERE sf_s_id=10 AND sf_sf_type=10;";
-  hustle_db->executeQuery(query4);
+    hustle_db->execute_query_result(query4);
 }
 
 void TATP::RunQuery5() {
@@ -399,7 +399,7 @@ void TATP::RunQuery5() {
       "WHERE sub_nbr='h10';";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 5");
-  hustle_db->executeQuery(query5);
+    hustle_db->execute_query_result(query5);
   container->endEvent("tatp - 5");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -415,7 +415,7 @@ void TATP::RunQuery5() {
       "msc_location, vlr_location "
       "FROM Subscriber "
       "WHERE s_id=10;";
-  hustle_db->executeQuery(query5);
+    hustle_db->execute_query_result(query5);
 }
 
 void TATP::RunQuery6() {
@@ -428,7 +428,7 @@ void TATP::RunQuery6() {
       "COMMIT;";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 6");
-  hustle_db->executeQuery(query6);
+    hustle_db->execute_query_result(query6);
   container->endEvent("tatp - 6");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -437,7 +437,7 @@ void TATP::RunQuery6() {
       "SELECT cf_s_id, start_time, end_time "
       "FROM Call_Forwarding "
       "WHERE cf_s_id=1111111;";
-  hustle_db->executeQuery(query6);
+    hustle_db->execute_query_result(query6);
 }
 
 void TATP::RunQuery7() {
@@ -447,7 +447,7 @@ void TATP::RunQuery7() {
       "WHERE cf_s_id = 11;";
   auto container = simple_profiler.getContainer();
   container->startEvent("tatp - 7");
-  hustle_db->executeQuery(query7);
+    hustle_db->execute_query_result(query7);
   container->endEvent("tatp - 7");
   simple_profiler.summarizeToStream(std::cout);
   simple_profiler.clear();
@@ -456,7 +456,7 @@ void TATP::RunQuery7() {
       "SELECT cf_s_id, start_time, end_time "
       "FROM Call_Forwarding "
       "WHERE cf_s_id=11;";
-  hustle_db->executeQuery(query7);
+    hustle_db->execute_query_result(query7);
 }
 
 }  // namespace hustle::operators

--- a/src/catalog/tests/catalog_test.cc
+++ b/src/catalog/tests/catalog_test.cc
@@ -80,10 +80,10 @@ TEST(CatalogTest, AddTable) {
   std::filesystem::remove("catalog.json");
   std::filesystem::remove("hustle_sqlite.db");
   hustle::HustleDB hustleDB("db_directory");
-  std::shared_ptr<Catalog> catalog = hustleDB.getCatalog("db_directory/hustle_sqlite.db");
+  std::shared_ptr<Catalog> catalog = hustleDB.get_catalog("db_directory/hustle_sqlite.db");
   
   EXPECT_FALSE(catalog->TableExists("Subscriber"));
-  std::cout << "SQLITE DB PATH: " << hustleDB.getSqliteDBPath() << std::endl;
+  std::cout << "SQLITE DB PATH: " << hustleDB.get_sqlite_path() << std::endl;
   TableSchema ts("Subscriber");
   ColumnSchema c1("c1", {HustleType::INTEGER, 0}, true, false);
   ColumnSchema c2("c2", {HustleType::CHAR, 10}, false, true);
@@ -113,7 +113,7 @@ TEST(CatalogTest, DropTable) {
   std::filesystem::remove("hustle_sqlite.db");
   hustle::HustleDB hustleDB("db_directory");
 
-  std::shared_ptr<Catalog> catalog = hustleDB.getCatalog("db_directory/hustle_sqlite.db");
+  std::shared_ptr<Catalog> catalog = hustleDB.get_catalog("db_directory/hustle_sqlite.db");
   TableSchema ts1("AccessInfo_drop");
   ColumnSchema c3("c3", {HustleType::INTEGER, 0}, true, false);
   ColumnSchema c4("c4", {HustleType::CHAR, 5}, false, true);
@@ -365,7 +365,7 @@ TEST(CatalogTest, Serialization) {
 
   
   hustle::HustleDB hustleDB("db_directory");
-  std::shared_ptr<Catalog> catalog_ptr = hustleDB.getCatalog("db_directory/hustle_sqlite.db");
+  std::shared_ptr<Catalog> catalog_ptr = hustleDB.get_catalog("db_directory/hustle_sqlite.db");
   EXPECT_TRUE(true);
   TableSchema ts("Subscriber_Serial");
   ColumnSchema c1("c1", {HustleType::INTEGER, 0}, true, false);
@@ -457,7 +457,7 @@ TEST(CatalogTest, Serialization) {
 TEST(CatalogSerialization, LoadFromFile) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
-  std::shared_ptr<Catalog> catalog = hustleDB.getCatalog("db_directory/hustle_sqlite.db");
+  std::shared_ptr<Catalog> catalog = hustleDB.get_catalog("db_directory/hustle_sqlite.db");
   
 
   TableSchema ts("Subscriber2");

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -247,7 +247,7 @@ std::shared_ptr<hustle::storage::DBTable> execute(
     hustle::resolver::SelectResolver *select_resolver, Catalog *catalog) {
   std::shared_ptr<hustle::storage::DBTable> out_table;
   using namespace hustle::operators;
-  hustle::Scheduler &scheduler = hustle::HustleDB::getScheduler();
+  hustle::Scheduler &scheduler = hustle::HustleDB::get_scheduler();
   SynchronizationLock sync_lock;
 
   scheduler.addTask(CreateTaskChain(
@@ -275,7 +275,7 @@ int resolveSelect(char *dbName, Sqlite3Select *queryTree, void *pArgs, sqlite3_c
   // TODO: (@srsuryadev) resolve the select query
   // return 0 if query is supported in column store else return 1
   using hustle::resolver::SelectResolver;
-  Catalog *catalog = hustle::HustleDB::getCatalog(dbName).get();
+  Catalog *catalog = hustle::HustleDB::get_catalog(dbName).get();
   if (dbName == NULL || catalog == nullptr) return 0;
 
   SelectResolver *select_resolver = new SelectResolver(catalog);

--- a/src/resolver/tests/resolver_test.cc
+++ b/src/resolver/tests/resolver_test.cc
@@ -350,11 +350,11 @@ TEST_F(ResolverTest, q1) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_extendedprice) as "
@@ -365,11 +365,11 @@ TEST_F(ResolverTest, q1) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
 
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 1);
@@ -386,11 +386,11 @@ TEST_F(ResolverTest, q2) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_extendedprice) as "
@@ -403,10 +403,10 @@ TEST_F(ResolverTest, q2) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 1);
@@ -423,11 +423,11 @@ TEST_F(ResolverTest, q3) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_extendedprice) as "
@@ -440,10 +440,10 @@ TEST_F(ResolverTest, q3) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 1);
@@ -460,11 +460,11 @@ TEST_F(ResolverTest, q4) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_revenue), d_year, p_brand1\n"
@@ -479,10 +479,10 @@ TEST_F(ResolverTest, q4) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -499,11 +499,11 @@ TEST_F(ResolverTest, q5) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_revenue), d_year, p_brand1\n"
@@ -518,10 +518,10 @@ TEST_F(ResolverTest, q5) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -538,11 +538,11 @@ TEST_F(ResolverTest, q6) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_revenue), d_year, p_brand1\n"
@@ -557,10 +557,10 @@ TEST_F(ResolverTest, q6) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -577,11 +577,11 @@ TEST_F(ResolverTest, q7) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select c_nation, s_nation, d_year, sum(lo_revenue) "
@@ -598,10 +598,10 @@ TEST_F(ResolverTest, q7) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -618,11 +618,11 @@ TEST_F(ResolverTest, q8) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select c_city, s_city, d_year, sum(lo_revenue) as "
@@ -639,10 +639,10 @@ TEST_F(ResolverTest, q8) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -659,11 +659,11 @@ TEST_F(ResolverTest, q9) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select c_city, s_city, d_year, sum(lo_revenue) as "
@@ -680,10 +680,10 @@ TEST_F(ResolverTest, q9) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -700,11 +700,11 @@ TEST_F(ResolverTest, q10) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select c_city, s_city, d_year, sum(lo_revenue) as "
@@ -721,10 +721,10 @@ TEST_F(ResolverTest, q10) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 3);
@@ -741,11 +741,11 @@ TEST_F(ResolverTest, q11) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select d_year, c_nation, "
@@ -763,10 +763,10 @@ TEST_F(ResolverTest, q11) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 4);
@@ -783,11 +783,11 @@ TEST_F(ResolverTest, q12) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select d_year, s_nation, p_category, sum(lo_revenue) "
@@ -806,11 +806,11 @@ TEST_F(ResolverTest, q12) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
 
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
 
   select_resolver.ResolveSelectTree(queryTree);
   EXPECT_EQ(select_resolver.join_predicates().size(), 4);
@@ -827,11 +827,11 @@ TEST_F(ResolverTest, q13) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select d_year, s_city, p_brand1, sum(lo_revenue) as "
@@ -850,11 +850,11 @@ TEST_F(ResolverTest, q13) {
 
   std::cout << "For query: " << query << std::endl
             << "The plan is: " << std::endl
-            << hustleDB.getPlan(query) << std::endl;
+            << hustleDB.get_plan(query) << std::endl;
 
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
 
   select_resolver.ResolveSelectTree(queryTree);
   EXPECT_EQ(select_resolver.join_predicates().size(), 4);
@@ -871,11 +871,11 @@ TEST_F(ResolverTest, queryAggExpr) {
   std::filesystem::remove_all("db_directory");
   hustle::HustleDB hustleDB("db_directory");
 
-  hustleDB.createTable(ResolverTest::lineorder, ResolverTest::lo);
-  hustleDB.createTable(ResolverTest::customer, ResolverTest::c);
-  hustleDB.createTable(ResolverTest::supplier, ResolverTest::s);
-  hustleDB.createTable(ResolverTest::part, ResolverTest::p);
-  hustleDB.createTable(ResolverTest::ddate, ResolverTest::d);
+    hustleDB.create_table(ResolverTest::lineorder, ResolverTest::lo);
+    hustleDB.create_table(ResolverTest::customer, ResolverTest::c);
+    hustleDB.create_table(ResolverTest::supplier, ResolverTest::s);
+    hustleDB.create_table(ResolverTest::part, ResolverTest::p);
+    hustleDB.create_table(ResolverTest::ddate, ResolverTest::d);
 
   std::string query =
       "select sum(lo_extendedprice*lo_discount) as "
@@ -887,8 +887,8 @@ TEST_F(ResolverTest, queryAggExpr) {
       "and lo_quantity < 35;";
 
   Sqlite3Select* queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
-  SelectResolver select_resolver(hustleDB.getCatalog());
+          hustleDB.get_sqlite_path(), query);
+  SelectResolver select_resolver(hustleDB.get_catalog());
   select_resolver.ResolveSelectTree(queryTree);
 
   EXPECT_EQ(select_resolver.join_predicates().size(), 1);
@@ -917,9 +917,9 @@ TEST_F(ResolverTest, queryAggExpr) {
       "and lo_discount < 6\n"
       "and lo_quantity < 35;";
   queryTree = (Sqlite3Select*)hustle::utils::executeSqliteParse(
-      hustleDB.getSqliteDBPath(), query);
+          hustleDB.get_sqlite_path(), query);
   
-  SelectResolver select_resolver2(hustleDB.getCatalog());
+  SelectResolver select_resolver2(hustleDB.get_catalog());
   select_resolver2.ResolveSelectTree(queryTree);
   EXPECT_TRUE((*select_resolver2.agg_references())[0].expr_ref == nullptr);
 }

--- a/src/storage/cmemlog.cc
+++ b/src/storage/cmemlog.cc
@@ -55,7 +55,7 @@ void memlog_remove_table_mapping(int db_id, char *db_name, char *tbl_name) {
   std::lock_guard<std::mutex> lock(instance_lock);
   using namespace hustle;
   std::shared_ptr<catalog::Catalog> catalog =
-      HustleDB::getCatalog(std::string(db_name));
+          HustleDB::get_catalog(std::string(db_name));
   auto table_itr = table_map[db_id].begin();
   std::string tbl_name_str = std::string(tbl_name);
   while (table_itr != table_map[db_id].end()) {
@@ -182,7 +182,7 @@ Status hustle_memlog_update_db(HustleMemLog *mem_log, int is_free) {
   using namespace hustle;
 
   std::shared_ptr<catalog::Catalog> catalog =
-      HustleDB::getCatalog(mem_log->db_name);
+          HustleDB::get_catalog(mem_log->db_name);
 
   int table_index = 0;
   struct DBRecord *tmp_record;

--- a/src/storage/tests/table_test.cc
+++ b/src/storage/tests/table_test.cc
@@ -222,8 +222,8 @@ TEST_F(HustleTableTest, Insert) {
   DBTable::TablePtr c =
       std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory_insert");
-  hustleDB.createTable(customer, c);
-  hustleDB.executeQuery(query);
+    hustleDB.create_table(customer, c);
+    hustleDB.execute_query_result(query);
   EXPECT_EQ(c->get_num_rows(), 2);
   EXPECT_EQ(c->get_num_cols(), 8);
   std::filesystem::remove_all("db_directory_insert");
@@ -269,15 +269,15 @@ TEST_F(HustleTableTest, Update) {
   DBTable::TablePtr customer_table_ptr =
       std::make_shared<DBTable>("customer_table", customer_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory_update");
-  hustleDB.createTable(customer_table, customer_table_ptr);
-  hustleDB.executeQuery(query);
+    hustleDB.create_table(customer_table, customer_table_ptr);
+    hustleDB.execute_query_result(query);
 
   query =
       "BEGIN TRANSACTION;"
       "UPDATE customer_table set c_region = 'fine' where c_custkey=800224;"
       "COMMIT;";
 
-  hustleDB.executeQuery(query);
+    hustleDB.execute_query_result(query);
   auto col = std::static_pointer_cast<arrow::StringArray>(
       customer_table_ptr->get_column(5)->chunk(0));
   EXPECT_EQ(col->GetString(0), "fine");
@@ -291,7 +291,7 @@ TEST_F(HustleTableTest, Update) {
       "BEGIN TRANSACTION;"
       "UPDATE customer_table set c_mktsegment = 1123 where c_custkey=800224;"
       "COMMIT;";
-  hustleDB.executeQuery(query);
+    hustleDB.execute_query_result(query);
   EXPECT_EQ(int_col->Value(0), 1123);
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 1);
   EXPECT_EQ(customer_table_ptr->get_num_blocks(), 1);
@@ -339,13 +339,13 @@ TEST_F(HustleTableTest, Delete) {
   DBTable::TablePtr customer_table_ptr = std::make_shared<DBTable>(
       "customer_table_d", customer_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory_delete");
-  hustleDB.createTable(customer_table, customer_table_ptr);
-  hustleDB.executeQuery(query);
+    hustleDB.create_table(customer_table, customer_table_ptr);
+    hustleDB.execute_query_result(query);
   query =
       "BEGIN TRANSACTION;"
       "DELETE FROM customer_table_d where c_custkey=800224;"
       "COMMIT;";
-  hustleDB.executeQuery(query);
+    hustleDB.execute_query_result(query);
   auto col = std::static_pointer_cast<arrow::StringArray>(
       customer_table_ptr->get_column(5)->chunk(0));
   EXPECT_EQ(customer_table_ptr->get_num_rows(), 0);
@@ -398,22 +398,22 @@ TEST_F(HustleTableTest, Load) {
   DBTable::TablePtr c =
       std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
   hustle::HustleDB hustleDB("db_directory_load");
-  hustleDB.createTable(customer, c);
-  hustleDB.executeQuery(query);
+    hustleDB.create_table(customer, c);
+    hustleDB.execute_query_result(query);
   EXPECT_EQ(c->get_num_rows(), 2);
   EXPECT_EQ(c->get_num_cols(), 8);
 
-  hustleDB.dropMemTable("customer_table_test");
+    hustleDB.drop_mem_table("customer_table_test");
   c = std::make_shared<DBTable>("customer_table_test", c_schema, BLOCK_SIZE);
-  hustleDB.createTable(customer, c);
-  hustleDB.loadTables();
+    hustleDB.create_table(customer, c);
+    hustleDB.load_tables();
   EXPECT_EQ(c->get_num_rows(), 2);
 
   query =
       "BEGIN TRANSACTION;"
       "DELETE FROM customer_table_test where c_custkey=800224;"
       "COMMIT;";
-  hustleDB.executeQuery(query);
+    hustleDB.execute_query_result(query);
   EXPECT_EQ(c->get_num_rows(), 1);
 
   query =
@@ -421,7 +421,7 @@ TEST_F(HustleTableTest, Load) {
       "UPDATE customer_table_test set c_mktsegment = 1123 where "
       "c_custkey=800225;"
       "COMMIT;";
-  hustleDB.executeQuery(query);
+    hustleDB.execute_query_result(query);
 
   auto int_col =
       std::static_pointer_cast<arrow::StringArray>(c->get_column(1)->chunk(0));

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.cc
@@ -11,7 +11,7 @@ txbench::TATPHustleBenchmark::TATPHustleBenchmark(int n_workers,
     : Benchmark(n_workers, warmup_duration, measurement_duration),
       n_rows_(n_rows) {
          std::cout << "Start scheduler" << std::endl;
-         hustle::HustleDB::startScheduler();
+    hustle::HustleDB::start_scheduler();
       }
 
 

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.h
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_benchmark.h
@@ -23,7 +23,7 @@ public:
 
 ~TATPHustleBenchmark() {
   std::cout << "Stop scheduler" << std::endl;
-  hustle::HustleDB::stopScheduler();
+    hustle::HustleDB::stop_scheduler();
 }
 private:
   int n_rows_;

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_connector.cc
@@ -30,7 +30,7 @@ double txbench::TATPHustleConnector::getSubscriberData(
       "WHERE s_id=" +
       std::to_string(s_id) + ";";
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;
@@ -59,7 +59,7 @@ double txbench::TATPHustleConnector::getNewDestination(int s_id, int sf_type,
       "AND end_time>" +
       std::to_string(end_time) + ");";
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;
@@ -76,7 +76,7 @@ double txbench::TATPHustleConnector::getAccessData(int s_id, int ai_type,
       "WHERE s_id=" +
       std::to_string(s_id) + " AND ai_type=" + std::to_string(ai_type) + ";";
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;
@@ -106,7 +106,7 @@ double txbench::TATPHustleConnector::updateSubscriberData(int s_id, bool bit_1,
       std::to_string(sf_type) + ";";
   query += "COMMIT;";
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;
@@ -123,7 +123,7 @@ double txbench::TATPHustleConnector::updateLocation(const std::string &sub_nbr,
       "WHERE sub_nbr='" +
       sub_nbr + "';";
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;
@@ -140,7 +140,7 @@ double txbench::TATPHustleConnector::insertCallForwarding(
       std::to_string(start_time) + "," + std::to_string(end_time) + "," +
       std::to_string(end_time) + ");";
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;
@@ -159,7 +159,7 @@ double txbench::TATPHustleConnector::deleteCallForwarding(
       std::to_string(start_time) + ";";
 
   const auto before = clock1::now();
-  if(!hustle_db->executeNoOutputQuery(query)) {
+  if(!hustle_db->execute_query(query)) {
     return -1;
   }
   const sec duration = clock1::now() - before;

--- a/src/txbench/benchmarks/tatp_hustle/tatp_hustle_loader.cc
+++ b/src/txbench/benchmarks/tatp_hustle/tatp_hustle_loader.cc
@@ -18,7 +18,7 @@ void txbench::TATPHustleLoader::load() {
   std::mt19937 mt(rd());
 
   RandomGenerator rg;
-  hustle::HustleDB::startScheduler();
+    hustle::HustleDB::start_scheduler();
   std::shared_ptr<arrow::Schema> s_schema, ai_schema, sf_schema, cf_schema;
   std::shared_ptr<hustle::HustleDB> hustle_db =
       txbench::TATPHustleBenchmark::getHustleDB();
@@ -204,12 +204,12 @@ void txbench::TATPHustleLoader::load() {
   cf = std::make_shared<hustle::storage::DBTable>("Call_Forwarding", cf_schema,
                                                   BLOCK_SIZE);
 
-  hustle_db->createTable(subscriber, s);
+    hustle_db->create_table(subscriber, s);
 
-  hustle_db->createTable(access_info, ai);
+    hustle_db->create_table(access_info, ai);
 
-  hustle_db->createTable(special_facility, sf);
-  hustle_db->createTable(call_forwarding, cf);
+    hustle_db->create_table(special_facility, sf);
+    hustle_db->create_table(call_forwarding, cf);
 
   std::vector<int> subscriber_ids(n_rows_);
   std::iota(subscriber_ids.begin(), subscriber_ids.end(), 1);
@@ -290,11 +290,11 @@ void txbench::TATPHustleLoader::load() {
   ac_query += "COMMIT;";
   sf_query += "COMMIT;";
   cf_query += "COMMIT;";
-  hustle_db->executeQuery(s_query);
-  hustle_db->executeQuery(ac_query);
-  hustle_db->executeQuery(sf_query);
-  hustle_db->executeQuery(cf_query);
+    hustle_db->execute_query_result(s_query);
+    hustle_db->execute_query_result(ac_query);
+    hustle_db->execute_query_result(sf_query);
+    hustle_db->execute_query_result(cf_query);
 
-  //hustle::HustleDB::stopScheduler();
+  //hustle::HustleDB::stop_scheduler();
   std::cout << "loaded the values" << std::endl;
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(hustle_src_utils_ParallelHashmap ../empty_src.cc parallel_hashmap/ph
 add_library(hustle_src_utils_Config ../empty_src.cc config.h)
 add_library(hustle_src_utils_skew ../empty_src.cc skew.h)
 add_library(hustle_src_utils_bit_utils ../empty_src.cc bit_utils.h)
-
+add_library(hustle_src_utils_string_utils ../empty_src.cc string_utils.h)
 
 add_library(hustle_src_utils_BloomFilter ../empty_src.cc bloom_filter.h histogram.h)
 

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <string>
+
+#ifndef HUSTLE_STRING_UTILS_H
+#define HUSTLE_STRING_UTILS_H
+
+class StringUtils {
+ public:
+  inline static std::string trim(const std::string& s) {
+    std::string trimmed_str;
+    std::stringstream stream(s);
+    stream >> trimmed_str;
+    return trimmed_str;
+  }
+};
+
+#endif  // HUSTLE_STRING_UTILS_H

--- a/test/data/test_generate_data.py
+++ b/test/data/test_generate_data.py
@@ -5,6 +5,7 @@ import os
 
 
 def generate_test_data():
+    random.seed(30)
     try:
         os.remove('lineorder.tbl')
     except OSError as error:

--- a/test/data/test_generate_data.py
+++ b/test/data/test_generate_data.py
@@ -1,0 +1,72 @@
+# This is a simple Python script to generate table data for Hustle SQL tests
+import csv
+import random
+import os
+
+
+def generate_test_data():
+    try:
+        os.remove('lineorder.tbl')
+    except OSError as error:
+        pass
+    with open('lineorder.tbl', 'w', newline='') as file:
+        writer = csv.writer(file, delimiter='|')
+        for x in range(0, 200, 5):
+            for p in range(100):
+                writer.writerow([x, x, p, p, p, 1993121, random.randint(0, 30), random.randint(
+                    0, 1000),  random.randint(0, 1000), random.randint(0, 5)])
+                writer.writerow([x + 1, x, p, p, p, 1993121, random.randint(0, 30),
+                                 random.randint(0, 1000),  random.randint(0, 1000), random.randint(0, 5)])
+                writer.writerow([x + 2, x, p, p, p, 1994024, random.randint(25, 30),
+                                 random.randint(0, 1000), random.randint(0, 1000), random.randint(3, 7)])
+                writer.writerow([x + 3, x, p, p, p, 1994034, random.randint(25, 30),
+                                 random.randint(0, 1000),  random.randint(0, 1000), random.randint(3, 7)])
+                writer.writerow([x + 4, x, p, p, p, 1994035, random.randint(25, 30),
+                                 random.randint(0, 1000),  random.randint(0, 1000), random.randint(4, 7)])
+    try:
+        os.remove('part.tbl')
+    except OSError as error:
+        pass
+    with open('part.tbl', 'w', newline='') as file:
+        writer = csv.writer(file, delimiter='|')
+        for p in range(100):
+            writer.writerow(
+                [p, "MFGR#" + str(p), "MFGR#" + str(p), "MFGR#" + str(p)])
+    try:
+        os.remove('supplier.tbl')
+    except OSError as error:
+        pass
+    with open('supplier.tbl', 'w', newline='') as file:
+        writer = csv.writer(file, delimiter='|')
+        for p in range(100):
+            writer.writerow(
+                [p, "SCITY" + str(p), "SNATION" + str(p), "SREGION" + str(p)])
+    try:
+        os.remove('customer.tbl')
+    except OSError as error:
+        pass
+    with open('customer.tbl', 'w', newline='') as file:
+        writer = csv.writer(file, delimiter='|')
+        for p in range(100):
+            writer.writerow(
+                [p, "CCITY" + str(p), "CNATION" + str(p), "CREGION" + str(p)])
+
+    try:
+        os.remove('date.tbl')
+    except OSError as error:
+        pass
+    with open('date.tbl', 'w', newline='') as file:
+        writer = csv.writer(file, delimiter='|')
+        for p in range(0, 30, 1):
+            writer.writerow([int("199201"+str(p)), p % 7, p %
+                             12, 1992,  p % 7, 199201, "Jan1992"])
+            writer.writerow([int("199312"+str(p)), p % 7, p %
+                             12, 1993,  p % 7, 199312, "Dec1993"])
+            writer.writerow([int("199402"+str(p)), p % 7, p %
+                             12, 1994,  6, 199402, "Feb1992"])
+            writer.writerow([int("199403"+str(p)), p % 7, p %
+                             12, 1994,  6, 199403, "Mar1992"])
+
+
+if __name__ == '__main__':
+    generate_test_data()

--- a/test/data/test_generate_data.py
+++ b/test/data/test_generate_data.py
@@ -9,7 +9,7 @@ def generate_test_data():
         os.remove('lineorder.tbl')
     except OSError as error:
         pass
-    with open('lineorder.tbl', 'w', newline='') as file:
+    with open('lineorder.tbl', 'wb') as file:
         writer = csv.writer(file, delimiter='|')
         for x in range(0, 200, 5):
             for p in range(100):
@@ -27,7 +27,7 @@ def generate_test_data():
         os.remove('part.tbl')
     except OSError as error:
         pass
-    with open('part.tbl', 'w', newline='') as file:
+    with open('part.tbl', 'wb') as file:
         writer = csv.writer(file, delimiter='|')
         for p in range(100):
             writer.writerow(
@@ -36,7 +36,7 @@ def generate_test_data():
         os.remove('supplier.tbl')
     except OSError as error:
         pass
-    with open('supplier.tbl', 'w', newline='') as file:
+    with open('supplier.tbl', 'wb') as file:
         writer = csv.writer(file, delimiter='|')
         for p in range(100):
             writer.writerow(
@@ -45,7 +45,7 @@ def generate_test_data():
         os.remove('customer.tbl')
     except OSError as error:
         pass
-    with open('customer.tbl', 'w', newline='') as file:
+    with open('customer.tbl', 'wb') as file:
         writer = csv.writer(file, delimiter='|')
         for p in range(100):
             writer.writerow(
@@ -55,7 +55,7 @@ def generate_test_data():
         os.remove('date.tbl')
     except OSError as error:
         pass
-    with open('date.tbl', 'w', newline='') as file:
+    with open('date.tbl', 'wb') as file:
         writer = csv.writer(file, delimiter='|')
         for p in range(0, 30, 1):
             writer.writerow([int("199201"+str(p)), p % 7, p %


### PR DESCRIPTION
### Summary (Continuation to #91 )
* End to End - SQL tests (Right now, SSB based queries)
* Test data generation using py script (20,000 rows) for SQL e2e tests
* Reformat/rename the hustle APIs to the standard format

Important file: **src/api/tests/sql_test.cc**