### PR TITLE
type_switcher() as a unified interface for arrow type switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ To install the required packages for Hustle use the following scripts:
 ./install_requirements.sh
 ./install_arrow.sh
 ```
-The scripts will install g++9, cmake 3.15 and Apache Arrow.
+The scripts will install g++9, cmake 3.15 and Apache Arrow. 
 
 Then use cmake to build Hustle:
 ```
 mkdir build
 cd build
-cmake -D CMAKE_BUILD_TYPE=RELEASE .. 
+cmake -DCMAKE_BUILD_TYPE=RELEASE .. 
 make -j all  
 ```
 
@@ -33,6 +33,51 @@ To run the test go into the build directory and use:
 ```
 ./run_test.sh 
 ```
+
+
+
+## (Pilot) Build Hustle with C++20
+
+**Tested systems**:
+
+- **Ubuntu**: 16.04, 18.04, 20.04. 
+- **macOS**: Catalina (10.15), Big Sur (11.2.3).
+
+User on MacOS shall install [homebrew](https://brew.sh/) before running the following scripts.
+
+To install the required packages for Hustle use the following scripts:
+
+```
+./install_requirements_cpp20.sh
+./install_arrow.sh
+```
+
+The scripts will install g++10, cmake 3.15 and Apache Arrow 3.0. 
+
+To verify the toolchain accessibility, verify the version of `g++`:
+
+```bash
+g++-10 -v # or g++ -v
+```
+
+
+Then use cmake to build Hustle:
+
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_COMPILER=gcc-10 \
+ -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_STANDARD=20 \
+ -DCMAKE_CXX_STANDARD_REQUIRED=True .. 
+make -j all  
+```
+
+To run the test go into the build directory and use:
+
+```
+./run_test.sh 
+```
+
 
 ## Run Benchmark
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,29 @@ To run the test go into the build directory and use:
 ```
 
 
+## Run Benchmark
+
+You can use the following commands to run the ssb benchmark, (before running the below commands make sure you have built the executable from the source files using the steps provided in the previous section).
+
+To generate the ssb benchmark data, 
+
+```
+sh ./scripts/ssb/gen_benchmark_data.sh ${SCALE_FACTOR}
+```
+(Usually scale factor can be 1 or 10).
+
+
+To run the ssb benchmark,
+
+```
+sh ./scripts/ssb/run_benchmark.sh  ssb_queries
+```
+
+To run the tatp benchmark,
+
+```
+sh ./scripts/tatp/run_benchmark.sh 
+```
 
 ## (Pilot) Build Hustle with C++20
 
@@ -78,27 +101,3 @@ To run the test go into the build directory and use:
 ./run_test.sh 
 ```
 
-
-## Run Benchmark
-
-You can use the following commands to run the ssb benchmark, (before running the below commands make sure you have built the executable from the source files using the steps provided in the previous section).
-
-To generate the ssb benchmark data, 
-
-```
-sh ./scripts/ssb/gen_benchmark_data.sh ${SCALE_FACTOR}
-```
-(Usually scale factor can be 1 or 10).
-
-
-To run the ssb benchmark,
-
-```
-sh ./scripts/ssb/run_benchmark.sh  ssb_queries
-```
-
-To run the tatp benchmark,
-
-```
-sh ./scripts/tatp/run_benchmark.sh 
-```

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -298,8 +298,8 @@ void Aggregate::InsertGroupColumns(std::vector<int> group_id, int agg_index) {
           isNotOneOf<T, arrow::ExtensionType, arrow::DictionaryType>>;
 
       if constexpr (is_supported_type) {
-        using BuilderType = GetArrowBuilderType<T>;
-        using ArrayType = GetArrowArrayType<T>;
+        using BuilderType = ArrowGetBuilderType<T>;
+        using ArrayType = ArrowGetArrayType<T>;
 
         if constexpr (arrow::is_number_type<T>::value) {
           // Downcast the column's builder

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -298,8 +298,8 @@ void Aggregate::InsertGroupColumns(std::vector<int> group_id, int agg_index) {
           isNotOneOf<T, arrow::ExtensionType, arrow::DictionaryType>>;
 
       if constexpr (is_supported_type) {
-        using BuilderType = typename arrow::TypeTraits<T>::BuilderType;
-        using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
+        using BuilderType = GetArrowBuilderType<T>;
+        using ArrayType = GetArrowArrayType<T>;
 
         if constexpr (arrow::is_number_type<T>::value) {
           // Downcast the column's builder

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -287,9 +287,7 @@ void Aggregate::InsertGroupColumns(std::vector<int> group_id, int agg_index) {
   // its builder.
   for (std::size_t i = 0; i < group_type_->num_fields(); ++i) {
     // Handle the insertion of record.
-    auto insert_handler = [&, this]<typename U>(U ptr_) {
-      using T = typename std::remove_pointer_t<U>;
-
+    auto insert_handler = [&, this]<typename T>(T * ptr_) {
       // TODO: Add support for other types.
       //  Right now we only support types that have builder and array
       //  in the type trait. It should be obvious that we can:

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -401,10 +401,8 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
       hash_t next_key = 0;
       auto get_hash_key = [&]<typename T>(T *ptr_) {
         if constexpr (arrow::is_primitive_ctype<T>::value) {
-          using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
-          // TODO: What is the difference between CType and the c_type?
-          //  using CType = typename arrow::TypeTraits<T>::CType;
-          using CType = typename T::c_type;
+          using ArrayType = GetArrowArrayType<T>;
+          using CType = GetArrowCType<T>;
 
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
           CType val = col->Value(item_index);
@@ -413,7 +411,7 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
         }
         if constexpr (arrow::is_base_binary_type<T>::value ||
                       arrow::is_fixed_size_binary_type<T>::value) {
-          using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
+          using ArrayType = GetArrowArrayType<T>;
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
           auto val = col->GetString(item_index);
           next_key = std::hash<std::string>{}(val);

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -401,7 +401,7 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
       hash_t next_key = 0;
       auto get_hash_key = [&]<typename T>(T *ptr_) {
         if constexpr (arrow::is_primitive_ctype<T>::value) {
-          using ArrayType = GetArrowArrayType<T>;
+          using ArrayType = ArrowGetArrayType<T>;
           using CType = GetArrowCType<T>;
 
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
@@ -411,7 +411,7 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
         }
         if constexpr (arrow::is_base_binary_type<T>::value ||
                       arrow::is_fixed_size_binary_type<T>::value) {
-          using ArrayType = GetArrowArrayType<T>;
+          using ArrayType = ArrowGetArrayType<T>;
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
           auto val = col->GetString(item_index);
           next_key = std::hash<std::string>{}(val);

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -444,7 +444,7 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
   }
       HUSTLE_SWITCH_ARROW_TYPE(enum_type);
 #undef HUSTLE_ARROW_TYPE_CASE_STMT
-      
+
       key = HashAggregateStrategy::HashCombine(key, next_key);
     }
     agg_item_key = key;

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -353,48 +353,6 @@ void HashAggregate::FirstPhaseAggregateChunks(Task *internal, size_t tid,
   }
 }
 
-//
-// GetHashKeyHandlers
-// - [1] GetHashKeyHandlerPrimitive: Hash primitive C types.
-// - [2] GetHashKeyHandlerStringLike: Hash string-like (binary) types.
-// Otherwise, marked unhashable.
-//
-template <typename T, typename U>
-hash_t GetHashKeyHandlerPrimitive(U &group_by_chunk, int item_index) {
-  using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
-  // TODO: What is the difference between CType and the c_type?
-  //  using CType = typename arrow::TypeTraits<T>::CType;
-  using CType = typename T::c_type;
-
-  auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
-  CType val = col->Value(item_index);
-  return std::hash<CType>{}(val);
-}
-template <typename T, typename U>
-hash_t GetHashKeyHandlerStringLike(U &group_by_chunk, int item_index) {
-  using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
-  auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
-  auto val = col->GetString(item_index);
-  return std::hash<std::string>{}(val);
-}
-
-template <typename T, typename U>
-hash_t GetHashKeyHandler(U &group_by_chunk, int item_index) {
-  if constexpr (arrow::is_primitive_ctype<T>::value) {
-    return GetHashKeyHandlerPrimitive<T>(group_by_chunk, item_index);
-  }
-  if constexpr (arrow::is_base_binary_type<T>::value ||
-                arrow::is_fixed_size_binary_type<T>::value) {
-    return GetHashKeyHandlerStringLike<T>(group_by_chunk, item_index);
-  }
-  /* TODO: Hash Key throw type list:
-   * null fixed_size_binary date32 date64 time32 time64 timestamp
-   * day_time_interval month_interval duration decimal struct list large_list
-   * fixed_size_list map dense_union sparse_union dictionary extension
-   */
-  throw std::runtime_error(std::string("Unhashable type: ") + T::type_name());
-}
-
 void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
                                               int chunk_index) {
   // if expression not null then evaluate the expression to get the result
@@ -438,18 +396,55 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
       auto group_by_chunk = group_by.chunked_array()->chunk(chunk_index);
 
       auto group_by_type = group_by.type();
-      auto group_by_type_id = group_by_type->id();
+      auto enum_type = group_by_type->id();
+      auto rawptr = group_by.type().get();
       hash_t next_key = 0;
       // TODO: Factor this out as template functions.
 
+      auto get_hash_key = [&, this]<typename U>(U ptr_) -> hash_t {
+        using T = typename std::remove_pointer_t<U>;
+        if constexpr (arrow::is_primitive_ctype<T>::value) {
+          {
+            using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
+            // TODO: What is the difference between CType and the c_type?
+            //  using CType = typename arrow::TypeTraits<T>::CType;
+            using CType = typename T::c_type;
+
+            auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
+            CType val = col->Value(item_index);
+            return std::hash<CType>{}(val);
+          }
+        }
+        if constexpr (arrow::is_base_binary_type<T>::value ||
+                      arrow::is_fixed_size_binary_type<T>::value) {
+          {
+            using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
+            auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
+            auto val = col->GetString(item_index);
+            return std::hash<std::string>{}(val);
+          }
+        }
+        /* TODO: Hash Key throw type list:
+         * null fixed_size_binary date32 date64 time32 time64 timestamp
+         * day_time_interval month_interval duration decimal struct list
+         * large_list fixed_size_list map dense_union sparse_union dictionary
+         * extension
+         */
+        throw std::runtime_error(std::string("Unhashable type: ") +
+                                 T::type_name());
+        return 0;  // Disable compiler error on return type.
+      };
+
 #undef HUSTLE_ARROW_TYPE_CASE_STMT
-#define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_) \
-  { next_key = GetHashKeyHandler<DataType_>(group_by_chunk, item_index); }
-
-      HUSTLE_SWITCH_ARROW_TYPE(group_by_type_id);
-
+#define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)    \
+  {                                               \
+    auto ptr = dynamic_cast<DataType_ *>(rawptr); \
+    next_key = get_hash_key(ptr);                 \
+    break;                                        \
+  }
+      HUSTLE_SWITCH_ARROW_TYPE(enum_type);
 #undef HUSTLE_ARROW_TYPE_CASE_STMT
-
+      
       key = HashAggregateStrategy::HashCombine(key, next_key);
     }
     agg_item_key = key;
@@ -757,7 +752,7 @@ void HashAggregate::SortResult(std::vector<arrow::Datum> &groups,
     // TODO(nicholas): better way to indicate we want to sort the aggregate?
     if (order_ref.table == nullptr) {
       status = arrow::compute::SortIndices(*aggregates.make_array())
-          .Value(&sorted_indices);
+                   .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);
     } else {
       auto group = groups[order_to_group[i]];

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -399,8 +399,7 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
 
       // Assign next_key.
       hash_t next_key = 0;
-      auto get_hash_key = [&, this]<typename U>(U ptr_) {
-        using T = typename std::remove_pointer_t<U>;
+      auto get_hash_key = [&]<typename T>(T *ptr_) {
         if constexpr (arrow::is_primitive_ctype<T>::value) {
           using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
           // TODO: What is the difference between CType and the c_type?

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -750,17 +750,18 @@ void HashAggregate::SortResult(std::vector<arrow::Datum> &groups,
 
   // If we are sorting after computing all aggregates, we evaluate the ORDER BY
   // clause in reverse order.
+  // TODO: Why do we handle order by in a reversed way?
   for (int i = order_by_refs_.size() - 1; i >= 0; i--) {
     auto order_ref = order_by_refs_[i];
     // A nullptr indicates that we are sorting by the aggregate column
     // TODO(nicholas): better way to indicate we want to sort the aggregate?
     if (order_ref.table == nullptr) {
-      status = arrow::compute::SortToIndices(*aggregates.make_array())
-                   .Value(&sorted_indices);
+      status = arrow::compute::SortIndices(*aggregates.make_array())
+          .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);
     } else {
       auto group = groups[order_to_group[i]];
-      status = arrow::compute::SortToIndices(*group.make_array())
+      status = arrow::compute::SortIndices(*group.make_array())
                    .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);
     }

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -121,10 +121,8 @@ arrow::Datum Expression::ExecuteBlock(bool is_result,
   }
 }
 
-
 template <typename T>
-enable_if_has_c_type<T, arrow::Datum>
-Expression::ExecuteBlockHandler(
+enable_if_has_c_type<T, arrow::Datum> Expression::ExecuteBlockHandler(
     bool is_result, int op, const std::shared_ptr<arrow::Array>& left_col,
     const std::shared_ptr<arrow::Array>& right_col) {
   using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
@@ -135,8 +133,7 @@ Expression::ExecuteBlockHandler(
 };
 
 template <typename T>
-enable_if_has_no_c_type<T, arrow::Datum>
-Expression::ExecuteBlockHandler(
+enable_if_has_no_c_type<T, arrow::Datum> Expression::ExecuteBlockHandler(
     bool is_result, int op, const std::shared_ptr<arrow::Array>& left_col,
     const std::shared_ptr<arrow::Array>& right_col) {
   throw std::runtime_error(
@@ -188,7 +185,6 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
             "expression evaluation currently not supported.");
       }
       auto enum_type = l_chunk->type()->id();
-
 
 #undef HUSTLE_ARROW_TYPE_CASE_STMT
 #define HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_)                      \

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -160,9 +160,9 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
         if constexpr (arrow::has_c_type<T>::value &&
                       !std::is_same_v<T, arrow::DayTimeIntervalType>) {
           std::cout << "Detect CType" << std::endl;
-          using ArrayType = typename arrow::TypeTraits<T>::ArrayType;
-          using ScalarType = typename arrow::TypeTraits<T>::ScalarType;
-          using CType = typename T::c_type;
+          using ArrayType = GetArrowArrayType<T>;
+          using ScalarType = GetArrowScalarType<T>;
+          using CType = GetArrowCType<T>;
           // TODO: Write a separate if constexpr branch to
           //  make sure scalar type is default constructable.
           //  Be aware of the ScalarType constructor.

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -154,8 +154,6 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
             "Implicit type conversion in"
             "expression evaluation currently not supported.");
       }
-      auto enum_type = l_chunk->type()->id();
-      auto rawptr = l_chunk->type().get();
 
       auto execute_block_handler = [&, this]<typename U>(U ptr_) {
         using T = typename std::remove_pointer_t<U>;
@@ -176,16 +174,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
         }
         throw std::runtime_error("No CType: " + std::string(T::type_name()));
       };
-
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
-#define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)   \
-  {                                              \
-    auto ptr = reinterpret_cast<DataType_*>(rawptr); \
-    execute_block_handler(ptr);                  \
-    break;                                       \
-  }
-      HUSTLE_SWITCH_ARROW_TYPE(enum_type);
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
+      type_switcher(l_chunk->type(), execute_block_handler);
 
       eval_stack.push({TK_AGG_COLUMN, true, arrow::Datum(result)});
     }

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -180,7 +180,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
 #undef HUSTLE_ARROW_TYPE_CASE_STMT
 #define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)   \
   {                                              \
-    auto ptr = dynamic_cast<DataType_*>(rawptr); \
+    auto ptr = reinterpret_cast<DataType_*>(rawptr); \
     execute_block_handler(ptr);                  \
     break;                                       \
   }

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -160,8 +160,8 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
         if constexpr (arrow::has_c_type<T>::value &&
                       !std::is_same_v<T, arrow::DayTimeIntervalType>) {
           std::cout << "Detect CType" << std::endl;
-          using ArrayType = GetArrowArrayType<T>;
-          using ScalarType = GetArrowScalarType<T>;
+          using ArrayType = ArrowGetArrayType<T>;
+          using ScalarType = ArrowScalarGetType<T>;
           using CType = GetArrowCType<T>;
           // TODO: Write a separate if constexpr branch to
           //  make sure scalar type is default constructable.

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -155,8 +155,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
             "expression evaluation currently not supported.");
       }
 
-      auto execute_block_handler = [&, this]<typename U>(U ptr_) {
-        using T = typename std::remove_pointer_t<U>;
+      auto execute_block_handler = [&, this]<typename T>(T * ptr_) {
         // Naturally handles block calculation
         if constexpr (arrow::has_c_type<T>::value &&
                       !std::is_same_v<T, arrow::DayTimeIntervalType>) {

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -106,7 +106,7 @@ arrow::Datum Expression::ExecuteBlock(
 }
 
 template <typename ArrayType, typename ArrayPrimitiveType>
-arrow::Datum Expression::ExecuteBlockAPI(
+arrow::Datum Expression::ExecuteBlock(
     bool is_result, const arrow::Scalar& scalar, int op,
     std::shared_ptr<arrow::Array> left_col,
     std::shared_ptr<arrow::Array> right_col) {
@@ -167,7 +167,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
           //  make sure scalar type is default constructable.
           //  Be aware of the ScalarType constructor.
           //  It may not be default constructable.
-          result = this->ExecuteBlockAPI<ArrayType, CType>(
+          result = this->ExecuteBlock<ArrayType, CType>(
               is_result, ScalarType(0), op, l_chunk, r_chunk);
           return;
         }

--- a/src/operators/expression.h
+++ b/src/operators/expression.h
@@ -93,23 +93,6 @@ class Expression {
                             std::shared_ptr<arrow::Array> left_col,
                             std::shared_ptr<arrow::Array> right_col);
 
-  // Arrow type handler for ExecuteBlock.
-  // Only enables type with ctype into the ExecuteBlock.
-  // Otherwise, throw a runtime error.
-  // In addition, DateTimeInterval types are disabled because
-  // no arithmetic binary operator are supported.
-  template <typename DataType>
-  enable_if_has_c_type<DataType, arrow::Datum>
-  ExecuteBlockHandler(
-      bool is_result, int op, const std::shared_ptr<arrow::Array>& left_col,
-      const std::shared_ptr<arrow::Array>& right_col);
-
-  template <typename DataType>
-  enable_if_has_no_c_type<DataType, arrow::Datum>
-  ExecuteBlockHandler(
-      bool is_result, int op, const std::shared_ptr<arrow::Array>& left_col,
-      const std::shared_ptr<arrow::Array>& right_col);
-
  public:
   Expression(OperatorResult::OpResultPtr prev_op_output,
              std::shared_ptr<ExprReference> expr);

--- a/src/operators/expression.h
+++ b/src/operators/expression.h
@@ -89,7 +89,7 @@ class Expression {
                             const std::shared_ptr<arrow::Array>& right_col);
 
   template <typename ArrayType, typename ArrayPrimitiveType>
-  arrow::Datum ExecuteBlockAPI(bool is_result, const arrow::Scalar& scalar, int op,
+  arrow::Datum ExecuteBlock(bool is_result, const arrow::Scalar& scalar, int op,
                             std::shared_ptr<arrow::Array> left_col,
                             std::shared_ptr<arrow::Array> right_col);
 

--- a/src/operators/expression.h
+++ b/src/operators/expression.h
@@ -85,11 +85,11 @@ class Expression {
   // Execute an arithmetic operator for two column of the chunk in the table
   template <typename ArrayType, typename ArrayPrimitiveType>
   arrow::Datum ExecuteBlock(int op, std::shared_ptr<arrow::Array> result,
-                            std::shared_ptr<arrow::Array> left_col,
-                            std::shared_ptr<arrow::Array> right_col);
+                            const std::shared_ptr<arrow::Array>& left_col,
+                            const std::shared_ptr<arrow::Array>& right_col);
 
   template <typename ArrayType, typename ArrayPrimitiveType>
-  arrow::Datum ExecuteBlock(bool is_result, const arrow::Scalar& scalar, int op,
+  arrow::Datum ExecuteBlockAPI(bool is_result, const arrow::Scalar& scalar, int op,
                             std::shared_ptr<arrow::Array> left_col,
                             std::shared_ptr<arrow::Array> right_col);
 
@@ -104,7 +104,7 @@ class Expression {
   arrow::Datum Evaluate(hustle::Task* ctx, int chunk_id);
 
   // number of chunks present in the input column on which it operates.
-  inline int32_t num_chunks() { return exp_num_chunks_; }
+  [[nodiscard]] inline int32_t num_chunks() const { return exp_num_chunks_; }
 };
 }  // namespace operators
 }  // namespace hustle

--- a/src/operators/expression.h
+++ b/src/operators/expression.h
@@ -104,7 +104,7 @@ class Expression {
   arrow::Datum Evaluate(hustle::Task* ctx, int chunk_id);
 
   // number of chunks present in the input column on which it operates.
-  [[nodiscard]] inline int32_t num_chunks() const { return exp_num_chunks_; }
+  inline int32_t num_chunks() const { return exp_num_chunks_; }
 };
 }  // namespace operators
 }  // namespace hustle

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -72,7 +72,7 @@ Block::Block(int id, const std::shared_ptr<arrow::Schema> &in_schema,
       if constexpr (arrow::is_number_type<T>::value &&
                     has_ctype_member<T>::value) {
         // TODO: Does number type always have CType?
-        using CType = typename arrow::TypeTraits<T>::CType;
+        using CType = GetArrowCType<T>;
         columns.push_back(AllocateColumnData<CType>(field->type(), init_rows));
         return;
       } else if constexpr (std::is_same_v<T, arrow::StringType>) {
@@ -163,7 +163,7 @@ void Block::ComputeByteSize() {
   for (int i = 0; i < num_cols; i++) {
     auto get_byte_size = [&, this]<typename T>(T *ptr) {
       if constexpr (has_ctype_member<T>::value) {
-        using CType = typename arrow::TypeTraits<T>::CType;
+        using CType = GetArrowCType<T>;
         int byte_width = sizeof(CType);
         column_sizes[i] = byte_width * columns[i]->length;
         num_bytes += byte_width * columns[i]->length;

--- a/src/storage/block.h
+++ b/src/storage/block.h
@@ -351,7 +351,7 @@ class Block {
    * @param record_batch RecordBatch read from a file
    * @param capacity Maximum number of date bytes to be stored in the Block
    */
-  Block(int id, std::shared_ptr<arrow::RecordBatch> record_batch, int capacity,
+  Block(int id, const std::shared_ptr<arrow::RecordBatch>& record_batch, int capacity,
         bool metadata_enabled);
 
  private:
@@ -394,7 +394,7 @@ class Block {
    * Total number of data bytes stored in the block, excluding the valid column
    * data.
    */
-  int num_bytes;
+  int num_bytes; // TODO: Should this be size_t?
 
   /**
    * Capacity of the block, initialized to BLOCK_SIZE.

--- a/src/type/type_helper.cc
+++ b/src/type/type_helper.cc
@@ -69,16 +69,16 @@ std::shared_ptr<arrow::DataType> TestFields(arrow::Type::type type_enum) {
 
 std::shared_ptr<arrow::ArrayBuilder> getBuilder(
     const std::shared_ptr<arrow::DataType> &dataType) {
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
-#define HUSTLE_ARROW_TYPE_CASE_STMT(T)          \
+#undef _HUSTLE_ARROW_TYPE_CASE_STMT
+#define _HUSTLE_ARROW_TYPE_CASE_STMT(T)          \
   {                                             \
     auto factory = BuilderFactory<T>(dataType); \
     auto result = factory.GetBuilder();         \
     return result.ValueOrDie();                 \
   }
   auto enum_type = dataType->id();
-  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
+  _HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+#undef _HUSTLE_ARROW_TYPE_CASE_STMT
   return nullptr;
 };
 

--- a/src/type/type_helper.cc
+++ b/src/type/type_helper.cc
@@ -66,21 +66,6 @@ std::shared_ptr<arrow::DataType> TestFields(arrow::Type::type type_enum) {
 }
 }  // namespace details
 
-template <typename Functor>
-void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
-                   Functor func) {
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
-#define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)        \
-  {                                                   \
-    auto rawptr = dataType.get();                     \
-    auto ptr = reinterpret_cast<DataType_ *>(rawptr); \
-    func(ptr);                                        \
-  }
-
-  auto enum_type = dataType->id();
-  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
-}
 
 std::shared_ptr<arrow::ArrayBuilder> getBuilder(
     const std::shared_ptr<arrow::DataType> &dataType) {

--- a/src/type/type_helper.cc
+++ b/src/type/type_helper.cc
@@ -66,6 +66,22 @@ std::shared_ptr<arrow::DataType> TestFields(arrow::Type::type type_enum) {
 }
 }  // namespace details
 
+template <typename Functor>
+void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
+                   Functor func) {
+#undef HUSTLE_ARROW_TYPE_CASE_STMT
+#define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)        \
+  {                                                   \
+    auto rawptr = dataType.get();                     \
+    auto ptr = reinterpret_cast<DataType_ *>(rawptr); \
+    func(ptr);                                        \
+  }
+
+  auto enum_type = dataType->id();
+  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+#undef HUSTLE_ARROW_TYPE_CASE_STMT
+}
+
 std::shared_ptr<arrow::ArrayBuilder> getBuilder(
     const std::shared_ptr<arrow::DataType> &dataType) {
 #undef HUSTLE_ARROW_TYPE_CASE_STMT

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -117,7 +117,7 @@ namespace hustle {
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL,                        \
                                   arrow::Decimal128Type);                      \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL256,                     \
-                                  arrow::Decimal256Type);                       \
+                                  arrow::Decimal256Type);                      \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRUCT, arrow::StructType);     \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LIST, arrow::ListType);         \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_LIST,                     \
@@ -139,6 +139,18 @@ namespace hustle {
 //
 // Type Traits
 //
+
+template <typename, typename = void>
+struct has_array_type : std::false_type {
+  using ArrayType = void;
+};
+
+template <typename DataType>
+struct has_array_type<
+    DataType, std::void_t<typename arrow::TypeTraits<DataType>::ArrayType>>
+    : std::true_type {
+  using BuilderType = typename arrow::TypeTraits<DataType>::BuilderType;
+};
 
 template <typename, typename = void>
 struct has_builder_type : std::false_type {
@@ -181,6 +193,9 @@ struct has_ctype_member<T, std::void_t<typename arrow::TypeTraits<T>::CType>>
 
 template <typename T, typename... Ts>
 using isOneOf = std::disjunction<std::is_same<T, Ts>...>;
+
+template <typename T, typename... Ts>
+using isNotOneOf = std::negation<isOneOf<T, Ts...>>;
 
 template <typename DataType>
 using is_string_type =

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -303,11 +303,12 @@ std::shared_ptr<arrow::ArrayBuilder> getBuilder(
 
 template <typename T>
 concept ArrowSwitchFunctor = requires(T func) {
+  // TODO: May lead to trouble when lambda function is declared as [&]
   // Can pass in an arrow::DataType pointer.
-  func((arrow::DataType *)nullptr);
+  //  func((arrow::DataType *)nullptr);
   // Return value is void
   //  std::is_void_v<T>;
-
+    true;
 };
 
 // Big arrow switch function.

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -116,6 +116,8 @@ namespace hustle {
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DURATION, arrow::DurationType); \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL,                        \
                                   arrow::Decimal128Type);                      \
+    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL256,                     \
+                                  arrow::Decima256Type);                       \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRUCT, arrow::StructType);     \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LIST, arrow::ListType);         \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_LIST,                     \
@@ -196,8 +198,6 @@ template <typename DataType, typename ReturnType>
 using enable_if_has_no_c_type =
     std::enable_if_t<!arrow::has_c_type<DataType>::value, ReturnType>;
 
-
-
 // Create Array Builder
 //    Use CreateBuilder as the central function.
 //
@@ -232,9 +232,6 @@ enum BuildCategory {
   dict_type = 6,
   extension_type = 7
 };
-
-
-
 
 template <typename T>
 static constexpr BuildCategory builder_category() {

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -136,6 +136,14 @@ namespace hustle {
     HUSTLE_ARROW_MAX_ID_CASE_STMT();                                           \
   };
 
+// TODO: Put requirement constraints that Functor must only have one argument
+//  that accepts a (const T * ptr_) and will never use it.
+//  This is the current constraint that lambda templates can't be initialized
+//  with non-type parameter.
+template <typename Functor>
+void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
+                   Functor func);
+
 //
 // Type Traits
 //

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -24,118 +24,6 @@
 
 namespace hustle {
 
-//
-// Helper macros that generates all switch statements to handle Arrow types.
-//
-// Basic usage:
-//
-//  // 1. Disable compiler warning
-//  #undef HUSTLE_ARROW_TYPE_CASE_STMT
-//
-//  // 2. Define the case body. This will be called for each arrow type.
-//  //    arrow_data_type_: a subclass of arrow::DataType
-//  #define HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_) \
-//        { std::cout << arrow_data_type_::name() << std::endl; }
-//
-//  // 3. Call the switch statement
-//  auto enum_type = arrow::Type::INT8; // Some dynmaic enum type...
-//  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
-//
-//  // 4. Reset the macro to prevent accidental reuse.
-//  #undef HUSTLE_ARROW_TYPE_CASE_STMT
-//
-//
-// Example usage:
-//  - src/operators/expression.h: ExecuteBlockHandler.
-
-// Placeholder case statement. Overwrite your macro definition when you use it.
-// The default statement simply throws error at runtime.
-#define HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_)                       \
-  {                                                                         \
-    std::cerr                                                               \
-        << "Used the default arrow type case statement placeholder macro. " \
-           "Please define the macro "                                       \
-           "HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_) in "              \
-           "your scope (and undef it at the end of the scope). "            \
-           "See type_helper.h for usage."                                   \
-        << std::endl;                                                       \
-    exit(0);                                                                \
-  }
-
-// Default macro that handles the MAX_ID case.
-// Simply throw an error and abort.
-#define HUSTLE_ARROW_MAX_ID_CASE_STMT()                                  \
-  case arrow::Type::MAX_ID: {                                            \
-    std::cerr << "Encountered MAX_ID in switch statement." << std::endl; \
-    exit(1);                                                             \
-  }
-
-// Individual switch statement that transforms
-// an arrow enum type to an arrow DataType type.
-#define HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow_enum_type_, data_type_) \
-  case arrow_enum_type_: {                                          \
-    HUSTLE_ARROW_TYPE_CASE_STMT(data_type_);                        \
-    break;                                                          \
-  };
-
-// The Big switch statement that make arrow type transform to the DataType type
-#define HUSTLE_SWITCH_ARROW_TYPE(arrow_enum_type_)                             \
-  switch (arrow_enum_type_) {                                                  \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::NA, arrow::NullType);           \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::BOOL, arrow::BooleanType);      \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT8, arrow::Int8Type);         \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT16, arrow::Int16Type);       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT32, arrow::Int32Type);       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT64, arrow::Int64Type);       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT8, arrow::UInt8Type);       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT16, arrow::UInt16Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT32, arrow::UInt32Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT64, arrow::UInt64Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::HALF_FLOAT,                     \
-                                  arrow::HalfFloatType);                       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::FLOAT, arrow::FloatType);       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DOUBLE, arrow::DoubleType);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRING, arrow::StringType);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::BINARY, arrow::BinaryType);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_STRING,                   \
-                                  arrow::LargeStringType);                     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_BINARY,                   \
-                                  arrow::LargeBinaryType);                     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::FIXED_SIZE_BINARY,              \
-                                  arrow::FixedSizeBinaryType);                 \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DATE32, arrow::Date32Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DATE64, arrow::Date64Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::TIME32, arrow::Time32Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::TIME64, arrow::Time64Type);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::TIMESTAMP,                      \
-                                  arrow::TimestampType);                       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INTERVAL_DAY_TIME,              \
-                                  arrow::DayTimeIntervalType);                 \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INTERVAL_MONTHS,                \
-                                  arrow::MonthIntervalType);                   \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DURATION, arrow::DurationType); \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL,                        \
-                                  arrow::Decimal128Type);                      \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL256,                     \
-                                  arrow::Decimal256Type);                      \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRUCT, arrow::StructType);     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LIST, arrow::ListType);         \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_LIST,                     \
-                                  arrow::LargeListType);                       \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::FIXED_SIZE_LIST,                \
-                                  arrow::FixedSizeListType);                   \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::MAP, arrow::MapType);           \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DENSE_UNION,                    \
-                                  arrow::DenseUnionType);                      \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::SPARSE_UNION,                   \
-                                  arrow::SparseUnionType);                     \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DICTIONARY,                     \
-                                  arrow::DictionaryType);                      \
-    HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::EXTENSION,                      \
-                                  arrow::ExtensionType);                       \
-    HUSTLE_ARROW_MAX_ID_CASE_STMT();                                           \
-  };
-
 // TODO: Put requirement constraints that Functor must only have one argument
 //  that accepts a (const T * ptr_) and will never use it.
 //  This is the current constraint that lambda templates can't be initialized
@@ -223,6 +111,126 @@ using enable_if_has_no_c_type =
 
 namespace details {
 
+// ***
+// *** DO NOT USE THIS MACRO UNLESS YOU ARE CERTAIN TO DO THAT! ***
+// ***
+// ***  See the following helpers as the first choice:
+// ***     - type_switcher(): Generic switcher with type control.
+// ***     - get_builder(): Get an arrow builder with type control.
+//
+
+// Helper macros that generates all switch statements to handle Arrow types.
+//
+// Basic usage:
+//
+//  // 1. Disable compiler warning
+//  #undef _HUSTLE_ARROW_TYPE_CASE_STMT
+//
+//  // 2. Define the case body. This will be called for each arrow type.
+//  //    arrow_data_type_: a subclass of arrow::DataType
+//  #define _HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_) \
+//        { std::cout << arrow_data_type_::name() << std::endl; }
+//
+//  // 3. Call the switch statement
+//  auto enum_type = arrow::Type::INT8; // Some dynmaic enum type...
+//  _HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+//
+//  // 4. Reset the macro to prevent accidental reuse.
+//  #undef _HUSTLE_ARROW_TYPE_CASE_STMT
+//
+//
+// Example usage:
+//  - src/operators/expression.h: ExecuteBlockHandler.
+
+// Placeholder case statement. Overwrite your macro definition when you use it.
+// The default statement simply throws error at runtime.
+#define _HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_)                      \
+  {                                                                         \
+    std::cerr                                                               \
+        << "Used the default arrow type case statement placeholder macro. " \
+           "Please define the macro "                                       \
+           "_HUSTLE_ARROW_TYPE_CASE_STMT(arrow_data_type_) in "             \
+           "your scope (and undef it at the end of the scope). "            \
+           "See type_helper.h for usage."                                   \
+        << std::endl;                                                       \
+    exit(0);                                                                \
+  }
+
+// Default macro that handles the MAX_ID case.
+// Simply throw an error and abort.
+#define _HUSTLE_ARROW_MAX_ID_CASE_STMT()                                 \
+  case arrow::Type::MAX_ID: {                                            \
+    std::cerr << "Encountered MAX_ID in switch statement." << std::endl; \
+    exit(1);                                                             \
+  }
+
+// Individual switch statement that transforms
+// an arrow enum type to an arrow DataType type.
+#define _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow_enum_type_, data_type_) \
+  case arrow_enum_type_: {                                           \
+    _HUSTLE_ARROW_TYPE_CASE_STMT(data_type_);                        \
+    break;                                                           \
+  };
+
+// The Big switch statement that make arrow type transform to the DataType type
+#define _HUSTLE_SWITCH_ARROW_TYPE(arrow_enum_type_)                         \
+  switch (arrow_enum_type_) {                                               \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::NA, arrow::NullType);       \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::BOOL, arrow::BooleanType);  \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT8, arrow::Int8Type);     \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT16, arrow::Int16Type);   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT32, arrow::Int32Type);   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INT64, arrow::Int64Type);   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT8, arrow::UInt8Type);   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT16, arrow::UInt16Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT32, arrow::UInt32Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::UINT64, arrow::UInt64Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::HALF_FLOAT,                 \
+                                   arrow::HalfFloatType);                   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::FLOAT, arrow::FloatType);   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DOUBLE, arrow::DoubleType); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRING, arrow::StringType); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::BINARY, arrow::BinaryType); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_STRING,               \
+                                   arrow::LargeStringType);                 \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_BINARY,               \
+                                   arrow::LargeBinaryType);                 \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::FIXED_SIZE_BINARY,          \
+                                   arrow::FixedSizeBinaryType);             \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DATE32, arrow::Date32Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DATE64, arrow::Date64Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::TIME32, arrow::Time32Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::TIME64, arrow::Time64Type); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::TIMESTAMP,                  \
+                                   arrow::TimestampType);                   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INTERVAL_DAY_TIME,          \
+                                   arrow::DayTimeIntervalType);             \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::INTERVAL_MONTHS,            \
+                                   arrow::MonthIntervalType);               \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DURATION,                   \
+                                   arrow::DurationType);                    \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL,                    \
+                                   arrow::Decimal128Type);                  \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL256,                 \
+                                   arrow::Decimal256Type);                  \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRUCT, arrow::StructType); \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LIST, arrow::ListType);     \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_LIST,                 \
+                                   arrow::LargeListType);                   \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::FIXED_SIZE_LIST,            \
+                                   arrow::FixedSizeListType);               \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::MAP, arrow::MapType);       \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DENSE_UNION,                \
+                                   arrow::DenseUnionType);                  \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::SPARSE_UNION,               \
+                                   arrow::SparseUnionType);                 \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DICTIONARY,                 \
+                                   arrow::DictionaryType);                  \
+    _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::EXTENSION,                  \
+                                   arrow::ExtensionType);                   \
+    _HUSTLE_ARROW_MAX_ID_CASE_STMT();                                       \
+  };
+
 enum BuildCategory {
   // Type classification
   // [1] Independent. Type does not depend on the field at all.
@@ -301,8 +309,9 @@ std::shared_ptr<arrow::DataType> TestFields(arrow::Type::type type_enum);
 std::shared_ptr<arrow::ArrayBuilder> getBuilder(
     const std::shared_ptr<arrow::DataType> &dataType);
 
-//template <typename T>
-//concept ArrowSwitchFunctor = requires(T func) {
+// TODO: Make ArrowSwitchFunctor a concept.
+// template <typename T>
+// concept ArrowSwitchFunctor = requires(T func) {
 //  // TODO: May lead to trouble when lambda function is declared as [&]
 //  // Can pass in an arrow::DataType pointer.
 //  //  func((arrow::DataType *)nullptr);
@@ -312,13 +321,14 @@ std::shared_ptr<arrow::ArrayBuilder> getBuilder(
 //};
 
 // Big arrow switch function.
+// Usage: in Aggregate::InsertGroupColumns().
 // Must put the definition in header until g++ resolve the error.
 // See: https://bit.ly/3bMbPG2
-template<typename ArrowSwitchFunctor>
+template <typename ArrowSwitchFunctor>
 void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
                    ArrowSwitchFunctor func) {
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
-#define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)        \
+#undef _HUSTLE_ARROW_TYPE_CASE_STMT
+#define _HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)       \
   {                                                   \
     auto rawptr = dataType.get();                     \
     auto ptr = reinterpret_cast<DataType_ *>(rawptr); \
@@ -326,10 +336,11 @@ void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
   }
 
   auto enum_type = dataType->id();
-  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
-#undef HUSTLE_ARROW_TYPE_CASE_STMT
+  _HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+#undef _HUSTLE_ARROW_TYPE_CASE_STMT
 }
 
+// TODO: Possibly refactor this to use type_switcher.
 template <typename DataTypeT>
 class BuilderFactory {
  public:
@@ -388,16 +399,18 @@ class BuilderFactory {
   using RType = typename std::enable_if_t<(category == categoryTarget),
                                           BuilderReturnType>;
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::independent> GetBuilderInternal() {
+  typedef details::BuildCategory Category;
+
+  template <Category cat>
+  RType<cat, Category::independent> GetBuilderInternal() {
     using BuilderType = typename arrow::TypeTraits<DataTypeT>::BuilderType;
     auto builder_ptr = std::make_shared<BuilderType>();
     arrow::Result<std::shared_ptr<arrow::ArrayBuilder>> result(builder_ptr);
     return result;
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::required_identity> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::required_identity> GetBuilderInternal() {
     using BuilderType = typename arrow::TypeTraits<DataTypeT>::BuilderType;
     auto builder_ptr = std::make_shared<BuilderType>(
         this->_dataType, arrow::default_memory_pool());
@@ -405,8 +418,8 @@ class BuilderFactory {
     return result;
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::list_like_type> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::list_like_type> GetBuilderInternal() {
     using BuilderType = typename arrow::TypeTraits<DataTypeT>::BuilderType;
     // TODO: List type should find the builder with this->_dataType 's nested
     // type.
@@ -418,8 +431,8 @@ class BuilderFactory {
     return result;
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::struct_type> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::struct_type> GetBuilderInternal() {
     std::shared_ptr<arrow::StructType> datatype =
         std::dynamic_pointer_cast<arrow::StructType>(this->_dataType);
     const int num_fields = datatype->num_fields();
@@ -435,8 +448,8 @@ class BuilderFactory {
     return result;
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::map_type> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::map_type> GetBuilderInternal() {
     std::shared_ptr<arrow::MapType> data_type =
         std::dynamic_pointer_cast<arrow::MapType>(this->_dataType);
 
@@ -452,8 +465,8 @@ class BuilderFactory {
     return result;
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::union_type> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::union_type> GetBuilderInternal() {
     std::shared_ptr<arrow::UnionType> data_type =
         std::dynamic_pointer_cast<arrow::UnionType>(this->_dataType);
     const int num_fields = data_type->num_fields();
@@ -469,8 +482,8 @@ class BuilderFactory {
     return result;
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::dict_type> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::dict_type> GetBuilderInternal() {
     std::shared_ptr<arrow::DictionaryType> data_type =
         std::dynamic_pointer_cast<arrow::DictionaryType>(this->_dataType);
     // Can only maps an integer to the corresponding dict type.
@@ -503,8 +516,8 @@ class BuilderFactory {
     }
   }
 
-  template <details::BuildCategory cat>
-  RType<cat, details::BuildCategory::extension_type> GetBuilderInternal() {
+  template <Category cat>
+  RType<cat, Category::extension_type> GetBuilderInternal() {
     // TODO: No support yet.
     return arrow::Result<std::shared_ptr<arrow::ArrayBuilder>>(arrow::Status(
         arrow::StatusCode::NotImplemented, "No support for Extension type!"));

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -301,21 +301,22 @@ std::shared_ptr<arrow::DataType> TestFields(arrow::Type::type type_enum);
 std::shared_ptr<arrow::ArrayBuilder> getBuilder(
     const std::shared_ptr<arrow::DataType> &dataType);
 
-template <typename T>
-concept ArrowSwitchFunctor = requires(T func) {
-  // TODO: May lead to trouble when lambda function is declared as [&]
-  // Can pass in an arrow::DataType pointer.
-  //  func((arrow::DataType *)nullptr);
-  // Return value is void
-  //  std::is_void_v<T>;
-    true;
-};
+//template <typename T>
+//concept ArrowSwitchFunctor = requires(T func) {
+//  // TODO: May lead to trouble when lambda function is declared as [&]
+//  // Can pass in an arrow::DataType pointer.
+//  //  func((arrow::DataType *)nullptr);
+//  // Return value is void
+//  //  std::is_void_v<T>;
+//    true;
+//};
 
 // Big arrow switch function.
 // Must put the definition in header until g++ resolve the error.
 // See: https://bit.ly/3bMbPG2
+template<typename ArrowSwitchFunctor>
 void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
-                   ArrowSwitchFunctor auto func) {
+                   ArrowSwitchFunctor func) {
 #undef HUSTLE_ARROW_TYPE_CASE_STMT
 #define HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)        \
   {                                                   \

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -193,7 +193,6 @@ using is_binary_type =
 template <typename DataType, typename ReturnType>
 using enable_if_has_c_type =
     std::enable_if_t<arrow::has_c_type<DataType>::value, ReturnType>;
-
 template <typename DataType, typename ReturnType>
 using enable_if_has_no_c_type =
     std::enable_if_t<!arrow::has_c_type<DataType>::value, ReturnType>;

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -34,13 +34,13 @@ namespace hustle {
 //
 
 template <typename DataType>
-using GetArrowBuilderType = typename arrow::TypeTraits<DataType>::BuilderType;
+using ArrowGetBuilderType = typename arrow::TypeTraits<DataType>::BuilderType;
 
 template <typename DataType>
-using GetArrowArrayType = typename arrow::TypeTraits<DataType>::ArrayType;
+using ArrowGetArrayType = typename arrow::TypeTraits<DataType>::ArrayType;
 
 template <typename DataType>
-using GetArrowScalarType = typename arrow::TypeTraits<DataType>::ScalarType;
+using ArrowScalarGetType = typename arrow::TypeTraits<DataType>::ScalarType;
 
 // template <typename DataType>
 // using GetArrowCType = typename arrow::TypeTraits<DataType>::CType;
@@ -57,7 +57,7 @@ template <typename DataType>
 struct has_array_type<
     DataType, std::void_t<typename arrow::TypeTraits<DataType>::ArrayType>>
     : std::true_type {
-  using BuilderType = GetArrowBuilderType<DataType>;
+  using BuilderType = ArrowGetBuilderType<DataType>;
 };
 
 template <typename, typename = void>
@@ -71,7 +71,7 @@ template <typename DataType>
 struct has_builder_type<
     DataType, std::void_t<typename arrow::TypeTraits<DataType>::BuilderType>>
     : std::true_type {
-  using BuilderType = GetArrowBuilderType<DataType>;
+  using BuilderType = ArrowGetBuilderType<DataType>;
   using is_defalut_constructable = std::is_default_constructible<BuilderType>;
   static constexpr bool is_defalut_constructable_v =
       is_defalut_constructable::value;
@@ -405,7 +405,7 @@ class BuilderFactory {
 
   template <Category cat>
   RType<cat, Category::independent> GetBuilderInternal() {
-    using BuilderType = GetArrowBuilderType<DataTypeT>;
+    using BuilderType = ArrowGetBuilderType<DataTypeT>;
     auto builder_ptr = std::make_shared<BuilderType>();
     arrow::Result<std::shared_ptr<arrow::ArrayBuilder>> result(builder_ptr);
     return result;
@@ -413,7 +413,7 @@ class BuilderFactory {
 
   template <Category cat>
   RType<cat, Category::required_identity> GetBuilderInternal() {
-    using BuilderType = GetArrowBuilderType<DataTypeT>;
+    using BuilderType = ArrowGetBuilderType<DataTypeT>;
     auto builder_ptr = std::make_shared<BuilderType>(
         this->_dataType, arrow::default_memory_pool());
     arrow::Result<std::shared_ptr<arrow::ArrayBuilder>> result(builder_ptr);
@@ -422,7 +422,7 @@ class BuilderFactory {
 
   template <Category cat>
   RType<cat, Category::list_like_type> GetBuilderInternal() {
-    using BuilderType = GetArrowBuilderType<DataTypeT>;
+    using BuilderType = ArrowGetBuilderType<DataTypeT>;
     // TODO: List type should find the builder with this->_dataType 's nested
     // type.
     std::shared_ptr<arrow::ArrayBuilder> value_builder =

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -117,7 +117,7 @@ namespace hustle {
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL,                        \
                                   arrow::Decimal128Type);                      \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::DECIMAL256,                     \
-                                  arrow::Decima256Type);                       \
+                                  arrow::Decimal256Type);                       \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::STRUCT, arrow::StructType);     \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LIST, arrow::ListType);         \
     HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::LARGE_LIST,                     \

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -62,18 +62,6 @@ struct has_builder_type<
       is_defalut_constructable::value;
 };
 
-template <typename T, typename R = void>
-using enable_if_builder_default_constructable =
-    std::enable_if_t<has_builder_type<T>::is_defalut_constructable_v, R>;
-
-template <typename T, typename R = void>
-using enable_if_builder_non_default_constructable =
-    std::enable_if_t<has_builder_type<T>::value &&
-                         !has_builder_type<T>::is_defalut_constructable_v,
-                     R>;
-
-template <typename T, typename R = void>
-using enable_if_no_builder = std::enable_if_t<!has_builder_type<T>::value, R>;
 
 // TODO: CType concept may be different. Some types have ctype nested in the
 //      body but not in the trait, and some (primitives) will expose that.


### PR DESCRIPTION
**Changes**
- Add `type_switcher()` to replace the (ugly) `HUSTLE_TYPE_SWITCH` macro. 
- Clean up most of the place where the type macro is used. Use `type_switcher` to simplify many switch statements.
- Make compatible with g++9. This does not necessarily mean we are compatible with c++17 now, but g++-9 already havee partial support for c++20, so we can get away with this in our existing stack.


**Usage of `type_switcher()`**

The concept of type switcher is
```c++
template <typename ArrowSwitchFunctor>
void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
                   ArrowSwitchFunctor func) {
  for each enum_type in Arrow's enum types:
    if constexpr enum_type == dataType->id(){
        auto rawptr = dataType.get();                     
        auto ptr = reinterpret_cast<DataType_ *>(rawptr); 
        func(ptr);                                        
    }
}
```

Type switcher accept two parameters:
- dataType: this is usually fetched from the builder (`builder->type()`) or from field (`field->child(i)->type()`). Used its enum id as the condition in switch.
- `ArrowSwitchFunctor func`: The lambda function must satisfies the following signature

```
auto func = [...]<typename T>(T * ptr){}
```
The type switcher will pass in a concrete pointer to the `func` as param `ptr`. This is only used as type deduction - to work around the fact that g++-10 does not support directly instantiate a template func (i.e. we can't do `func<Type>()` yet). 