### PR TITLE
type_switch(): Simplify more code

### DIFF
--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -287,7 +287,8 @@ void Aggregate::InsertGroupColumns(std::vector<int> group_id, int agg_index) {
   // its builder.
   for (std::size_t i = 0; i < group_type_->num_fields(); ++i) {
     // Handle the insertion of record.
-    auto insert_handler = [&, this]<typename T>(T * ptr_) {
+    auto data_type = group_type_->field(i)->type();
+    auto insert_handler = [&, this]<typename T>(T* ptr_) {
       // TODO: Add support for other types.
       //  Right now we only support types that have builder and array
       //  in the type trait. It should be obvious that we can:
@@ -323,11 +324,12 @@ void Aggregate::InsertGroupColumns(std::vector<int> group_id, int agg_index) {
           evaluate_status(status, __FUNCTION__, __LINE__);
           return;
         }
+      } else {
+        throw std::runtime_error("Cannot insert unsupported aggregate type:" +
+                                 data_type->ToString());
       }
-      throw std::runtime_error("Cannot insert unsupported aggregate type:" +
-                               group_type_->field(i)->type()->ToString());
     };
-    type_switcher(group_type_->field(i)->type(), insert_handler);
+    type_switcher(data_type, insert_handler);
   }
   // StructBuilder does not automatically update its length when we append to
   // its children. We must do this manually.

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -402,7 +402,7 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
       auto get_hash_key = [&]<typename T>(T *ptr_) {
         if constexpr (arrow::is_primitive_ctype<T>::value) {
           using ArrayType = ArrowGetArrayType<T>;
-          using CType = GetArrowCType<T>;
+          using CType = ArrowGetCType<T>;
 
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
           CType val = col->Value(item_index);

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -161,7 +161,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
                       !std::is_same_v<T, arrow::DayTimeIntervalType>) {
           std::cout << "Detect CType" << std::endl;
           using ArrayType = ArrowGetArrayType<T>;
-          using ScalarType = ArrowScalarGetType<T>;
+          using ScalarType = ArrowGetScalarType<T>;
           using CType = GetArrowCType<T>;
           // TODO: Write a separate if constexpr branch to
           //  make sure scalar type is default constructable.

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -162,7 +162,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
           std::cout << "Detect CType" << std::endl;
           using ArrayType = ArrowGetArrayType<T>;
           using ScalarType = ArrowGetScalarType<T>;
-          using CType = GetArrowCType<T>;
+          using CType = ArrowGetCType<T>;
           // TODO: Write a separate if constexpr branch to
           //  make sure scalar type is default constructable.
           //  Be aware of the ScalarType constructor.

--- a/src/operators/select/select.cc
+++ b/src/operators/select/select.cc
@@ -28,6 +28,7 @@
 #include "storage/ma_block.h"
 #include "storage/table.h"
 #include "storage/utils/util.h"
+#include "type/type_helper.h"
 #include "utils/bit_utils.h"
 
 namespace hustle {
@@ -126,159 +127,104 @@ arrow::Datum Select::Filter(const std::shared_ptr<Block> &block,
 
 arrow::Datum Select::Filter(const std::shared_ptr<Block> &block,
                             const std::shared_ptr<Predicate> &predicate) {
-  switch (predicate->value_.type()->id()) {
-    case arrow::Type::UINT8: {
-      uint8_t val = std::static_pointer_cast<arrow::UInt8Scalar>(
-                        predicate->value_.scalar())
-                        ->value;
-      auto datum_val = predicate->value_;
+  auto data_type = predicate->value_.type();
 
-      switch (predicate->comparator_) {
-        case arrow::compute::CompareOperator::LESS: {
-          return Filter<uint8_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::less());
-        }
-        case arrow::compute::CompareOperator::LESS_EQUAL: {
-          return Filter<uint8_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::less_equal());
-        }
-        case arrow::compute::CompareOperator::GREATER: {
-          return Filter<uint8_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::greater());
-        }
-        case arrow::compute::CompareOperator::GREATER_EQUAL: {
-          return Filter<uint8_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::greater_equal());
-        }
-        case arrow::compute::CompareOperator::EQUAL: {
-          return Filter<uint8_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::equal_to());
-        }
+  // [1] Handle default types.
+  // TODO: (Type Coverage) Any concerns over the default types?
+  auto default_filter = [&]<typename T>(T *) -> arrow::Datum {
+    arrow::Status status;
+    arrow::compute::CompareOptions compare_options(predicate->comparator_);
+    arrow::Datum block_filter;
+
+    auto select_col = block->get_column_by_name(predicate->col_ref_.col_name);
+    auto value = predicate->value_;
+
+    status = arrow::compute::Compare(select_col, value, compare_options)
+                 .Value(&block_filter);
+    evaluate_status(status, __FUNCTION__, __LINE__);
+
+    filters_[block->get_id()] = block_filter.make_array();
+    return block_filter;
+  };
+
+  // [2] Handle numeric types.
+  // TODO: There are a lot of assumptions over the type T.
+  auto numeric_filter = [&]<typename T>(T *) -> arrow::Datum {
+    using CType = ArrowGetCType<T>;
+    using ScalarType = ArrowGetScalarType<T>;
+
+    CType val =
+        std::static_pointer_cast<ScalarType>(predicate->value_.scalar())->value;
+    auto datum_val = predicate->value_;
+
+    switch (predicate->comparator_) {
+      case arrow::compute::CompareOperator::LESS: {
+        return Filter<CType>(block, predicate->col_ref_, datum_val, val,
+                             predicate->comparator_, std::less());
+      }
+      case arrow::compute::CompareOperator::LESS_EQUAL: {
+        return Filter<CType>(block, predicate->col_ref_, datum_val, val,
+                             predicate->comparator_, std::less_equal());
+      }
+      case arrow::compute::CompareOperator::GREATER: {
+        return Filter<CType>(block, predicate->col_ref_, datum_val, val,
+                             predicate->comparator_, std::greater());
+      }
+      case arrow::compute::CompareOperator::GREATER_EQUAL: {
+        return Filter<CType>(block, predicate->col_ref_, datum_val, val,
+                             predicate->comparator_, std::greater_equal());
+      }
+      case arrow::compute::CompareOperator::EQUAL: {
+        return Filter<CType>(block, predicate->col_ref_, datum_val, val,
+                             predicate->comparator_, std::equal_to());
+      }
         // TODO(nicholas): placeholder for BETWEEN
-        case arrow::compute::CompareOperator::NOT_EQUAL: {
-          auto num_rows = block->get_num_rows();
-          auto col_data =
-              block->get_column_by_name(predicate->col_ref_.col_name)
-                  ->data()
-                  ->GetValues<uint8_t>(1);
+      case arrow::compute::CompareOperator::NOT_EQUAL: {
+        auto num_rows = block->get_num_rows();
+        auto col_data = block->get_column_by_name(predicate->col_ref_.col_name)
+                            ->data()
+                            ->GetValues<CType>(1);
 
-          auto lo = std::static_pointer_cast<arrow::UInt8Scalar>(
-                        predicate->value_.scalar())
-                        ->value;
-          auto hi = std::static_pointer_cast<arrow::UInt8Scalar>(
-                        predicate->value2_.scalar())
-                        ->value;
-          auto diff = hi - lo;
+        auto lo = std::static_pointer_cast<arrow::UInt8Scalar>(
+                      predicate->value_.scalar())
+                      ->value;
+        auto hi = std::static_pointer_cast<arrow::UInt8Scalar>(
+                      predicate->value2_.scalar())
+                      ->value;
+        auto diff = hi - lo;
 
-          std::shared_ptr<arrow::Buffer> buffer;
-          auto status = arrow::AllocateBuffer(num_rows).Value(&buffer);
-          evaluate_status(status, __FUNCTION__, __LINE__);
-          auto bytemap = buffer->mutable_data();
+        std::shared_ptr<arrow::Buffer> buffer;
+        auto status = arrow::AllocateBuffer(num_rows).Value(&buffer);
+        evaluate_status(status, __FUNCTION__, __LINE__);
+        auto bytemap = buffer->mutable_data();
 
-          auto f = [](uint8_t val, uint8_t diff) -> bool {
-            return val <= diff;
-          };
-          for (uint32_t i = 0; i < num_rows; ++i) {
-            bytemap[i] = f(col_data[i] - lo, diff);
-          }
-
-          std::shared_ptr<arrow::BooleanArray> out_filter;
-          utils::pack(num_rows, bytemap, &out_filter);
-          return out_filter;
+        auto f = [](uint8_t val, uint8_t diff) -> bool { return val <= diff; };
+        for (uint32_t i = 0; i < num_rows; ++i) {
+          bytemap[i] = f(col_data[i] - lo, diff);
         }
-        default: {
-          std::cerr << "No support for comparator" << std::endl;
-        }
+
+        std::shared_ptr<arrow::BooleanArray> out_filter;
+        utils::pack(num_rows, bytemap, &out_filter);
+        return out_filter;
       }
-      break;
-    }
-    case arrow::Type::INT64: {
-      int64_t val = std::static_pointer_cast<arrow::Int64Scalar>(
-                        predicate->value_.scalar())
-                        ->value;
-      auto datum_val = predicate->value_;
-
-      switch (predicate->comparator_) {
-        case arrow::compute::CompareOperator::LESS: {
-          return Filter<int64_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::less());
-          break;
-        }
-        case arrow::compute::CompareOperator::LESS_EQUAL: {
-          return Filter<int64_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::less_equal());
-          break;
-        }
-        case arrow::compute::CompareOperator::GREATER: {
-          return Filter<int64_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::greater());
-          break;
-        }
-        case arrow::compute::CompareOperator::GREATER_EQUAL: {
-          return Filter<int64_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::greater_equal());
-          break;
-        }
-        case arrow::compute::CompareOperator::EQUAL: {
-          return Filter<int64_t>(block, predicate->col_ref_, datum_val, val,
-                                 predicate->comparator_, std::equal_to());
-          break;
-        }
-        case arrow::compute::CompareOperator::NOT_EQUAL: {
-          auto num_rows = block->get_num_rows();
-          auto col_data =
-              block->get_column_by_name(predicate->col_ref_.col_name)
-                  ->data()
-                  ->GetValues<int64_t>(1);
-
-          auto lo = std::static_pointer_cast<arrow::Int64Scalar>(
-                        predicate->value_.scalar())
-                        ->value;
-          auto hi = std::static_pointer_cast<arrow::Int64Scalar>(
-                        predicate->value2_.scalar())
-                        ->value;
-          auto diff = hi - lo;
-
-          std::shared_ptr<arrow::Buffer> buffer;
-          auto status = arrow::AllocateBuffer(num_rows).Value(&buffer);
-          evaluate_status(status, __FUNCTION__, __LINE__);
-
-          auto f = [](int64_t val, int64_t diff) -> bool {
-            return val <= diff;
-          };
-
-          auto bytemap = buffer->mutable_data();
-          for (uint32_t i = 0; i < num_rows; ++i) {
-            bytemap[i] = f(col_data[i] - lo, diff);
-          }
-
-          std::shared_ptr<arrow::BooleanArray> out_filter;
-          utils::pack(num_rows, bytemap, &out_filter);
-          return out_filter;
-        }
-        default: {
-          std::cerr << "No supprt for comparator" << std::endl;
-        }
+      default: {
+        std::cerr << "No support for comparator" << std::endl;
       }
-      break;
     }
+  };
 
-    default: {
-      arrow::Status status;
-      arrow::compute::CompareOptions compare_options(predicate->comparator_);
-      arrow::Datum block_filter;
-
-      auto select_col = block->get_column_by_name(predicate->col_ref_.col_name);
-      auto value = predicate->value_;
-
-      status = arrow::compute::Compare(select_col, value, compare_options)
-                   .Value(&block_filter);
-      evaluate_status(status, __FUNCTION__, __LINE__);
-
-      filters_[block->get_id()] = block_filter.make_array();
-      return block_filter;
+  arrow::Datum result;
+  auto filter_handler = [&]<typename T>(T *ptr) {
+    if constexpr (has_ctype_member<T>::value) {
+      result = numeric_filter(ptr);
+    } else {
+      result = default_filter(ptr);
     }
-  }
+  };
+
+  type_switcher(data_type, filter_handler);
+
+  return result;
 }
 
 void Select::Clear() { filters_.clear(); }

--- a/src/operators/select/select.cc
+++ b/src/operators/select/select.cc
@@ -213,6 +213,7 @@ arrow::Datum Select::Filter(const std::shared_ptr<Block> &block,
     }
   };
 
+  // Set `result` to return value through the filter_handler().
   arrow::Datum result;
   auto filter_handler = [&]<typename T>(T *ptr) {
     if constexpr (has_ctype_member<T>::value) {

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "absl/strings/numbers.h"
+#include "arrow_compute_wrappers.h"
 #include "storage/utils/util.h"
 #include "type/type_helper.h"
 
@@ -104,6 +105,7 @@ Block::Block(int id, const std::shared_ptr<arrow::Schema> &in_schema,
         data->ZeroPadding();
         columns.push_back(
             arrow::ArrayData::Make(field->type(), 0, {nullptr, data}));
+
       } else {
         throw std::logic_error("Block created with unsupported type: " +
                                std::string(T::type_name()));
@@ -225,8 +227,12 @@ void Block::out_block(void *pArg, sqlite3_callback callback) {
           txt_length = col->GetString(row).length();
           return;
         } else {
+          const auto func_name = __FUNCTION__;
+          const auto lino = __LINE__;
+          const std::string func =
+              std::string(func_name) + " " + std::to_string(lino);
           throw std::logic_error(
-              std::string("Block created with unsupported type: ") +
+              func + std::string("Block created with unsupported type: ") +
               schema->field(i)->type()->ToString());
         }
       };
@@ -268,8 +274,8 @@ void Block::print() {
           auto col = std::static_pointer_cast<ArrayType>(arrays[i]);
           std::cout << col->Value(row) << "\t";
 
-        } else if constexpr (isOneOf<T, arrow::StringArray,
-                                     arrow::FixedSizeBinaryArray>::value) {
+        } else if constexpr (isOneOf<T, arrow::StringType,
+                                     arrow::FixedSizeBinaryType>::value) {
           using ArrayType = ArrowGetArrayType<T>;
           auto col = std::static_pointer_cast<ArrayType>(arrays[i]);
           std::cout << col->GetString(row) << "\t";

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -104,10 +104,9 @@ Block::Block(int id, const std::shared_ptr<arrow::Schema> &in_schema,
         data->ZeroPadding();
         columns.push_back(
             arrow::ArrayData::Make(field->type(), 0, {nullptr, data}));
-
       } else {
-        throw_type_error<T, __FUNCTION__, __LINE__,
-                         "Block created with unsupported type">();
+        throw std::logic_error("Block created with unsupported type: " +
+                               std::string(T::type_name()));
       }
     };
 

--- a/src/storage/ma_block.cc
+++ b/src/storage/ma_block.cc
@@ -38,6 +38,7 @@ std::vector<MetadataUnit *> MetadataAttachedBlock::GenerateMetadataForColumn(
     int column_id) {
   std::vector<MetadataUnit *> out;
   std::vector<MetadataUnit *> verify_buffer;
+  // TODO: (Type Handle) Handle SMA for different data type.
   switch (get_column(column_id)->type()->id()) {
     case arrow::Type::UINT8:
     case arrow::Type::INT8:

--- a/src/storage/table.cc
+++ b/src/storage/table.cc
@@ -26,6 +26,7 @@
 #include "storage/block.h"
 #include "storage/ma_block.h"
 #include "storage/utils/util.h"
+#include "type/type_helper.h"
 
 namespace hustle::storage {
 
@@ -62,7 +63,7 @@ DBTable::DBTable(
   for (const auto &batch : record_batches) {
     if (enable_metadata) {
       block = std::make_shared<MetadataAttachedBlock>(block_counter, batch,
-                                                     BLOCK_SIZE);
+                                                      BLOCK_SIZE);
     } else {
       block = std::make_shared<Block>(block_counter, batch, BLOCK_SIZE);
     }
@@ -114,55 +115,33 @@ void DBTable::InsertRecords(
   int data_size = 0;
   auto block = GetBlockForInsert();
   int offset = 0;
-  int length = l;
-  // optimize?
-  int column_types[num_cols];
-  for (int i = 0; i < num_cols; i++) {
-    column_types[i] = schema->field(i)->type()->id();
-  }
+
+  // TODO: (Optimize) Why don't we switch column type then loop over rows?
   for (int row = 0; row < l; row++) {
     int record_size = 0;
     for (int i = 0; i < num_cols; i++) {
-      switch (column_types[i]) {
-        case arrow::Type::STRING: {
-          // optimize with offsets per schema?
+      auto data_type = schema->field(i)->type();
+      // TODO: (Optimize) Make this function inline.
+      auto handler = [&]<typename T>(T *) {
+        if constexpr (has_ctype_member<T>::value) {
+          using CType = ArrowGetCType<T>;
+          int byte_width = sizeof(CType);
+          record_size += byte_width;
+        } else if constexpr (isOneOf<T, arrow::StringType>::value) {
           auto *offsets = column_data[i]->GetValues<int32_t>(1, 0);
           record_size += offsets[row + 1] - offsets[row];
-          break;
-        }
-        case arrow::Type::FIXED_SIZE_BINARY: {
+        } else if constexpr (isOneOf<T, arrow::FixedSizeBinaryType>::value) {
           int byte_width =
               schema->field(i)->type()->layout().FixedWidth(1).byte_width;
           record_size += byte_width;
-          break;
-        }
-        case arrow::Type::DOUBLE:
-        case arrow::Type::INT64: {
-          int byte_width = sizeof(int64_t);
-          record_size += byte_width;
-          break;
-        }
-        case arrow::Type::UINT32: {
-          int byte_width = sizeof(uint32_t);
-          record_size += byte_width;
-          break;
-        }
-        case arrow::Type::UINT16: {
-          int byte_width = sizeof(uint16_t);
-          record_size += byte_width;
-          break;
-        }
-        case arrow::Type::UINT8: {
-          int byte_width = sizeof(uint8_t);
-          record_size += byte_width;
-          break;
-        }
-        default: {
+        } else {
           throw std::logic_error(
               std::string("Cannot compute record width. Unsupported type: ") +
               schema->field(i)->type()->ToString());
         }
-      }
+      };
+
+      type_switcher(data_type, handler);
     }
     std::vector<std::shared_ptr<arrow::ArrayData>> sliced_column_data;
     if (data_size + record_size > block->get_bytes_left()) {

--- a/src/storage/utils/record_utils.h
+++ b/src/storage/utils/record_utils.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// TODO: Refactor this whole file using the C++17 constexpr.
+
 #ifndef HUSTLE_RECORD_UTILS_H
 #define HUSTLE_RECORD_UTILS_H
 

--- a/src/storage/utils/util.h
+++ b/src/storage/utils/util.h
@@ -41,9 +41,12 @@
  * @param line_no Line number of the call to evaluate_status
  *
  * TODO: Do we want to throw an expection on error?
+ * TODO: Move this out of the storage scope. This can be made globa.
  */
 void evaluate_status(const arrow::Status& status, const char* function_name,
                      int line_no);
+
+
 
 /**
  * Write a table to a file. Currently, all blocks are written to the same file.

--- a/src/type/type_helper.cc
+++ b/src/type/type_helper.cc
@@ -77,7 +77,7 @@ std::shared_ptr<arrow::ArrayBuilder> getBuilder(
     return result.ValueOrDie();                 \
   }
   auto enum_type = dataType->id();
-  _HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
 #undef _HUSTLE_ARROW_TYPE_CASE_STMT
   return nullptr;
 };

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -40,7 +40,7 @@ template <typename DataType>
 using ArrowGetArrayType = typename arrow::TypeTraits<DataType>::ArrayType;
 
 template <typename DataType>
-using ArrowScalarGetType = typename arrow::TypeTraits<DataType>::ScalarType;
+using ArrowGetScalarType = typename arrow::TypeTraits<DataType>::ScalarType;
 
 // template <typename DataType>
 // using GetArrowCType = typename arrow::TypeTraits<DataType>::CType;
@@ -100,12 +100,6 @@ template <typename DataType>
 using is_binary_type =
     isOneOf<DataType, arrow::BinaryType, arrow::LargeBinaryType>;
 
-template <typename DataType, typename ReturnType>
-using enable_if_has_c_type =
-    std::enable_if_t<arrow::has_c_type<DataType>::value, ReturnType>;
-template <typename DataType, typename ReturnType>
-using enable_if_has_no_c_type =
-    std::enable_if_t<!arrow::has_c_type<DataType>::value, ReturnType>;
 
 // Create Array Builder
 //    Use CreateBuilder as the central function.

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -29,14 +29,7 @@ namespace hustle {
 //  This is the current constraint that lambda templates can't be initialized
 //  with non-type parameter.
 
-template <typename DataType, const char *fn_name, int lineno, const char *msg>
-constexpr void throw_type_error() {
-  // TODO: (Refactor) C++20 has format string as a constexpr.
-  constexpr auto result = std::string(fn_name) + ":" + std::to_string(lineno) +
-                          ":" + "Unsupported type error " + "(" +
-                          DataType::type_name() + "): " + std::string(msg);
-  throw std::logic_error(result);
-}
+//#define TYPE_ERROR(fn, lineno, mesg)
 
 //
 // Type Traits

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -318,13 +318,12 @@ std::shared_ptr<arrow::ArrayBuilder> getBuilder(
 //    true;
 //};
 
-// Big arrow switch function.
-// Usage: in Aggregate::InsertGroupColumns().
+// Switcher: arrow enum types -> arrow DataType child classes.
 // Must put the definition in header until g++ resolve the error.
 // See: https://bit.ly/3bMbPG2
 template <typename ArrowDataTypeSwitchFunctor>
 void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
-                   ArrowDataTypeSwitchFunctor func) {
+                   const ArrowDataTypeSwitchFunctor &func) {
 #undef _HUSTLE_ARROW_TYPE_CASE_STMT
 #define _HUSTLE_ARROW_TYPE_CASE_STMT(T) \
   { func((T *)nullptr); }
@@ -332,10 +331,10 @@ void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
 #undef _HUSTLE_ARROW_TYPE_CASE_STMT
 };
 
-// Arrow switch function for predicate comparator.
+// Switcher: arrow comparator enum -> std comparator
 template <typename ArrowComputeOperatorSwitchFunctor>
 auto comparator_switcher(arrow::compute::CompareOperator c,
-                         ArrowComputeOperatorSwitchFunctor func)
+                         const ArrowComputeOperatorSwitchFunctor &func)
     // Take the return type of the functor.
     -> decltype(func(std::equal_to())) {
   switch (c) {

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -170,7 +170,7 @@ namespace details {
   };
 
 // The Big switch statement that make arrow type transform to the DataType type
-#define HUSTLE_SWITCH_ARROW_TYPE(arrow_enum_type_)                         \
+#define HUSTLE_SWITCH_ARROW_TYPE(arrow_enum_type_)                          \
   switch (arrow_enum_type_) {                                               \
     _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::NA, arrow::NullType);       \
     _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::BOOL, arrow::BooleanType);  \
@@ -325,17 +325,12 @@ template <typename ArrowSwitchFunctor>
 void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
                    ArrowSwitchFunctor func) {
 #undef _HUSTLE_ARROW_TYPE_CASE_STMT
-#define _HUSTLE_ARROW_TYPE_CASE_STMT(DataType_)       \
-  {                                                   \
-    auto rawptr = dataType.get();                     \
-    auto ptr = reinterpret_cast<DataType_ *>(rawptr); \
-    func(ptr);                                        \
-  }
-
-  auto enum_type = dataType->id();
-  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+#define _HUSTLE_ARROW_TYPE_CASE_STMT(T) \
+  { func((T *)nullptr); }
+  HUSTLE_SWITCH_ARROW_TYPE(dataType->id());
 #undef _HUSTLE_ARROW_TYPE_CASE_STMT
 }
+
 
 // TODO: Possibly refactor this to use type_switcher.
 template <typename DataTypeT>

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -43,10 +43,10 @@ template <typename DataType>
 using ArrowGetScalarType = typename arrow::TypeTraits<DataType>::ScalarType;
 
 // template <typename DataType>
-// using GetArrowCType = typename arrow::TypeTraits<DataType>::CType;
+// using ArrowGetCType = typename arrow::TypeTraits<DataType>::CType;
 
 template <typename DataType>
-using GetArrowCType = typename DataType::c_type;
+using ArrowGetCType = typename DataType::c_type;
 
 template <typename, typename = void>
 struct has_array_type : std::false_type {
@@ -99,7 +99,6 @@ using is_string_type =
 template <typename DataType>
 using is_binary_type =
     isOneOf<DataType, arrow::BinaryType, arrow::LargeBinaryType>;
-
 
 // Create Array Builder
 //    Use CreateBuilder as the central function.
@@ -169,7 +168,7 @@ namespace details {
   };
 
 // The Big switch statement that make arrow type transform to the DataType type
-#define _HUSTLE_SWITCH_ARROW_TYPE(arrow_enum_type_)                         \
+#define HUSTLE_SWITCH_ARROW_TYPE(arrow_enum_type_)                         \
   switch (arrow_enum_type_) {                                               \
     _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::NA, arrow::NullType);       \
     _HUSTLE_ARROW_TYPE_SWITCH_CASE(arrow::Type::BOOL, arrow::BooleanType);  \
@@ -332,7 +331,7 @@ void type_switcher(const std::shared_ptr<arrow::DataType> &dataType,
   }
 
   auto enum_type = dataType->id();
-  _HUSTLE_SWITCH_ARROW_TYPE(enum_type);
+  HUSTLE_SWITCH_ARROW_TYPE(enum_type);
 #undef _HUSTLE_ARROW_TYPE_CASE_STMT
 }
 

--- a/src/type/type_helper.h
+++ b/src/type/type_helper.h
@@ -29,6 +29,15 @@ namespace hustle {
 //  This is the current constraint that lambda templates can't be initialized
 //  with non-type parameter.
 
+template <typename DataType, const char *fn_name, int lineno, const char *msg>
+constexpr void throw_type_error() {
+  // TODO: (Refactor) C++20 has format string as a constexpr.
+  constexpr auto result = std::string(fn_name) + ":" + std::to_string(lineno) +
+                          ":" + "Unsupported type error " + "(" +
+                          DataType::type_name() + "): " + std::string(msg);
+  throw std::logic_error(result);
+}
+
 //
 // Type Traits
 //

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -26,6 +26,12 @@
 
 namespace hustle {
 
+void throw_type_error(const char* function_name, const int line_no,
+                      const std::string message) {
+  const auto r = std::string(function_name) + std::to_string(line_no) + message;
+  throw std::logic_error(r);
+}
+
 Context::Context() { slice_length_ = 30000; }
 
 template <typename T>
@@ -332,7 +338,7 @@ void Context::apply_indices(Task* ctx, const arrow::Datum values,
               }
 
               throw std::logic_error("Apply indices to unsupported type:" +
-                                       std::string(T::type_name()));
+                                     std::string(T::type_name()));
             };
 
             type_switcher(data_type, apply_index_handler);

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -26,11 +26,6 @@
 
 namespace hustle {
 
-void throw_type_error(const char* function_name, const int line_no,
-                      const std::string message) {
-  const auto r = std::string(function_name) + std::to_string(line_no) + message;
-  throw std::logic_error(r);
-}
 
 Context::Context() { slice_length_ = 30000; }
 

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -17,7 +17,7 @@
 
 #include "arrow_compute_wrappers.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include <thread>
 

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -22,6 +22,7 @@
 #include <thread>
 
 #include "storage/utils/util.h"
+#include "type/type_helper.h"
 
 namespace hustle {
 
@@ -302,49 +303,39 @@ void Context::apply_indices(Task* ctx, const arrow::Datum values,
           internal->spawnLambdaTask([this, indices_array, chunked_values,
                                      has_index_chunks, offsets, index_chunks,
                                      i] {
-            switch (chunked_values->type()->id()) {
-              case arrow::Type::INT64: {
-                std::vector<const int64_t*> values_data_vec(
-                    chunked_values->num_chunks());
-                for (int i = 0; i < chunked_values->num_chunks(); ++i) {
-                  values_data_vec[i] =
-                      chunked_values->chunk(i)->data()->GetValues<int64_t>(1);
-                }
-                if (has_index_chunks) {
-                  apply_indices_internal2<int64_t>(
-                      chunked_values, values_data_vec.data(), indices_array,
-                      index_chunks.make_array(), offsets, i);
-                } else {
-                  apply_indices_internal<int64_t>(chunked_values,
-                                                  values_data_vec.data(),
-                                                  indices_array, offsets, i);
-                }
-                break;
-              }
-              case arrow::Type::UINT32: {
-                std::vector<const uint32_t*> values_data_vec(
-                    chunked_values->num_chunks());
-                for (int i = 0; i < chunked_values->num_chunks(); ++i) {
-                  values_data_vec[i] =
-                      chunked_values->chunk(i)->data()->GetValues<uint32_t>(1);
-                }
-                if (has_index_chunks) {
-                  apply_indices_internal2<uint32_t>(
-                      chunked_values, values_data_vec.data(), indices_array,
-                      index_chunks.make_array(), offsets, i);
-                } else {
-                  apply_indices_internal<uint32_t>(chunked_values,
-                                                   values_data_vec.data(),
-                                                   indices_array, offsets, i);
-                }
-                break;
-              }
-              case arrow::Type::STRING: {
+            auto data_type = chunked_values->type();
+
+            auto apply_index_handler = [&, this]<typename T>(T*) {
+              if constexpr (arrow::is_string_type<T>::value) {
                 apply_indices_internal_str(chunked_values, indices_array,
                                            offsets, i);
-                break;
+                return;
               }
-            }
+              if constexpr (has_ctype_member<T>::value) {
+                using CType = ArrowGetCType<T>;
+                std::vector<const CType*> values_data_vec(
+                    chunked_values->num_chunks());
+                for (int j = 0; j < chunked_values->num_chunks(); ++j) {
+                  values_data_vec[j] =
+                      chunked_values->chunk(i)->data()->GetValues<CType>(1);
+                }
+                if (has_index_chunks) {
+                  apply_indices_internal2<CType>(
+                      chunked_values, values_data_vec.data(), indices_array,
+                      index_chunks.make_array(), offsets, i);
+                } else {
+                  apply_indices_internal<CType>(chunked_values,
+                                                values_data_vec.data(),
+                                                indices_array, offsets, i);
+                }
+                return;
+              }
+
+              throw std::logic_error("Apply indices to unsupported type:" +
+                                       std::string(T::type_name()));
+            };
+
+            type_switcher(data_type, apply_index_handler);
           });
         }
       }),

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -26,22 +26,6 @@
 
 namespace hustle {
 
-/**
- * Throw a type error.
- *
- * The function_name and line_no parameters allow us to find exactly where
- * the error occured, since the same error can be thrown from different places.
- *
- * @param function_name name of the function that called evaluate_status
- * @param line_no Line number of the call to evaluate_status
- * @param message Message to show apart from the other info.
- *
- * TODO: Do we want to throw an expection on error?
- * TODO: Move this out of the storage scope. This can be made globa.
- */
-void throw_type_error(const char *function_name, int line_no,
-                      std::string message);
-
 class Context {
  public:
   Context();

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -26,6 +26,22 @@
 
 namespace hustle {
 
+/**
+ * Throw a type error.
+ *
+ * The function_name and line_no parameters allow us to find exactly where
+ * the error occured, since the same error can be thrown from different places.
+ *
+ * @param function_name name of the function that called evaluate_status
+ * @param line_no Line number of the call to evaluate_status
+ * @param message Message to show apart from the other info.
+ *
+ * TODO: Do we want to throw an expection on error?
+ * TODO: Move this out of the storage scope. This can be made globa.
+ */
+void throw_type_error(const char *function_name, int line_no,
+                      std::string message);
+
 class Context {
  public:
   Context();


### PR DESCRIPTION
Use `type_switch()` to simplify code. 


**Known issues**
- `__FUNCTION__` macro used in lambda only outputs `operator()` because invoking lambda function is equivalent to invoking a structure's operator(). We may need to switch to find some extern lib.
- Performance _may_ degrade if we first loop on rows and then columns. 