### PR TITLE
Fix documentation about arrow installation on MacOS for CPP20

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To install the required packages for Hustle use the following scripts:
 
 ```
 ./install_requirements_cpp20.sh
-./install_arrow.sh
+./install_arrow_cpp20.sh
 ```
 
 The scripts will install g++10, cmake 3.15 and Apache Arrow 3.0. 

--- a/install_arrow_cpp20.sh
+++ b/install_arrow_cpp20.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Checkout the arrow 3.0.0 Version
+if [ ! -d "arrow" ]; then
+  git clone https://github.com/apache/arrow.git
+  cd arrow || exit 1
+  git checkout apache-arrow-3.0.0
+  cd ..
+fi
+
+# Make the release
+mkdir -p arrow/cpp/release
+cd arrow/cpp/release || exit 1
+
+CMAKE_BIN=cmake
+CMAKE_FLAGS="-DARROW_COMPUTE=ON -DARROW_DEPENDENCY_SOURCE=AUTO -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10"
+
+# TODO: (Remove) Since we have installed cmake globally in Linux,
+#       we may not need to reference the previous cmake binary again.
+if [[ $(uname) == "Darwin" ]]; then
+  # -DARROW_DEPENDENCY_SOURCE=AUTO: try to build dependencies from source if they are not found on the machine.
+  CMAKE_BIN=cmake
+elif [[ $(uname) == "Linux" ]]; then
+  CMAKE_BIN=../../../cmake-3.15.5/bin/cmake
+fi
+
+# Build arrow
+${CMAKE_BIN} ${CMAKE_FLAGS} ..
+sudo make install -j4


### PR DESCRIPTION
**Changes**
- Forked another script `install_arrow_cpp20.sh` for C++20 installation.

**Next PR**
- Let CMake decide which compiler to use, if user not specified. CMake should also let the user know if they are not using gcc.
- Make `arrow` a CMake dependent, if not installed in system or not compatible (i.e. clang-built vs gcc-built). 