### PR TITLE
Fix SEGFAULT on SSB benchmark

### DIFF
--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -219,8 +219,8 @@ void Block::out_block(void *pArg, sqlite3_callback callback) {
           col_txt = (char *)std::to_string(col->Value(row)).c_str();
           txt_length = std::to_string(col->Value(row)).length();
           return;
-        } else if constexpr (isOneOf<T, arrow::StringArray,
-                                     arrow::FixedSizeBinaryArray>::value) {
+        } else if constexpr (arrow::is_string_type<T>::value ||
+                             arrow::is_fixed_size_binary_type<T>::value) {
           using ArrayType = ArrowGetArrayType<T>;
           auto col = std::static_pointer_cast<ArrayType>(arrays[i]);
           col_txt = (char *)col->GetString(row).c_str();

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -304,39 +304,84 @@ void Context::apply_indices(Task* ctx, const arrow::Datum values,
           internal->spawnLambdaTask([this, indices_array, chunked_values,
                                      has_index_chunks, offsets, index_chunks,
                                      i] {
-            auto data_type = chunked_values->type();
+            // TODO: This somehow causes an unkown segfault error.
+//            auto data_type = chunked_values->type();
+//
+//            auto apply_index_handler = [&, this]<typename T>(T*) {
+//              if constexpr (arrow::is_string_type<T>::value) {
+//                apply_indices_internal_str(chunked_values, indices_array,
+//                                           offsets, i);
+//                return;
+//              }
+//              if constexpr (has_ctype_member<T>::value) {
+//                using CType = ArrowGetCType<T>;
+//                std::vector<const CType*> values_data_vec(
+//                    chunked_values->num_chunks());
+//                for (int j = 0; j < chunked_values->num_chunks(); ++j) {
+//                  values_data_vec[j] =
+//                      chunked_values->chunk(i)->data()->GetValues<CType>(1);
+//                }
+//                if (has_index_chunks) {
+//                  apply_indices_internal2<CType>(
+//                      chunked_values, values_data_vec.data(), indices_array,
+//                      index_chunks.make_array(), offsets, i);
+//                } else {
+//                  apply_indices_internal<CType>(chunked_values,
+//                                                values_data_vec.data(),
+//                                                indices_array, offsets, i);
+//                }
+//                return;
+//              }
+//
+//              throw std::logic_error("Apply indices to unsupported type:" +
+//                                     std::string(T::type_name()));
+//            };
+//
+//            type_switcher(data_type, apply_index_handler);
 
-            auto apply_index_handler = [&, this]<typename T>(T*) {
-              if constexpr (arrow::is_string_type<T>::value) {
-                apply_indices_internal_str(chunked_values, indices_array,
-                                           offsets, i);
-                return;
-              }
-              if constexpr (has_ctype_member<T>::value) {
-                using CType = ArrowGetCType<T>;
-                std::vector<const CType*> values_data_vec(
+            switch (chunked_values->type()->id()) {
+              case arrow::Type::INT64: {
+                std::vector<const int64_t*> values_data_vec(
                     chunked_values->num_chunks());
-                for (int j = 0; j < chunked_values->num_chunks(); ++j) {
-                  values_data_vec[j] =
-                      chunked_values->chunk(i)->data()->GetValues<CType>(1);
+                for (int i = 0; i < chunked_values->num_chunks(); ++i) {
+                  values_data_vec[i] =
+                      chunked_values->chunk(i)->data()->GetValues<int64_t>(1);
                 }
                 if (has_index_chunks) {
-                  apply_indices_internal2<CType>(
+                  apply_indices_internal2<int64_t>(
                       chunked_values, values_data_vec.data(), indices_array,
                       index_chunks.make_array(), offsets, i);
                 } else {
-                  apply_indices_internal<CType>(chunked_values,
-                                                values_data_vec.data(),
-                                                indices_array, offsets, i);
+                  apply_indices_internal<int64_t>(chunked_values,
+                                                  values_data_vec.data(),
+                                                  indices_array, offsets, i);
                 }
-                return;
+                break;
               }
-
-              throw std::logic_error("Apply indices to unsupported type:" +
-                                     std::string(T::type_name()));
-            };
-
-            type_switcher(data_type, apply_index_handler);
+              case arrow::Type::UINT32: {
+                std::vector<const uint32_t*> values_data_vec(
+                    chunked_values->num_chunks());
+                for (int i = 0; i < chunked_values->num_chunks(); ++i) {
+                  values_data_vec[i] =
+                      chunked_values->chunk(i)->data()->GetValues<uint32_t>(1);
+                }
+                if (has_index_chunks) {
+                  apply_indices_internal2<uint32_t>(
+                      chunked_values, values_data_vec.data(), indices_array,
+                      index_chunks.make_array(), offsets, i);
+                } else {
+                  apply_indices_internal<uint32_t>(chunked_values,
+                                                   values_data_vec.data(),
+                                                   indices_array, offsets, i);
+                }
+                break;
+              }
+              case arrow::Type::STRING: {
+                apply_indices_internal_str(chunked_values, indices_array,
+                                           offsets, i);
+                break;
+              }
+            }
           });
         }
       }),

--- a/src/utils/arrow_compute_wrappers.cc
+++ b/src/utils/arrow_compute_wrappers.cc
@@ -304,7 +304,7 @@ void Context::apply_indices(Task* ctx, const arrow::Datum values,
           internal->spawnLambdaTask([this, indices_array, chunked_values,
                                      has_index_chunks, offsets, index_chunks,
                                      i] {
-            // TODO: This somehow causes an unkown segfault error.
+            // TODO: This somehow causes an unknown segfault error.
 //            auto data_type = chunked_values->type();
 //
 //            auto apply_index_handler = [&, this]<typename T>(T*) {
@@ -380,6 +380,10 @@ void Context::apply_indices(Task* ctx, const arrow::Datum values,
                 apply_indices_internal_str(chunked_values, indices_array,
                                            offsets, i);
                 break;
+              }
+              default: {
+                throw std::logic_error(std::string("Unsupported type: ") +
+                                       chunked_values->type()->ToString());
               }
             }
           });


### PR DESCRIPTION
**Changes**
- Revert the change in `apply_indecies()`. This solved an unknown SEGFAULT error on SSB benchmark.

**Next Step**
- Add mock SSB test on CircleCI. @srsuryadev has a similar SQL test, but a different schema than SSB. May be good to just replicate the SSB schema. Even better, we can generate the data in C++ so that we don't need to load data from external.
- Fix the `SEGFAULT` bug.
- Better error message. As the lambda func get deeply nested, it can be much harder to trace the bug in debug mode. Having a exception catch and signal handler for exception can help. 