### PR TITLE
SQL support fixes 

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -47,5 +47,3 @@ target_link_libraries(hustle_SQL_MISC_test
         hustleDB
         )
 add_test(SQL_MISC_test hustle_SQL_MISC_test)
-
-

--- a/src/api/hustle_db.cc
+++ b/src/api/hustle_db.cc
@@ -66,10 +66,10 @@ bool HustleDB::create_table(const TableSchema ts, DBTable::TablePtr table_ref) {
 }
 
 void HustleDB::reinitialize_sqlite_db() {
-    if (db != NULL) {
-        utils::close_sqlite3(db);
-    }
-    utils::open_sqlite3_db(SqliteDBPath_, &db);
+  if (db != NULL) {
+    utils::close_sqlite3(db);
+  }
+  utils::open_sqlite3_db(SqliteDBPath_, &db);
 }
 
 void HustleDB::load_tables() {

--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -52,6 +52,7 @@ class HustleDB {
     if (Scheduler::GlobalInstance().isActive()) {
       Scheduler::GlobalInstance().join();
     }
+    catalogs.clear();
     utils::destroy_sqlite3();
   }
 

--- a/src/api/tests/sql_test.cc
+++ b/src/api/tests/sql_test.cc
@@ -70,9 +70,9 @@ class SQLTest : public Test {
     return stream;
   }
 
-  SQLTest() {
+  void SetUp()  override{
+      std::cout << "In setup" << std::endl;
     int num_remove = std::filesystem::remove_all("db_directory_sql");
-    std::cout << "Num of removes: " << num_remove << std::endl;
     EXPECT_FALSE(std::filesystem::exists("db_directory_sql"));
 
     SQLTest::hustle_db = std::make_shared<hustle::HustleDB>("db_directory_sql");
@@ -205,11 +205,6 @@ class SQLTest : public Test {
     SQLTest::d = std::make_shared<hustle::storage::DBTable>(
         "ddate", SQLTest::ddate.getArrowSchema(), BLOCK_SIZE);
 
-    SQLTest::lo.reset();
-    SQLTest::c.reset();
-    SQLTest::s.reset();
-    SQLTest::p.reset();
-    SQLTest::d.reset();
 
     hustle_db->create_table(SQLTest::lineorder, SQLTest::lo);
     hustle_db->create_table(SQLTest::customer, SQLTest::c);
@@ -321,6 +316,11 @@ class SQLTest : public Test {
 
   void TearDown() override {
     hustle::HustleDB::destroy();
+      SQLTest::lo.reset();
+      SQLTest::c.reset();
+      SQLTest::s.reset();
+      SQLTest::p.reset();
+      SQLTest::d.reset();
     hustle_db.reset();
   }
 };
@@ -480,16 +480,16 @@ TEST_F(SQLTest, q9) {
 
 TEST_F(SQLTest, q10) {
   std::string query =
-      "select c_city, s_city, d_year, sum(lo_revenue) as "
+      "select c_city, s_city,  d_year, sum(lo_revenue) as "
       "revenue\n"
       "\tfrom customer, lineorder, supplier, ddate\n"
       "\twhere lo_custkey = c_custkey\n"
       "\t\tand lo_suppkey = s_suppkey\n"
       "\t\tand lo_orderdate = d_datekey\n"
-      "\t\tand (c_city='CCITY40' or c_city='CCITY60')\n"
-      "\t\tand (s_city='SCITY40' or s_city='SCITY60')\n"
-      "\t\tand d_yearmonth = 'Dec1993'\n"
-      "\tgroup by c_city, s_city, d_year\n"
+      "\t\tand (c_city='CCITY10')\n"
+      "\t\tand (s_city='SCITY10')\n"
+      "\t\tand d_yearmonth = 'Feb1992'\n"
+      "\tgroup by s_city, c_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
 
   std::string output = hustle_db->execute_query_result(query);

--- a/src/api/tests/sql_test.cc
+++ b/src/api/tests/sql_test.cc
@@ -70,8 +70,7 @@ class SQLTest : public Test {
     return stream;
   }
 
-  void SetUp()  override{
-      std::cout << "In setup" << std::endl;
+  void SetUp() override {
     int num_remove = std::filesystem::remove_all("db_directory_sql");
     EXPECT_FALSE(std::filesystem::exists("db_directory_sql"));
 
@@ -205,7 +204,6 @@ class SQLTest : public Test {
     SQLTest::d = std::make_shared<hustle::storage::DBTable>(
         "ddate", SQLTest::ddate.getArrowSchema(), BLOCK_SIZE);
 
-
     hustle_db->create_table(SQLTest::lineorder, SQLTest::lo);
     hustle_db->create_table(SQLTest::customer, SQLTest::c);
     hustle_db->create_table(SQLTest::supplier, SQLTest::s);
@@ -316,11 +314,11 @@ class SQLTest : public Test {
 
   void TearDown() override {
     hustle::HustleDB::destroy();
-      SQLTest::lo.reset();
-      SQLTest::c.reset();
-      SQLTest::s.reset();
-      SQLTest::p.reset();
-      SQLTest::d.reset();
+    SQLTest::lo.reset();
+    SQLTest::c.reset();
+    SQLTest::s.reset();
+    SQLTest::p.reset();
+    SQLTest::d.reset();
     hustle_db.reset();
   }
 };

--- a/src/api/tests/sql_test.cc
+++ b/src/api/tests/sql_test.cc
@@ -130,7 +130,7 @@ class SQLTest : public Test {
     hustle::catalog::ColumnSchema d_datekey(
         "d_datekey", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
     hustle::catalog::ColumnSchema d_dayofweek(
-        "d_dayofweek", {hustle::catalog::HustleType::CHAR, 10}, true, false);
+        "d_dayofweek", {hustle::catalog::HustleType::INTEGER, 10}, true, false);
     hustle::catalog::ColumnSchema d_month(
         "d_month", {hustle::catalog::HustleType::CHAR, 10}, true, false);
     hustle::catalog::ColumnSchema d_year(
@@ -477,6 +477,7 @@ TEST_F(SQLTest, q9) {
 }
 
 TEST_F(SQLTest, q10) {
+    // TODO (@suryadev): fix the data to support exact SSB query 10
   std::string query =
       "select c_city, s_city,  d_year, sum(lo_revenue) as "
       "revenue\n"
@@ -484,8 +485,8 @@ TEST_F(SQLTest, q10) {
       "\twhere lo_custkey = c_custkey\n"
       "\t\tand lo_suppkey = s_suppkey\n"
       "\t\tand lo_orderdate = d_datekey\n"
-      "\t\tand (c_city='CCITY10')\n"
-      "\t\tand (s_city='SCITY10')\n"
+      "\t\tand (c_city='CCITY60')\n"
+      "\t\tand (s_city='SCITY60')\n"
       "\t\tand d_yearmonth = 'Feb1992'\n"
       "\tgroup by s_city, c_city, d_year\n"
       "\torder by d_year asc, revenue desc;";
@@ -493,7 +494,7 @@ TEST_F(SQLTest, q10) {
   std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(
       output,
-      "CCITY40 | SCITY40 | 1993 | 39807\nCCITY60 | SCITY60 | 1993 | 37564\n");
+      "CCITY60 | SCITY60 | 1994 | 19753\n");
 }
 
 TEST_F(SQLTest, q11) {

--- a/src/api/tests/sql_test_misc.cc
+++ b/src/api/tests/sql_test_misc.cc
@@ -94,17 +94,17 @@ TEST_F(SQLMiscTest, q_without_join) {
   std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "2\n");
 }
-/*
+
 TEST_F(SQLMiscTest, q_predicate_assorted) {
     std::string query =
-            "select Count(lo_orderkey)\n"
+            "select Count(lo_quantity)\n"
             "from  lineorder, ddate\n"
-            "where d_datekey = lo_custkey and lo_quantity = 20 and d_year = 1993 and lo_revenue = "
-            "763 and d_dayofweek = 3;\n";
+            "where d_datekey = lo_orderdate and d_year = 1993 and (lo_quantity = 20 and lo_revenue = "
+            "763);\n";
 
     std::string output = hustle_db->execute_query_result(query);
-    EXPECT_EQ(output, "6 | 1992011 | 1\n");
-}*/
+    EXPECT_EQ(output, "1\n");
+}
 
 
 TEST_F(SQLMiscTest, q_joins_non_unique_columns) {

--- a/src/api/tests/sql_test_misc.cc
+++ b/src/api/tests/sql_test_misc.cc
@@ -74,26 +74,38 @@ TEST_F(SQLMiscTest, q_without_agg_and_join) {
 
 TEST_F(SQLMiscTest, q_without_agg) {
   std::string query =
-      "select lo_orderkey, lo_revenue, lo_quantity, d_month, d_yearmonth\n"
+      "select  lo_revenue, lo_quantity, d_month, d_yearmonth\n"
       "from ddate, lineorder\n"
-      "where d_datekey = 1992015 and (lo_quantity = 29 and lo_revenue = "
+      "where d_datekey = lo_orderdate  and (lo_quantity = 29 and lo_revenue = "
       "946)\n;";
 
   std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output,
-            "12713 | 946 | 29 | 5 | Jan1992\n"
-            "19527 | 946 | 29 | 5 | Jan1992\n");
+            "946 | 29 | 4 | Feb1992\n"
+            "946 | 29 | 4 | Mar1992\n");
 }
 
 TEST_F(SQLMiscTest, q_without_join) {
   std::string query =
-      "select Count(lo_orderkey)\n"
+      "select Count(lo_quantity)\n"
       "from  lineorder\n"
       "where (lo_quantity = 29 and lo_revenue = 946)\n;";
 
   std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output, "2\n");
 }
+/*
+TEST_F(SQLMiscTest, q_predicate_assorted) {
+    std::string query =
+            "select Count(lo_orderkey)\n"
+            "from  lineorder, ddate\n"
+            "where d_datekey = lo_custkey and lo_quantity = 20 and d_year = 1993 and lo_revenue = "
+            "763 and d_dayofweek = 3;\n";
+
+    std::string output = hustle_db->execute_query_result(query);
+    EXPECT_EQ(output, "6 | 1992011 | 1\n");
+}*/
+
 
 TEST_F(SQLMiscTest, q_joins_non_unique_columns) {
   std::string query =
@@ -144,10 +156,10 @@ TEST_F(SQLMiscTest, q_nested_subquery_predicate) {
       "SELECT lo_orderkey\n"
       "FROM  lineorder\n"
       "WHERE lo_orderkey IN (\n"
-      "SELECT lo_orderkey FROM lineorder WHERE lo_orderkey=3);\n";
+      "SELECT lo_orderkey FROM lineorder WHERE lo_orderkey < 5);\n";
 
   output = hustle_db->execute_query_result(query);
-  EXPECT_EQ(output, "3\n");
+  EXPECT_EQ(output, "0\n1\n2\n3\n4\n");
 
   query =
       "SELECT lo_orderkey\n"

--- a/src/benchmark/aggregate_workload.cc
+++ b/src/benchmark/aggregate_workload.cc
@@ -84,6 +84,7 @@ void AggregateWorkload::q1(AggregateType agg_type) {
   AggregateReference agg_ref = {
     AggregateKernel::MEAN, "agg_col", inputTable, "Col0"};
   std::vector<ColumnReference> group_by_refs;
+  std::vector<OrderByReference> order_by_refs;
   std::vector<ColumnReference> output_refs;
 
   output_refs.push_back({nullptr, "agg_col"});
@@ -96,7 +97,7 @@ void AggregateWorkload::q1(AggregateType agg_type) {
 
   BaseAggregate *agg_op = get_agg_op(
     0, agg_type, input_, out_result,
-    {agg_ref}, group_by_refs, group_by_refs,
+    {agg_ref}, group_by_refs, order_by_refs,
     aggregate_options);
 
   ExecutionPlan plan(0);

--- a/src/benchmark/ssb_queries.cc
+++ b/src/benchmark/ssb_queries.cc
@@ -246,18 +246,16 @@ namespace hustle::operators {
 
         std::cout << "read the table files..." << std::endl;
         DBTable::TablePtr lo, c, s, p, d;
-        const auto block_size =
-            Config::GetInstance().GetDoubleValue("block-size");
         lo = std::make_shared<hustle::storage::DBTable>("lineorder", lo_schema,
-                                                        block_size);
+                                                        20 * BLOCK_SIZE);
         d = std::make_shared<hustle::storage::DBTable>("ddate", d_schema,
-                                                       block_size);
+                                                       20 * BLOCK_SIZE);
         p = std::make_shared<hustle::storage::DBTable>("part", p_schema,
-                                                       block_size);
+                                                       20 * BLOCK_SIZE);
         c = std::make_shared<hustle::storage::DBTable>("customer", c_schema,
-                                                       block_size);
+                                                       20 * BLOCK_SIZE);
         s = std::make_shared<hustle::storage::DBTable>("supplier", s_schema,
-                                                       block_size);
+                                                       20 * BLOCK_SIZE);
         hustle_db->create_table(supplier, s);
         hustle_db->create_table(customer, c);
         hustle_db->create_table(ddate, d);

--- a/src/benchmark/ssb_queries.cc
+++ b/src/benchmark/ssb_queries.cc
@@ -247,15 +247,15 @@ namespace hustle::operators {
         std::cout << "read the table files..." << std::endl;
         DBTable::TablePtr lo, c, s, p, d;
         lo = std::make_shared<hustle::storage::DBTable>("lineorder", lo_schema,
-                                                        20 * BLOCK_SIZE);
+                                                          BLOCK_SIZE);
         d = std::make_shared<hustle::storage::DBTable>("ddate", d_schema,
-                                                       20 * BLOCK_SIZE);
+                                                          BLOCK_SIZE);
         p = std::make_shared<hustle::storage::DBTable>("part", p_schema,
-                                                       20 * BLOCK_SIZE);
+                                                          BLOCK_SIZE);
         c = std::make_shared<hustle::storage::DBTable>("customer", c_schema,
-                                                       20 * BLOCK_SIZE);
+                                                          BLOCK_SIZE);
         s = std::make_shared<hustle::storage::DBTable>("supplier", s_schema,
-                                                       20 * BLOCK_SIZE);
+                                                          BLOCK_SIZE);
         hustle_db->create_table(supplier, s);
         hustle_db->create_table(customer, c);
         hustle_db->create_table(ddate, d);

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -460,7 +460,7 @@ void SSB::q21() {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {{d, "year"}, {p, "brand1"}};
-  std::vector<ColumnReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
+  std::vector<OrderByReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -548,7 +548,7 @@ void SSB::q22() {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {{d, "year"}, {p, "brand1"}};
-  std::vector<ColumnReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
+  std::vector<OrderByReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -625,7 +625,7 @@ void SSB::q23() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
 
   std::vector<ColumnReference> group_by_refs = {{d, "year"}, {p, "brand1"}};
-  std::vector<ColumnReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
+  std::vector<OrderByReference> order_by_refs = {{d, "year"}, {p, "brand1"}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -715,8 +715,8 @@ void SSB::q31() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_nation_ref,
                                                 s_nation_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref,
-                                                {nullptr, "revenue"}};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false},
+                                                {nullptr, "revenue", false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -809,8 +809,8 @@ void SSB::q32() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_city_ref,
                                                 s_city_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref,
-                                                {nullptr, "revenue"}};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false},
+                                                {nullptr, "revenue", false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -927,8 +927,8 @@ void SSB::q33() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_city_ref,
                                                 s_city_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref,
-                                                {nullptr, "revenue"}};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false},
+                                                {nullptr, "revenue", false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -1043,8 +1043,8 @@ void SSB::q34() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_city_ref,
                                                 s_city_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref,
-                                                {nullptr, "revenue"}};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false},
+                                                {nullptr, "revenue", false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -1145,7 +1145,7 @@ void SSB::q41() {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, c_nation_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref, c_nation_ref};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false}, {c_nation_ref, false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -1260,8 +1260,8 @@ void SSB::q42() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, s_nation_ref,
                                                 p_category_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref, s_nation_ref,
-                                                p_category_ref};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false}, {s_nation_ref, false},
+                                                 {p_category_ref, false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);
@@ -1370,8 +1370,8 @@ void SSB::q43() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   std::vector<ColumnReference> group_by_refs = {d_year_ref, s_city_ref,
                                                 p_brand1_ref};
-  std::vector<ColumnReference> order_by_refs = {d_year_ref, s_city_ref,
-                                                p_brand1_ref};
+  std::vector<OrderByReference> order_by_refs = {{d_year_ref, false}, {s_city_ref, false},
+                                                 {p_brand1_ref, false}};
   auto agg_op =
       get_agg_op(0, aggregate_type, join_result_out, agg_result_out, {agg_ref},
                  group_by_refs, order_by_refs, aggregate_options);

--- a/src/benchmark/ssb_workload_lip.cc
+++ b/src/benchmark/ssb_workload_lip.cc
@@ -649,7 +649,7 @@ void SSB::q31_lip() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_nation_ref, s_nation_ref},
-                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
+                   {{d_year_ref, false}, {nullptr, "revenue", false}}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -749,7 +749,7 @@ void SSB::q32_lip() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
-                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
+                   {{d_year_ref, false}, {nullptr, "revenue", false}}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -873,7 +873,7 @@ void SSB::q33_lip() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
-                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
+                   {{d_year_ref, false}, {nullptr, "revenue", false}}, aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
 
@@ -988,7 +988,7 @@ void SSB::q34_lip() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, c_city_ref, s_city_ref},
-                   {d_year_ref, {nullptr, "revenue"}}, aggregate_options);
+                   {{d_year_ref, false}, {nullptr, "revenue", false}}, aggregate_options);
 
   ExecutionPlan plan(0);
   auto s_select_id = plan.addOperator(&s_select_op);
@@ -1088,7 +1088,7 @@ void SSB::q41_lip() {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
-                   {d_year_ref, c_nation_ref}, {d_year_ref, c_nation_ref},
+                   {d_year_ref, c_nation_ref}, {{d_year_ref, false}, {c_nation_ref, false}},
                    aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1213,7 +1213,7 @@ void SSB::q42_lip() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, {lip_result_out}, agg_result_out, {agg_ref},
                    {d_year_ref, s_nation_ref, p_category_ref},
-                   {d_year_ref, s_nation_ref, p_category_ref},
+                   {{d_year_ref, false}, {s_nation_ref, false}, {p_category_ref, false}},
                    aggregate_options);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1328,7 +1328,7 @@ void SSB::q43_lip() {
   AggregateReference agg_ref = {AggregateKernel::SUM, "revenue", lo_rev_ref};
   HashAggregate agg_op(0, lip_result_out, agg_result_out, {agg_ref},
                    {d_year_ref, s_city_ref, p_brand1_ref},
-                   {d_year_ref, s_city_ref, p_brand1_ref}, aggregate_options);
+                   {{d_year_ref, false}, {s_city_ref, false}, {p_brand1_ref, false}}, aggregate_options);
 
   ExecutionPlan plan(0);
   auto p_select_id = plan.addOperator(&p_select_op);

--- a/src/catalog/catalog.cc
+++ b/src/catalog/catalog.cc
@@ -79,7 +79,7 @@ Catalog Catalog::CreateCatalog(std::string CatalogPath,
     sqlite3 *db;
     utils::open_sqlite3_db(SqlitePath, &db);
     for (const auto &t : catalog.tables_) {
-        utils::execute_sqlite_query(db, createCreateSql(t.second.table_schema));
+      utils::execute_sqlite_query(db, createCreateSql(t.second.table_schema));
     }
     utils::close_sqlite3(db);
     return catalog;
@@ -118,7 +118,7 @@ void Catalog::SaveToFile() {
   out.close();
 }
 
-bool Catalog::DropTable(sqlite3* db, std::string name) {
+bool Catalog::DropTable(sqlite3 *db, std::string name) {
   if (!utils::execute_sqlite_query(db,
                                    absl::StrCat("DROP TABLE ", name, ";"))) {
     std::cerr << "SqliteDB catalog out of sync" << std::endl;
@@ -146,12 +146,13 @@ std::optional<TableSchema *> Catalog::TableExists(std::string name) {
   return &tables_[name].table_schema;
 }
 
-bool Catalog::AddTable(sqlite3* db, TableSchema t) {
+bool Catalog::AddTable(sqlite3 *db, TableSchema t) {
   return this->AddTable(db, t, nullptr);
 }
 
-bool Catalog::AddTable(sqlite3* db, TableSchema t, DBTable::TablePtr table_ref) {
- auto search = tables_.find(t.getName());
+bool Catalog::AddTable(sqlite3 *db, TableSchema t,
+                       DBTable::TablePtr table_ref) {
+  auto search = tables_.find(t.getName());
   if (search != tables_.end()) {
     return false;
   }

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -35,7 +35,7 @@ Aggregate::Aggregate(const std::size_t query_id,
                      OperatorResult::OpResultPtr output_result,
                      std::vector<AggregateReference> aggregate_refs,
                      std::vector<ColumnReference> group_by_refs,
-                     std::vector<ColumnReference> order_by_refs)
+                     std::vector<OrderByReference> order_by_refs)
     : Aggregate(query_id, prev_result, output_result, aggregate_refs,
                 group_by_refs, order_by_refs,
                 std::make_shared<OperatorOptions>()) {}
@@ -45,7 +45,7 @@ Aggregate::Aggregate(const std::size_t query_id,
                      OperatorResult::OpResultPtr output_result,
                      std::vector<AggregateReference> aggregate_refs,
                      std::vector<ColumnReference> group_by_refs,
-                     std::vector<ColumnReference> order_by_refs,
+                     std::vector<OrderByReference> order_by_refs,
                      std::shared_ptr<OperatorOptions> options)
     : BaseAggregate(query_id, options),
       prev_result_(prev_result),
@@ -514,7 +514,7 @@ void Aggregate::SortResult(std::vector<arrow::Datum>& groups,
 
   for (auto& order_by_ref : order_by_refs_) {
     for (std::size_t j = 0; j < group_by_refs_.size(); ++j) {
-      if (order_by_ref.table == group_by_refs_[j].table) {
+      if (order_by_ref.col_ref_.table == group_by_refs_[j].table) {
         order_to_group.push_back(j);
       }
     }
@@ -534,7 +534,7 @@ void Aggregate::SortResult(std::vector<arrow::Datum>& groups,
     auto order_ref = order_by_refs_[i];
     // A nullptr indicates that we are sorting by the aggregate column
     // TODO(nicholas): better way to indicate we want to sort the aggregate?
-    if (order_ref.table == nullptr) {
+    if (order_ref.col_ref_.table == nullptr) {
       status = arrow::compute::SortIndices(*aggregates.make_array())
                    .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);

--- a/src/operators/aggregate/aggregate.h
+++ b/src/operators/aggregate/aggregate.h
@@ -26,6 +26,7 @@
 #include "operators/aggregate/aggregate_const.h"
 #include "operators/expression.h"
 #include "operators/operator.h"
+#include "operators/select/predicate.h"
 #include "operators/utils/operator_result.h"
 #include "parallel_hashmap/phmap.h"
 #include "storage/block.h"
@@ -111,14 +112,14 @@ class Aggregate : public BaseAggregate {
             OperatorResult::OpResultPtr output_result,
             std::vector<AggregateReference> aggregate_refs,
             std::vector<ColumnReference> group_by_refs,
-            std::vector<ColumnReference> order_by_refs);
+            std::vector<OrderByReference> order_by_refs);
 
   Aggregate(const std::size_t query_id,
             OperatorResult::OpResultPtr prev_result,
             OperatorResult::OpResultPtr output_result,
             std::vector<AggregateReference> aggregate_refs,
             std::vector<ColumnReference> group_by_refs,
-            std::vector<ColumnReference> order_by_refs,
+            std::vector<OrderByReference> order_by_refs,
             std::shared_ptr<OperatorOptions> options);
 
   /**
@@ -152,7 +153,7 @@ class Aggregate : public BaseAggregate {
     group_by_refs_ = group_by_refs;
   }
 
-  inline void set_orderby_refs(std::vector<ColumnReference> order_by_refs) {
+  inline void set_orderby_refs(std::vector<OrderByReference> order_by_refs) {
     order_by_refs_ = order_by_refs;
   }
 
@@ -175,7 +176,8 @@ class Aggregate : public BaseAggregate {
   // and which aggregate to perform.
   std::vector<AggregateReference> aggregate_refs_;
   // References denoting which columns we want to group by and order by
-  std::vector<ColumnReference> group_by_refs_, order_by_refs_;
+  std::vector<ColumnReference> group_by_refs_;
+  std::vector<OrderByReference> order_by_refs_;
 
   // Map group by column names to the actual group column
   std::vector<arrow::Datum> group_by_cols_;

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -408,9 +408,6 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
                       arrow::is_fixed_size_binary_type<T>::value) {
           using ArrayType = ArrowGetArrayType<T>;
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
-
-          std::cout << col << " " << item_index << " " << col->length()
-                    << std::endl;
           auto val = col->GetString(item_index);
           next_key = std::hash<std::string>{}(val);
           return;

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -409,7 +409,8 @@ void HashAggregate::FirstPhaseAggregateChunk_(Task *internal, size_t tid,
           using ArrayType = ArrowGetArrayType<T>;
           auto col = std::static_pointer_cast<ArrayType>(group_by_chunk);
 
-          std::cout << col << " " << item_index << " " << col->length() << std::endl;
+          std::cout << col << " " << item_index << " " << col->length()
+                    << std::endl;
           auto val = col->GetString(item_index);
           next_key = std::hash<std::string>{}(val);
           return;
@@ -731,17 +732,14 @@ void HashAggregate::SortResult(std::vector<arrow::Datum> &groups,
     // TODO(nicholas): better way to indicate we want to sort the aggregate?
     auto order = arrow::compute::SortOrder::Ascending;
     if (order_ref.is_desc) {
-        order = arrow::compute::SortOrder::Descending;
+      order = arrow::compute::SortOrder::Descending;
     }
     if (order_ref.col_ref_.table == nullptr) {
-        std::cout << "Order by ref (table null): " << order_ref.col_ref_.col_name << std::endl;
       status = arrow::compute::SortIndices(*aggregates.make_array(), order)
                    .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);
     } else {
-        std::cout << "Order by ref: " << order_ref.col_ref_.col_name << std::endl;
-
-        auto group = groups[order_to_group[i]];
+      auto group = groups[order_to_group[i]];
       status = arrow::compute::SortIndices(*group.make_array(), order)
                    .Value(&sorted_indices);
       evaluate_status(status, __FUNCTION__, __LINE__);

--- a/src/operators/aggregate/hash_aggregate.h
+++ b/src/operators/aggregate/hash_aggregate.h
@@ -21,6 +21,7 @@
 #include "operators/aggregate/aggregate_const.h"
 #include "operators/expression.h"
 #include "operators/operator.h"
+#include "operators/select/predicate.h"
 
 namespace hustle::operators {
 
@@ -119,14 +120,14 @@ class HashAggregate : public BaseAggregate {
                 OperatorResult::OpResultPtr output_result,
                 std::vector<AggregateReference> aggregate_refs,
                 std::vector<ColumnReference> group_by_refs,
-                std::vector<ColumnReference> order_by_refs);
+                std::vector<OrderByReference> order_by_refs);
 
   HashAggregate(std::size_t query_id,
                 OperatorResult::OpResultPtr prev_result,
                 OperatorResult::OpResultPtr output_result,
                 std::vector<AggregateReference> aggregate_refs,
                 std::vector<ColumnReference> group_by_refs,
-                std::vector<ColumnReference> order_by_refs,
+                std::vector<OrderByReference> order_by_refs,
                 std::shared_ptr<OperatorOptions> options);
 
   void execute(Task* ctx) override;
@@ -148,7 +149,7 @@ class HashAggregate : public BaseAggregate {
     group_by_refs_ = std::move(group_by_refs);
   }
 
-  inline void set_orderby_refs(std::vector<ColumnReference> order_by_refs) {
+  inline void set_orderby_refs(std::vector<OrderByReference> order_by_refs) {
     order_by_refs_ = std::move(order_by_refs);
   }
 
@@ -168,7 +169,8 @@ class HashAggregate : public BaseAggregate {
   // and which aggregate to perform.
   std::vector<AggregateReference> aggregate_refs_;
   // References denoting which columns we want to group by and order by
-  std::vector<ColumnReference> group_by_refs_, order_by_refs_;
+  std::vector<ColumnReference> group_by_refs_;
+  std::vector<OrderByReference> order_by_refs_;
 
   // Map group by column names to the actual group column
   std::vector<arrow::Datum> group_by_cols_;

--- a/src/operators/aggregate/hash_aggregate.h
+++ b/src/operators/aggregate/hash_aggregate.h
@@ -176,6 +176,7 @@ class HashAggregate : public BaseAggregate {
   std::vector<arrow::Datum> group_by_cols_;
 
   arrow::Datum agg_col_;
+  std::shared_ptr<arrow::ChunkedArray> filter_;
   // A StructType containing the types of all group by columns
   std::shared_ptr<arrow::DataType> group_type_;
   // We append each aggregate to this after it is computed.

--- a/src/operators/fused/filter_join.cc
+++ b/src/operators/fused/filter_join.cc
@@ -150,9 +150,9 @@ void FilterJoin::ProbeFilters(int chunk_start, int chunk_end, int filter_j,
               // i.e doing join on the fly while doing look ahead filtering
               if (key_value_pair != dim_hash_end) {
                 // FilterJoin supports only join on unique key columns
-                assert(key_value_pair->second.size() == 1);
+                assert(key_value_pair->second->size() == 1);
                 indices[join_row_idx] = row + offset;
-                dim_indices[join_row_idx] = key_value_pair->second.at(0).index;
+                dim_indices[join_row_idx] = key_value_pair->second->at(0).index;
                 join_row_idx++;
               }
             }
@@ -191,9 +191,9 @@ void FilterJoin::ProbeFilters(int chunk_start, int chunk_end, int filter_j,
               // i.e doing join on the fly while doing look ahead filtering
               if (key_value_pair != dim_hash_end) {
                 // FilterJoin supports only join on unique key columns
-                assert(key_value_pair->second.size() == 1);
+                assert(key_value_pair->second->size() == 1);
                 dim_indices[join_row_idx++] =
-                    key_value_pair->second.at(0).index;
+                    key_value_pair->second->at(0).index;
               } else {
                 // There's no matched value in the current dimension table
                 // then remove the stored matched indices in the prev dimension

--- a/src/operators/fused/filter_join.h
+++ b/src/operators/fused/filter_join.h
@@ -34,7 +34,7 @@ namespace hustle::operators {
 
 struct LookupFilterJoin {
   std::shared_ptr<BloomFilter> bloom_filter;
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>> hash_table;
+  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>> hash_table;
   std::vector<std::vector<uint32_t>> indices_;
 };
 

--- a/src/operators/fused/select_build_hash.h
+++ b/src/operators/fused/select_build_hash.h
@@ -21,6 +21,7 @@
 
 #include <arrow/compute/api.h>
 
+#include <mutex>
 #include <string>
 
 #include "operators/operator.h"
@@ -75,8 +76,11 @@ class SelectBuildHash : public Select {
   ColumnReference join_column_;
 
   std::vector<uint64_t> chunk_row_offsets_;
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>> hash_table_;
+  std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+      hash_table_;
 
+  std::mutex table_lock;
   void ExecuteBlock(int block_index);
 };
 

--- a/src/operators/fused/select_build_hash.h
+++ b/src/operators/fused/select_build_hash.h
@@ -75,7 +75,7 @@ class SelectBuildHash : public Select {
   ColumnReference join_column_;
 
   std::vector<uint64_t> chunk_row_offsets_;
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>> hash_table_;
+  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>> hash_table_;
 
   void ExecuteBlock(int block_index);
 };

--- a/src/operators/join/hash_join.h
+++ b/src/operators/join/hash_join.h
@@ -83,7 +83,7 @@ class HashJoin : public Operator {
   std::shared_ptr<JoinPredicate> predicate_;
 
   // Hash table for the join
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>
+  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
       hash_table_;
 
   std::vector<std::vector<uint32_t>> left_indices_, right_indices_;

--- a/src/operators/join/lip.h
+++ b/src/operators/join/lip.h
@@ -34,7 +34,7 @@ namespace hustle::operators {
 
 struct LookupFilter {
   std::shared_ptr<BloomFilter> bloom_filter;
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>> hash_table;
+  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>> hash_table;
 };
 
 static bool SortByBloomFilter(const LookupFilter &lhs,

--- a/src/operators/join/multiway_join.h
+++ b/src/operators/join/multiway_join.h
@@ -104,7 +104,7 @@ class MultiwayJoin : public Operator {
   JoinGraph graph_;
 
   // Hash table for the right table in each join
-  std::vector<std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>>
+  std::vector<std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>>
       hash_tables_;
 
   // new_left_indices_vector[i] = the indices of rows joined in chunk i in

--- a/src/operators/select/predicate.h
+++ b/src/operators/select/predicate.h
@@ -48,6 +48,11 @@ struct JoinPredicate {
   ColumnReference right_col_;
 };
 
+struct OrderByReference {
+  ColumnReference col_ref_;
+  bool is_desc;
+};
+
 using JoinPredicatePtr = std::shared_ptr<JoinPredicate>;
 
 /**
@@ -74,10 +79,12 @@ class Node {
 
   void print() {
     if (is_leaf()) {
-      std::cout << predicate_->col_ref_.col_name << " comp:" <<  predicate_->comparator_ <<  " " << 
-      "val " << predicate_->value_.ToString() << " " << predicate_->value2_.ToString() << std::endl;
+      std::cout << predicate_->col_ref_.col_name
+                << " comp:" << predicate_->comparator_ << " "
+                << "val " << predicate_->value_.ToString() << " "
+                << predicate_->value2_.ToString() << std::endl;
       return;
-    } 
+    }
     left_child_->print();
     std::cout << "CONNECTIVE: " << connective_ << std::endl;
     right_child_->print();
@@ -116,7 +123,6 @@ class PredicateTree {
   std::shared_ptr<Node> root_;
   int table_id_;
   std::string table_name_;
-
 };
 
 }  // namespace hustle::operators

--- a/src/operators/tests/aggregate_test.cc
+++ b/src/operators/tests/aggregate_test.cc
@@ -265,7 +265,7 @@ TEST_F(AggregateTestFixture, SumWithGroupByTest) {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-                   {R_group_ref});
+                   {{R_group_ref, false}});
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
 
@@ -320,7 +320,7 @@ TEST_F(AggregateTestFixture, SumWithGroupByOrderByTest) {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   Aggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-                   {R_group_ref});
+                   {{R_group_ref, false}});
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
 

--- a/src/operators/tests/hash_aggregate_test.cc
+++ b/src/operators/tests/hash_aggregate_test.cc
@@ -264,7 +264,7 @@ TEST_F(HashAggregateTestFixture, SumWithGroupByTest) {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   HashAggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-                   {R_group_ref});
+                   {{R_group_ref, false}});
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
 
@@ -319,7 +319,7 @@ TEST_F(HashAggregateTestFixture, SumWithGroupByOrderByTest) {
 
   AggregateReference agg_ref = {AggregateKernel::SUM, "data_sum", R, "data"};
   HashAggregate agg_op(0, result, out_result, {agg_ref}, {R_group_ref},
-                   {R_group_ref});
+                   {{R_group_ref, false}});
   Scheduler &scheduler = Scheduler::GlobalInstance();
   scheduler.addTask(agg_op.createTask());
 

--- a/src/operators/tests/select_build_hash_test.cc
+++ b/src/operators/tests/select_build_hash_test.cc
@@ -135,9 +135,7 @@ TEST_F(SelectTestFixture, SingleSelectTest) {
   status = int_builder.AppendValues({20, 30, 40, 50});
   status = int_builder.Finish(&expected_R_col_3);
 
-  std::shared_ptr<
-      phmap::flat_hash_map<int64_t, std::vector<hustle::operators::RecordID>>>
-      hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0).hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -214,9 +212,7 @@ TEST_F(SelectTestFixture, AndSelectTest) {
   status = int_builder.AppendValues({20, 30});
   status = int_builder.Finish(&expected_R_col_3);
 
-  std::shared_ptr<
-      phmap::flat_hash_map<int64_t, std::vector<hustle::operators::RecordID>>>
-      hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0).hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -294,9 +290,7 @@ TEST_F(SelectTestFixture, OrSelectTest) {
   status = int_builder.AppendValues({0, 20, 30, 40, 50});
   status = int_builder.Finish(&expected_R_col_3);
 
-  std::shared_ptr<
-      phmap::flat_hash_map<int64_t, std::vector<hustle::operators::RecordID>>>
-      hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0).hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -359,9 +353,7 @@ TEST_F(SelectTestFixture, SingleSelectManyBlocksTest) {
   status = int_builder.AppendValues({20, 30, 40, 50});
   status = int_builder.Finish(&expected_R_col_3);
 
-  std::shared_ptr<
-      phmap::flat_hash_map<int64_t, std::vector<hustle::operators::RecordID>>>
-      hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0).hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -439,9 +431,7 @@ TEST_F(SelectTestFixture, AndSelectManyBlocksTest) {
   status = int_builder.AppendValues({20, 30});
   status = int_builder.Finish(&expected_R_col_3);
 
-  std::shared_ptr<
-      phmap::flat_hash_map<int64_t, std::vector<hustle::operators::RecordID>>>
-      hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0).hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));

--- a/src/operators/utils/aggregate_factory.cc
+++ b/src/operators/utils/aggregate_factory.cc
@@ -27,7 +27,7 @@ BaseAggregate * get_agg_op(
   const OperatorResult::OpResultPtr &output_result,
   const std::vector<AggregateReference> &aggregate_units,
   const std::vector<ColumnReference> &group_by_refs,
-  const std::vector<ColumnReference> &order_by_refs,
+  const std::vector<OrderByReference> &order_by_refs,
   const std::shared_ptr<OperatorOptions> &options) {
 
   if (aggregate_type == AggregateType::ARROW_AGGREGATE) {

--- a/src/operators/utils/aggregate_factory.h
+++ b/src/operators/utils/aggregate_factory.h
@@ -45,7 +45,7 @@ BaseAggregate * get_agg_op(
   const OperatorResult::OpResultPtr &output_result,
   const std::vector<AggregateReference> &aggregate_units,
   const std::vector<ColumnReference> &group_by_refs,
-  const std::vector<ColumnReference> &order_by_refs,
+  const std::vector<OrderByReference> &order_by_refs,
   const std::shared_ptr<OperatorOptions> &options);
 
 } // namespace hustle::operators

--- a/src/operators/utils/lazy_table.cc
+++ b/src/operators/utils/lazy_table.cc
@@ -49,7 +49,7 @@ LazyTable::LazyTable(DBTable::TablePtr table, arrow::Datum filter,
 LazyTable::LazyTable(
     DBTable::TablePtr table, arrow::Datum filter, arrow::Datum indices,
     arrow::Datum index_chunks,
-    std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>
+    std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
         hash_table)
     : LazyTable(table, filter, indices, index_chunks) {
   this->hash_table_ = hash_table;

--- a/src/operators/utils/lazy_table.h
+++ b/src/operators/utils/lazy_table.h
@@ -74,7 +74,7 @@ class LazyTable {
   LazyTable(
       DBTable::TablePtr table, arrow::Datum filter, arrow::Datum indices,
       arrow::Datum index_chunks,
-      std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>
+      std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
           hash_table);
 
   /**
@@ -88,7 +88,7 @@ class LazyTable {
    */
   std::shared_ptr<arrow::ChunkedArray> MaterializeColumn(int i);
 
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>
+  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
   hash_table() {
     return hash_table_;
   }
@@ -114,7 +114,7 @@ class LazyTable {
   }
 
   inline void set_hash_table(
-      std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>
+      std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
           hash_table) {
     hash_table_ = hash_table;
   }
@@ -126,7 +126,7 @@ class LazyTable {
 
  private:
   // Hash table for the right table in each join
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::vector<RecordID>>>
+  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
       hash_table_;
   std::vector<std::shared_ptr<arrow::ChunkedArray>> materialized_cols_;
   std::unordered_map<int, std::shared_ptr<arrow::ChunkedArray>> filtered_cols_;

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -146,15 +146,17 @@ void build_aggregate(hustle::resolver::SelectResolver *select_resolver,
                                            group_by_refs, order_by_refs);
 }
 
-void build_output_cols(std::vector<ProjectReferencePtr> &project_references,
+void build_output_cols(bool is_agg_out,
+                       std::vector<ProjectReferencePtr> &project_references,
                        std::vector<ColumnReference> &agg_project_cols) {
   for (auto project_ref : project_references) {
+    auto table_ptr = is_agg_out ? nullptr : project_ref->colRef.table;
     if (!project_ref->alias.empty()) {
       agg_project_cols.emplace_back(
-          ColumnReference{nullptr, project_ref->alias});
+          ColumnReference{table_ptr, project_ref->alias});
     } else {
       agg_project_cols.emplace_back(
-          ColumnReference{nullptr, project_ref->colRef.col_name});
+          ColumnReference{table_ptr, project_ref->colRef.col_name});
     }
   }
 }
@@ -206,7 +208,7 @@ std::shared_ptr<hustle::ExecutionPlan> createPlan(
   std::vector<ProjectReferencePtr> project_references =
       *(select_resolver->project_references());
   std::vector<ColumnReference> agg_project_cols;
-  build_output_cols(project_references, agg_project_cols);
+  build_output_cols(agg_op != nullptr, project_references, agg_project_cols);
 
   std::shared_ptr<hustle::ExecutionPlan> plan =
       std::make_shared<hustle::ExecutionPlan>(0);

--- a/src/resolver/cresolver.cc
+++ b/src/resolver/cresolver.cc
@@ -26,8 +26,8 @@
 #include "operators/aggregate/hash_aggregate.h"
 #include "operators/fused/filter_join.h"
 #include "operators/fused/select_build_hash.h"
-#include "operators/select/select.h"
 #include "operators/select/predicate.h"
+#include "operators/select/select.h"
 #include "operators/utils/operator_result.h"
 #include "resolver/select_resolver.h"
 #include "scheduler/threading/synchronization_lock.h"
@@ -134,10 +134,12 @@ void build_aggregate(hustle::resolver::SelectResolver *select_resolver,
       [](std::shared_ptr<hustle::operators::ColumnReference> x) { return *x; });
 
   auto order_by_ref_ptrs = *(select_resolver->orderby_references());
-  std::vector<ColumnReference> order_by_refs(order_by_ref_ptrs.size());
-  std::transform(
-      order_by_ref_ptrs.begin(), order_by_ref_ptrs.end(), order_by_refs.begin(),
-      [](std::shared_ptr<hustle::operators::ColumnReference> x) { return *x; });
+  std::vector<OrderByReference> order_by_refs(order_by_ref_ptrs.size());
+  std::transform(order_by_ref_ptrs.begin(), order_by_ref_ptrs.end(),
+                 order_by_refs.begin(),
+                 [](std::shared_ptr<hustle::operators::OrderByReference> x) {
+                   return *x;
+                 });
 
   agg_op = std::make_unique<HashAggregate>(DEFAULT_QUERY_ID, prev_result_out,
                                            agg_result_out, *agg_refs,
@@ -221,19 +223,19 @@ std::shared_ptr<hustle::ExecutionPlan> createPlan(
     join_id = plan->addOperator(std::move(filter_join_op));
   }
   if (join_id != NULL_OP_ID && plan->getOperatorResult() == nullptr) {
-        plan->setOperatorResult(join_result_out);
+    plan->setOperatorResult(join_result_out);
   }
 
   for (auto &select_op : select_operators) {
     select_id = plan->addOperator(std::move(select_op));
     if (join_id != NULL_OP_ID) {
-        plan->createLink(select_id, join_id);
+      plan->createLink(select_id, join_id);
     }
   }
   if (select_id != NULL_OP_ID && plan->getOperatorResult() == nullptr) {
-      // Since you do not have a join there will be only one table
-      assert(select_result.size() == 1);
-      plan->setOperatorResult(select_result.at(0));
+    // Since you do not have a join there will be only one table
+    assert(select_result.size() == 1);
+    plan->setOperatorResult(select_result.at(0));
   }
 
   // Declare aggregate dependency on join operator
@@ -257,7 +259,6 @@ std::shared_ptr<hustle::storage::DBTable> execute(
   using namespace hustle::operators;
   hustle::Scheduler &scheduler = hustle::HustleDB::get_scheduler();
   SynchronizationLock sync_lock;
-
   scheduler.addTask(CreateTaskChain(
       hustle::CreateLambdaTask([&plan](hustle::Task *ctx) {
         ctx->spawnLambdaTask([&plan](hustle::Task *internal) {
@@ -268,10 +269,7 @@ std::shared_ptr<hustle::storage::DBTable> execute(
       }),
       hustle::CreateLambdaTask([&plan, &out_table, &sync_lock] {
         OperatorResult::OpResultPtr agg_result_out = plan->getOperatorResult();
-        out_table =
-            agg_result_out->materialize(plan->getResultColumns());
-        //out_table->print();
-
+        out_table = agg_result_out->materialize(plan->getResultColumns());
         sync_lock.release();
       })));
   sync_lock.wait();
@@ -279,9 +277,8 @@ std::shared_ptr<hustle::storage::DBTable> execute(
   return out_table;
 }
 
-int resolveSelect(char *dbName, Sqlite3Select *queryTree, void *pArgs, sqlite3_callback xCallback) {
-  // TODO: (@srsuryadev) resolve the select query
-  // return 0 if query is supported in column store else return 1
+int resolveSelect(char *dbName, Sqlite3Select *queryTree, void *pArgs,
+                  sqlite3_callback xCallback) {
   using hustle::resolver::SelectResolver;
   Catalog *catalog = hustle::HustleDB::get_catalog(dbName).get();
   if (dbName == NULL || catalog == nullptr) return 0;
@@ -292,6 +289,7 @@ int resolveSelect(char *dbName, Sqlite3Select *queryTree, void *pArgs, sqlite3_c
   if (is_resolvable) {
     std::shared_ptr<hustle::ExecutionPlan> plan =
         createPlan(select_resolver, catalog);
+
     if (plan != nullptr) {
       std::shared_ptr<hustle::storage::DBTable> outTable =
           execute(plan, select_resolver, catalog);

--- a/src/resolver/cresolver.h
+++ b/src/resolver/cresolver.h
@@ -64,6 +64,8 @@ typedef struct sqlite3_context sqlite3_context;
 
 struct sqlite3;
 
+#define KEYINFO_ORDER_DESC    0x01
+
 #define TK_SEMI                             1
 #define TK_EXPLAIN                          2
 #define TK_QUERY                            3

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -338,20 +338,20 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     for (int i = 0; i < pOrderBy->nExpr; i++) {
       if (pOrderBy->a[i].u.x.iOrderByCol > 0) {
         if (pOrderBy->a[i].pExpr->iColumn >= 0) {
-          std::shared_ptr<ColumnReference> colRef;
+          std::shared_ptr<OrderByReference> order_ref;
           if (pOrderBy->a[i].pExpr->op == TK_AGG_FUNCTION) {
-            colRef = std::make_shared<ColumnReference>(ColumnReference{
+              order_ref = std::make_shared<OrderByReference>(OrderByReference{
                 nullptr,
                 (*project_references_)[pOrderBy->a[i].u.x.iOrderByCol - 1]
-                    ->alias});
+                    ->alias, (bool)(pOrderBy->a[i].sortFlags & KEYINFO_ORDER_DESC)});
           } else {
-            colRef = std::make_shared<ColumnReference>(ColumnReference{
+              order_ref = std::make_shared<OrderByReference>(OrderByReference{
                 catalog_->GetTable(pOrderBy->a[i].pExpr->y.pTab->zName),
                 pOrderBy->a[i]
                     .pExpr->y.pTab->aCol[pOrderBy->a[i].pExpr->iColumn]
-                    .zName});
+                    .zName, (bool)(pOrderBy->a[i].sortFlags & KEYINFO_ORDER_DESC)});
           }
-          order_by_references_->emplace_back(colRef);
+          order_by_references_->emplace_back(order_ref);
         }
       }
     }

--- a/src/resolver/select_resolver.h
+++ b/src/resolver/select_resolver.h
@@ -55,7 +55,7 @@ class SelectResolver {
   std::shared_ptr<std::vector<AggregateReference>> agg_references_;
   std::shared_ptr<std::vector<std::shared_ptr<ColumnReference>>>
       group_by_references_;
-  std::shared_ptr<std::vector<std::shared_ptr<ColumnReference>>>
+  std::shared_ptr<std::vector<std::shared_ptr<OrderByReference>>>
       order_by_references_;
   std::shared_ptr<std::vector<std::shared_ptr<ProjectReference>>>
       project_references_;
@@ -78,7 +78,7 @@ class SelectResolver {
     group_by_references_ =
         std::make_shared<std::vector<std::shared_ptr<ColumnReference>>>();
     order_by_references_ =
-        std::make_shared<std::vector<std::shared_ptr<ColumnReference>>>();
+        std::make_shared<std::vector<std::shared_ptr<OrderByReference>>>();
     project_references_ =
         std::make_shared<std::vector<std::shared_ptr<ProjectReference>>>();
 
@@ -113,7 +113,7 @@ class SelectResolver {
     return group_by_references_;
   }
 
-  inline std::shared_ptr<std::vector<std::shared_ptr<ColumnReference>>>
+  inline std::shared_ptr<std::vector<std::shared_ptr<OrderByReference>>>
   orderby_references() {
     return order_by_references_;
   }

--- a/src/resolver/select_resolver.h
+++ b/src/resolver/select_resolver.h
@@ -90,7 +90,9 @@ class SelectResolver {
     resolve_status_ = true;
   }
 
-  SelectResolver() : SelectResolver(nullptr) {}
+  SelectResolver() : SelectResolver(nullptr) {
+      resolve_status_ = true;
+  }
 
   inline std::unordered_map<std::string,
                             std::shared_ptr<hustle::operators::PredicateTree>>&

--- a/src/storage/block.cc
+++ b/src/storage/block.cc
@@ -218,6 +218,8 @@ void Block::out_block(void *pArg, sqlite3_callback callback) {
           auto col = std::static_pointer_cast<ArrayType>(arrays[i]);
           col_txt = (char *)std::to_string(col->Value(row)).c_str();
           txt_length = std::to_string(col->Value(row)).length();
+          azVals[i] = (char *)malloc(txt_length + 1);
+          memcpy(azVals[i], (char *)col_txt, txt_length + 1);
           return;
         } else if constexpr (arrow::is_string_type<T>::value ||
                              arrow::is_fixed_size_binary_type<T>::value) {
@@ -225,6 +227,8 @@ void Block::out_block(void *pArg, sqlite3_callback callback) {
           auto col = std::static_pointer_cast<ArrayType>(arrays[i]);
           col_txt = (char *)col->GetString(row).c_str();
           txt_length = col->GetString(row).length();
+          azVals[i] = (char *)malloc(txt_length + 1);
+          memcpy(azVals[i], (char *)col_txt, txt_length + 1);
           return;
         } else {
           const auto func_name = __FUNCTION__;
@@ -238,10 +242,6 @@ void Block::out_block(void *pArg, sqlite3_callback callback) {
       };
 
       type_switcher(data_type, lambda_func);
-
-      azVals[i] = (char *)malloc(txt_length + 1);
-      memcpy(azVals[i], (char *)col_txt, txt_length);
-      azVals[i][txt_length] = 0;
     }
     callback(pArg, num_cols, azVals, azCols);
     i = 0;

--- a/src/txbench/benchmarks/tatp_hustle/CMakeLists.txt
+++ b/src/txbench/benchmarks/tatp_hustle/CMakeLists.txt
@@ -18,19 +18,23 @@ target_include_directories(
         hustle_src_utils_EventProfiler
         hustle_src_utils_skew
         hustle_src_utils_Config
+		sqlite3
+		sqlite_utils
 )
 
 target_link_libraries(
         tatp_hustle
         txbench
         tatp
-	hustleDB
+		hustleDB
         hustle_src_catalog
         hustle_src_storage
         hustle_src_resolver
         hustle_src_operators
         hustle_src_scheduler_Scheduler
         hustle_src_optimizer_ExecutionPlan
+		sqlite3
+		sqlite_utils
         ${ARROW_SHARED_LIB}
         ${GFLAGS_LIB_NAME}
         glog


### PR DESCRIPTION
### Summary

* Support for order by desc.
*  Fix in resolver for handling nested sub queries and other unsupported constructs
* Concurrency issue in the hash table build in select fused operator
* Catalog table freeing up in the db object.
* Filtering of rows in hash aggregate when it is not filtered.
* SQL test fixes for adapt to test data.
* Resolver fix for handling the case for output table when agg operator is not present.