### PR TITLE
Predicate handling without grouping - fixes

### DIFF
--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -122,46 +122,46 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
       std::shared_ptr<PredicateTree> lpred_tree = ResolvePredExpr(leftExpr);
       std::shared_ptr<PredicateTree> rpred_tree = ResolvePredExpr(rightExpr);
 
-        if (lpred_tree == nullptr &&  rpred_tree == nullptr )
-            break;
-        if (lpred_tree == nullptr ||  rpred_tree == nullptr ) {
-            auto  cur_pred_tree = (lpred_tree == nullptr) ? rpred_tree : lpred_tree;
-                if (pExpr->op == TK_AND) {
-                    auto prev_pred_tree = select_predicates_[cur_pred_tree->table_name_];
-                    if (prev_pred_tree != cur_pred_tree) {
-                        std::shared_ptr<ConnectiveNode> connective_node =
-                                std::make_shared<ConnectiveNode>(prev_pred_tree.get()->root_,
-                                                                 cur_pred_tree.get()->root_,
-                                                                 FilterOperator::AND);
-                        predicate_tree = std::make_shared<PredicateTree>(connective_node);
-                        select_predicates_[cur_pred_tree->table_name_] = predicate_tree;
-                    }
-                }
-                break;
+      if (lpred_tree == nullptr && rpred_tree == nullptr) break;
+      if (lpred_tree == nullptr || rpred_tree == nullptr) {
+        auto cur_pred_tree = (lpred_tree == nullptr) ? rpred_tree : lpred_tree;
+        if (pExpr->op == TK_AND) {
+          auto prev_pred_tree = select_predicates_[cur_pred_tree->table_name_];
+          if (prev_pred_tree != cur_pred_tree) {
+            std::shared_ptr<ConnectiveNode> connective_node =
+                std::make_shared<ConnectiveNode>(prev_pred_tree.get()->root_,
+                                                 cur_pred_tree.get()->root_,
+                                                 FilterOperator::AND);
+            predicate_tree = std::make_shared<PredicateTree>(connective_node);
+            select_predicates_[cur_pred_tree->table_name_] = predicate_tree;
+          }
+        }
+        break;
       }
       if (leftExpr->pLeft->iTable == rightExpr->pLeft->iTable) {
-          if (pExpr->op == TK_OR) {
-              std::shared_ptr<ConnectiveNode> connective_node =
-                      std::make_shared<ConnectiveNode>(lpred_tree.get()->root_,
-                                                       rpred_tree.get()->root_,
-                                                       FilterOperator::OR);
-              predicate_tree = std::make_shared<PredicateTree>(connective_node);
-          }
-          if (pExpr->op == TK_AND) {
-              std::shared_ptr<ConnectiveNode> connective_node =
-                      std::make_shared<ConnectiveNode>(lpred_tree.get()->root_,
-                                                       rpred_tree.get()->root_,
-                                                       FilterOperator::AND);
-              predicate_tree = std::make_shared<PredicateTree>(connective_node);
-          }
-          predicate_tree->table_id_ = lpred_tree->table_id_;
-          predicate_tree->table_name_ = lpred_tree->table_name_;
-          select_predicates_[predicate_tree->table_name_] = predicate_tree;
-      } else {
-            if (pExpr->op == TK_OR) {
-                throw std::runtime_error("Logical OR operator on different table is not supported.");
-            }
+        if (pExpr->op == TK_OR) {
+          std::shared_ptr<ConnectiveNode> connective_node =
+              std::make_shared<ConnectiveNode>(lpred_tree.get()->root_,
+                                               rpred_tree.get()->root_,
+                                               FilterOperator::OR);
+          predicate_tree = std::make_shared<PredicateTree>(connective_node);
         }
+        if (pExpr->op == TK_AND) {
+          std::shared_ptr<ConnectiveNode> connective_node =
+              std::make_shared<ConnectiveNode>(lpred_tree.get()->root_,
+                                               rpred_tree.get()->root_,
+                                               FilterOperator::AND);
+          predicate_tree = std::make_shared<PredicateTree>(connective_node);
+        }
+        predicate_tree->table_id_ = lpred_tree->table_id_;
+        predicate_tree->table_name_ = lpred_tree->table_name_;
+        select_predicates_[predicate_tree->table_name_] = predicate_tree;
+      } else {
+        if (pExpr->op == TK_OR) {
+          throw std::runtime_error(
+              "Logical OR operator on different table is not supported.");
+        }
+      }
       break;
     }
     case TK_NE:
@@ -205,13 +205,13 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
         predicate_tree->table_id_ = leftExpr->iTable;
         predicate_tree->table_name_ = std::string(leftExpr->y.pTab->zName);
         if (select_predicates_[leftExpr->y.pTab->zName] == nullptr) {
-            select_predicates_[leftExpr->y.pTab->zName] = predicate_tree;
+          select_predicates_[leftExpr->y.pTab->zName] = predicate_tree;
         }
       } else {
-          if (!((leftExpr != NULL && leftExpr->op == TK_COLUMN) &&
-          (rightExpr != NULL && rightExpr->op == TK_COLUMN))) {
-              resolve_status_ = false;
-          }
+        if (!((leftExpr != NULL && leftExpr->op == TK_COLUMN) &&
+              (rightExpr != NULL && rightExpr->op == TK_COLUMN))) {
+          resolve_status_ = false;
+        }
         return nullptr;
       }
       break;
@@ -253,10 +253,10 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
     case TK_AGG_COLUMN:
     case TK_AGG_FUNCTION:
     case TK_COLUMN: {
-        break;
+      break;
     }
     default: {
-        resolve_status_ = false;
+      resolve_status_ = false;
     }
   }
   // predicate_tree is NULL it it contains operator not supported
@@ -264,13 +264,13 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
 }
 
 bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
-    // Collect all the src tables
+  // Collect all the src tables
   SrcList* pTabList = queryTree->pSrc;
   if (pTabList == NULL) {
     return false;
   }
 
-    // Currently having construct is not handled in Hustle
+  // Currently having construct is not handled in Hustle
   if (queryTree->pHaving != NULL) {
     return false;
   }
@@ -283,12 +283,12 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     select_predicates_.insert({pTabList->a[i].zName, nullptr});
   }
 
-    ExprList* pEList = queryTree->pEList;
+  ExprList* pEList = queryTree->pEList;
   for (int k = 0; k < pEList->nExpr; k++) {
     ResolvePredExpr(pEList->a[k].pExpr);
   }
 
-    for (int k = 0; k < pEList->nExpr; k++) {
+  for (int k = 0; k < pEList->nExpr; k++) {
     if (pEList->a[k].pExpr->op == TK_AGG_FUNCTION) {
       Expr* expr = pEList->a[k].pExpr->x.pList->a[0].pExpr;
       char* zName = NULL;
@@ -340,19 +340,19 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     }
   }
 
-    // Resolve predicates
+  // Resolve predicates
   Expr* pWhere = queryTree->pWhere;
   if (pWhere != NULL) {
     ResolvePredExpr(pWhere);
     if (!resolve_status_) {
-        return false;
+      return false;
     }
   }
   if (pWhere != NULL) {
     ResolveJoinPredExpr(pWhere);
   }
 
-    // Resolve GroupBy
+  // Resolve GroupBy
   ExprList* pGroupBy = queryTree->pGroupBy;
   if (pGroupBy != NULL) {
     for (int i = 0; i < pGroupBy->nExpr; i++) {
@@ -376,23 +376,25 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
         if (pOrderBy->a[i].pExpr->iColumn >= 0) {
           std::shared_ptr<OrderByReference> order_ref;
           if (pOrderBy->a[i].pExpr->op == TK_AGG_FUNCTION) {
-              order_ref = std::make_shared<OrderByReference>(OrderByReference{
+            order_ref = std::make_shared<OrderByReference>(OrderByReference{
                 nullptr,
                 (*project_references_)[pOrderBy->a[i].u.x.iOrderByCol - 1]
-                    ->alias, (bool)(pOrderBy->a[i].sortFlags & KEYINFO_ORDER_DESC)});
+                    ->alias,
+                (bool)(pOrderBy->a[i].sortFlags & KEYINFO_ORDER_DESC)});
           } else {
-              order_ref = std::make_shared<OrderByReference>(OrderByReference{
+            order_ref = std::make_shared<OrderByReference>(OrderByReference{
                 catalog_->GetTable(pOrderBy->a[i].pExpr->y.pTab->zName),
                 pOrderBy->a[i]
                     .pExpr->y.pTab->aCol[pOrderBy->a[i].pExpr->iColumn]
-                    .zName, (bool)(pOrderBy->a[i].sortFlags & KEYINFO_ORDER_DESC)});
+                    .zName,
+                (bool)(pOrderBy->a[i].sortFlags & KEYINFO_ORDER_DESC)});
           }
           order_by_references_->emplace_back(order_ref);
         }
       }
     }
   }
-    return true;  // TODO: return true or false based on query resolvability
+  return true;  // TODO: return true or false based on query resolvability
 }
 }  // namespace resolver
 }  // namespace hustle

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -109,7 +109,6 @@ std::shared_ptr<PredicateTree> SelectResolver::ResolvePredExpr(Expr* pExpr) {
     return nullptr;
   }
   arrow::compute::CompareOperator comparatorOperator;
-  FilterOperator connective;
   std::shared_ptr<PredicateTree> predicate_tree = nullptr;
   switch (pExpr->op) {
     case TK_INTEGER:


### PR DESCRIPTION
### Summary

* Handle the predicates in the SQL query without grouped with the same tables for logical AND.
* Throw unsupported exception for the query containing logical OR, if attributes of two different relations are grouped with logical OR.