### PR TITLE
Handle Unsupported Join Type in Resolver and other refactor

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -47,3 +47,17 @@ target_link_libraries(hustle_SQL_MISC_test
         hustleDB
         )
 add_test(SQL_MISC_test hustle_SQL_MISC_test)
+
+add_executable(hustle_SQL_JOIN_test "tests/sql_join_test.cc")
+target_link_libraries(hustle_SQL_JOIN_test
+        gtest
+        gtest_main
+        gmock
+        hustle_src_catalog
+        sqlite3
+        absl::container absl::hash
+        absl::flat_hash_map
+        hustleDB
+        )
+add_test(SQL_JOIN_test hustle_SQL_JOIN_test)
+

--- a/src/api/tests/sql_join_test.cc
+++ b/src/api/tests/sql_join_test.cc
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "gtest/gtest.h"
+#include "sql_test.cc"
+#include "sqlite3/sqlite3.h"
+#include "utils/string_utils.h"
+
+using namespace testing;
+using namespace hustle::resolver;
+
+class SQLJoinTest : public SQLTest {
+
+    static hustle::catalog::TableSchema t1_schema, t2_schema;
+    static DBTable::TablePtr t1, t2;
+    static std::shared_ptr<hustle::HustleDB> hustle_db;
+
+    void SetUp() override {
+        int num_remove = std::filesystem::remove_all("db_directory_join");
+        EXPECT_FALSE(std::filesystem::exists("db_directory_join"));
+
+        SQLTest::hustle_db = std::make_shared<hustle::HustleDB>("db_directory_join");
+
+        // Create table part
+        //hustle::catalog::TableSchema part("part");
+        hustle::catalog::ColumnSchema a (
+                "a", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+        hustle::catalog::ColumnSchema b (
+                "b", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+        hustle::catalog::ColumnSchema c (
+                "c", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+        SQLTest::t1_schema.addColumn(a);
+        SQLTest::t1_schema.addColumn(b);
+        SQLTest::t1_schema.addColumn(c);
+
+        // Create table supplier
+        // hustle::catalog::TableSchema supplier("supplier");
+        hustle::catalog::ColumnSchema b (
+                "b", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+        hustle::catalog::ColumnSchema c (
+                "c", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+        hustle::catalog::ColumnSchema d (
+                "d", {hustle::catalog::HustleType::INTEGER, 0}, true, false);
+
+        SQLTest::t2_schema.addColumn(b);
+        SQLTest::t2_schema.addColumn(c);
+        SQLTest::t2_schema.addColumn(d);
+
+        SQLTest::t1 = std::make_shared<hustle::storage::DBTable>(
+                "t1", SQLTest::t1_schema.getArrowSchema(), BLOCK_SIZE);
+        SQLTest::t2 = std::make_shared<hustle::storage::DBTable>(
+                "t2", SQLTest::t2_schema.getArrowSchema(), BLOCK_SIZE);
+
+        hustle_db->create_table(SQLTest::t1_schema, SQLTest::t1);
+        hustle_db->create_table(SQLTest::t2_schema, SQLTest::t2);
+
+        hustle_db->execute_query_result("INSERT INTO t1 VALUES(1,2,3);");
+        hustle_db->execute_query_result("INSERT INTO t1 VALUES(2,3,4);");
+        hustle_db->execute_query_result("INSERT INTO t1 VALUES(3,4,5);");
+
+        hustle_db->execute_query_result("INSERT INTO t2 VALUES(1,2,3);");
+        hustle_db->execute_query_result("INSERT INTO t2 VALUES(2,3,4);");
+        hustle_db->execute_query_result("INSERT INTO t2 VALUES(3,4,5);");
+
+        hustle::HustleDB::init();
+    }
+};
+
+
+TEST_F(SQLMiscTest, q1_join_reorder) {
+    std::string query =
+            "select sum(lo_extendedprice*lo_discount) as "
+            "revenue "
+            "from lineorder, ddate "
+            "where d_datekey = lo_orderdate and d_year = 1993 and (lo_discount "
+            "BETWEEN 0 and 3 and lo_quantity < 25);";
+    std::string output = hustle_db->execute_query_result(query);
+    EXPECT_EQ(output, "3249196\n");
+}

--- a/src/api/tests/sql_test_misc.cc
+++ b/src/api/tests/sql_test_misc.cc
@@ -81,8 +81,8 @@ TEST_F(SQLMiscTest, q_without_agg) {
 
   std::string output = hustle_db->execute_query_result(query);
   EXPECT_EQ(output,
-            "946 | 29 | 4 | Feb1992\n"
-            "946 | 29 | 4 | Mar1992\n");
+            "946 | 29 | 4 | Mar1992\n"
+                 "946 | 29 | 4 | Feb1992\n");
 }
 
 TEST_F(SQLMiscTest, q_without_join) {

--- a/src/benchmark/aggregate_workload.cc
+++ b/src/benchmark/aggregate_workload.cc
@@ -103,7 +103,7 @@ void AggregateWorkload::q1(AggregateType agg_type) {
   ExecutionPlan plan(0);
   plan.addOperator(agg_op);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   auto name = "Q1_" + std::to_string(cardinality) + "*" +
                       std::to_string(num_group_by);
   auto eventName = this->eventName(agg_type, name);
@@ -117,8 +117,8 @@ void AggregateWorkload::q1(AggregateType agg_type) {
   if (print_) {
     out_table->print();
   }
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
 
 };
 

--- a/src/benchmark/ssb_workload.cc
+++ b/src/benchmark/ssb_workload.cc
@@ -233,7 +233,7 @@ void SSB::q11() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("1.1");
   scheduler->start();
   scheduler->join();
@@ -242,10 +242,10 @@ void SSB::q11() {
   if (print_) {
     out_table = agg_result_out->materialize({{nullptr, "revenue"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -315,7 +315,7 @@ void SSB::q12() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("1.2");
   scheduler->start();
   scheduler->join();
@@ -324,10 +324,10 @@ void SSB::q12() {
   if (print_) {
     out_table = agg_result_out->materialize({{nullptr, "revenue"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -407,7 +407,7 @@ void SSB::q13() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("1.3");
   scheduler->start();
   scheduler->join();
@@ -416,10 +416,10 @@ void SSB::q13() {
   if (print_) {
     out_table = agg_result_out->materialize({{nullptr, "revenue"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -483,7 +483,7 @@ void SSB::q21() {
 
   scheduler->addTask(&plan);
 
-  auto container = hustle::simple_profiler.getContainer();
+  auto container = hustle::profiler.getContainer();
   container->startEvent("2.1");
   scheduler->start();
   scheduler->join();
@@ -493,9 +493,9 @@ void SSB::q21() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "brand1"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -571,7 +571,7 @@ void SSB::q22() {
 
   scheduler->addTask(&plan);
 
-  auto container = hustle::simple_profiler.getContainer();
+  auto container = hustle::profiler.getContainer();
   container->startEvent("2.2");
   scheduler->start();
   scheduler->join();
@@ -581,9 +581,9 @@ void SSB::q22() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "brand1"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -648,7 +648,7 @@ void SSB::q23() {
 
   scheduler->addTask(&plan);
 
-  auto container = hustle::simple_profiler.getContainer();
+  auto container = hustle::profiler.getContainer();
   container->startEvent("2.3");
   scheduler->start();
   scheduler->join();
@@ -658,9 +658,9 @@ void SSB::q23() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "brand1"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -739,7 +739,7 @@ void SSB::q31() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.1");
   scheduler->start();
   scheduler->join();
@@ -751,10 +751,10 @@ void SSB::q31() {
                                              {nullptr, "c nation"},
                                              {nullptr, "s nation"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -833,7 +833,7 @@ void SSB::q32() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.2");
   scheduler->start();
   scheduler->join();
@@ -845,10 +845,10 @@ void SSB::q32() {
                                              {nullptr, "c city"},
                                              {nullptr, "s city"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -951,7 +951,7 @@ void SSB::q33() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.3");
   scheduler->start();
   scheduler->join();
@@ -963,10 +963,10 @@ void SSB::q33() {
                                              {nullptr, "c city"},
                                              {nullptr, "s city"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1067,7 +1067,7 @@ void SSB::q34() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.4");
   scheduler->start();
   scheduler->join();
@@ -1079,10 +1079,10 @@ void SSB::q34() {
                                              {nullptr, "c city"},
                                              {nullptr, "s city"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1172,7 +1172,7 @@ void SSB::q41() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("4.1");
   scheduler->start();
   scheduler->join();
@@ -1182,10 +1182,10 @@ void SSB::q41() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "c nation"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1288,7 +1288,7 @@ void SSB::q42() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("4.2");
   scheduler->start();
   scheduler->join();
@@ -1300,10 +1300,10 @@ void SSB::q42() {
                                              {nullptr, "s nation"},
                                              {nullptr, "category"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1396,7 +1396,7 @@ void SSB::q43() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("4.3");
   scheduler->start();
   scheduler->join();
@@ -1408,10 +1408,10 @@ void SSB::q43() {
                                              {nullptr, "s city"},
                                              {nullptr, "brand1"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 

--- a/src/benchmark/ssb_workload_lip.cc
+++ b/src/benchmark/ssb_workload_lip.cc
@@ -107,7 +107,7 @@ void SSB::q11_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("1.1_lip");
   scheduler->start();
   scheduler->join();
@@ -116,10 +116,10 @@ void SSB::q11_lip() {
   if (print_) {
     out_table = agg_result_out->materialize({{nullptr, "revenue"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -213,7 +213,7 @@ void SSB::q12_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("1.2_lip");
   scheduler->start();
   scheduler->join();
@@ -222,10 +222,10 @@ void SSB::q12_lip() {
   if (print_) {
     out_table = agg_result_out->materialize({{nullptr, "revenue"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -329,7 +329,7 @@ void SSB::q13_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("1.3_lip");
   scheduler->start();
   scheduler->join();
@@ -338,10 +338,10 @@ void SSB::q13_lip() {
   if (print_) {
     out_table = agg_result_out->materialize({{nullptr, "revenue"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -408,7 +408,7 @@ void SSB::q21_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = hustle::simple_profiler.getContainer();
+  auto container = hustle::profiler.getContainer();
   container->startEvent("2.1_lip");
   scheduler->start();
   scheduler->join();
@@ -418,9 +418,9 @@ void SSB::q21_lip() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "brand1"}});
     out_table->print();
-    hustle::simple_profiler.summarizeToStream(std::cout);
+    hustle::profiler.summarizeToStream(std::cout);
   }
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -496,7 +496,7 @@ void SSB::q22_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = hustle::simple_profiler.getContainer();
+  auto container = hustle::profiler.getContainer();
   container->startEvent("2.2_lip");
   scheduler->start();
   scheduler->join();
@@ -506,9 +506,9 @@ void SSB::q22_lip() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "brand1"}});
     out_table->print();
-    hustle::simple_profiler.summarizeToStream(std::cout);
+    hustle::profiler.summarizeToStream(std::cout);
   }
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -574,7 +574,7 @@ void SSB::q23_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = hustle::simple_profiler.getContainer();
+  auto container = hustle::profiler.getContainer();
   container->startEvent("2.3_lip");
   scheduler->start();
   scheduler->join();
@@ -584,9 +584,9 @@ void SSB::q23_lip() {
     out_table = agg_result_out->materialize(
         {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "brand1"}});
     out_table->print();
-    hustle::simple_profiler.summarizeToStream(std::cout);
+    hustle::profiler.summarizeToStream(std::cout);
   }
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -671,7 +671,7 @@ void SSB::q31_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.1_lip");
   scheduler->start();
   scheduler->join();
@@ -683,10 +683,10 @@ void SSB::q31_lip() {
                                              {nullptr, "c nation"},
                                              {nullptr, "s nation"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -771,7 +771,7 @@ void SSB::q32_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.2_lip");
   scheduler->start();
   scheduler->join();
@@ -783,10 +783,10 @@ void SSB::q32_lip() {
                                              {nullptr, "c city"},
                                              {nullptr, "s city"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -895,7 +895,7 @@ void SSB::q33_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.3_lip");
   scheduler->start();
   scheduler->join();
@@ -907,10 +907,10 @@ void SSB::q33_lip() {
                                              {nullptr, "c city"},
                                              {nullptr, "s city"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1008,7 +1008,7 @@ void SSB::q34_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("3.4_lip");
   scheduler->start();
   scheduler->join();
@@ -1020,10 +1020,10 @@ void SSB::q34_lip() {
                                              {nullptr, "c city"},
                                              {nullptr, "s city"}});
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1115,7 +1115,7 @@ void SSB::q41_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("4.1_lip");
   scheduler->start();
   scheduler->join();
@@ -1125,10 +1125,10 @@ void SSB::q41_lip() {
       {{nullptr, "revenue"}, {nullptr, "year"}, {nullptr, "c nation"}});
   if (print_) {
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1238,7 +1238,7 @@ void SSB::q42_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("4.2_lip");
   scheduler->start();
   scheduler->join();
@@ -1250,10 +1250,10 @@ void SSB::q42_lip() {
                                            {nullptr, "category"}});
   if (print_) {
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 
@@ -1350,7 +1350,7 @@ void SSB::q43_lip() {
 
   scheduler->addTask(&plan);
 
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("4.3_lip");
   scheduler->start();
   scheduler->join();
@@ -1362,10 +1362,10 @@ void SSB::q43_lip() {
                                            {nullptr, "brand1"}});
   if (print_) {
     out_table->print();
-    simple_profiler.summarizeToStream(std::cout);
+    profiler.summarizeToStream(std::cout);
   }
 
-  simple_profiler.clear();
+  profiler.clear();
   reset_results();
 }
 

--- a/src/benchmark/tatp_workload.cc
+++ b/src/benchmark/tatp_workload.cc
@@ -298,12 +298,12 @@ void TATP::RunQuery1() {
       "msc_location, vlr_location "
       "FROM Subscriber "
       "WHERE s_id=10;";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 1");
     hustle_db->execute_query_result(query1);
   container->endEvent("tatp - 1");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
 }
 
 void TATP::RunQuery2() {
@@ -319,12 +319,12 @@ void TATP::RunQuery2() {
       "AND is_active=131321 )"
       "AND (start_time <=1000 "
       "AND end_time > 1000);";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 2");
     hustle_db->execute_query_result(query2);
   container->endEvent("tatp - 2");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
 }
 
 void TATP::RunQuery3() {
@@ -334,12 +334,12 @@ void TATP::RunQuery3() {
       "FROM Access_Info "
       "WHERE s_id=10 "
       "AND ai_type=131321;";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 3");
     hustle_db->execute_query_result(query3);
   container->endEvent("tatp - 3");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
 }
 
 void TATP::RunQuery4() {
@@ -348,12 +348,12 @@ void TATP::RunQuery4() {
       "UPDATE Subscriber "
       "SET bit_1=999 "
       "WHERE s_id=10; ";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 4.1");
     hustle_db->execute_query_result(query4);
   container->endEvent("tatp - 4.1");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
 
   std::cout << "Verify Query 4.1: " << std::endl;
   query4 =
@@ -375,12 +375,12 @@ void TATP::RunQuery4() {
       "SET data_a = 999 "
       "WHERE sf_s_id=10 "
       "AND sf_sf_type=10";
-  container = simple_profiler.getContainer();
+  container = profiler.getContainer();
   container->startEvent("tatp - 4.2");
     hustle_db->execute_query_result(query4);
   container->endEvent("tatp - 4.2");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
 
   std::cout << "Verify Query 4.2: " << std::endl;
   query4 =
@@ -397,12 +397,12 @@ void TATP::RunQuery5() {
       "UPDATE Subscriber"
       " SET  vlr_location=50 "
       "WHERE sub_nbr='h10';";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 5");
     hustle_db->execute_query_result(query5);
   container->endEvent("tatp - 5");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
   std::cout << "Verify Query 5: " << std::endl;
   query5 =
       "SELECT s_id, sub_nbr,"
@@ -426,12 +426,12 @@ void TATP::RunQuery6() {
       "131321,"
       "'great');"
       "COMMIT;";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 6");
     hustle_db->execute_query_result(query6);
   container->endEvent("tatp - 6");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
   std::cout << "Verify Query 6: " << std::endl;
   query6 =
       "SELECT cf_s_id, start_time, end_time "
@@ -445,12 +445,12 @@ void TATP::RunQuery7() {
   std::string query7 =
       "DELETE FROM Call_Forwarding "
       "WHERE cf_s_id = 11;";
-  auto container = simple_profiler.getContainer();
+  auto container = profiler.getContainer();
   container->startEvent("tatp - 7");
     hustle_db->execute_query_result(query7);
   container->endEvent("tatp - 7");
-  simple_profiler.summarizeToStream(std::cout);
-  simple_profiler.clear();
+  profiler.summarizeToStream(std::cout);
+  profiler.clear();
   std::cout << "Verify Query 7: " << std::endl;
   query7 =
       "SELECT cf_s_id, start_time, end_time "

--- a/src/execution/execution_plan.cc
+++ b/src/execution/execution_plan.cc
@@ -77,7 +77,7 @@ void ExecutionPlan::execute() {
   scheduler->addTask(
       CreateLambdaTask([qid = query_id_, operators, start_time] {
         if (FLAGS_print_per_query_span) {
-          const auto &zero_time = simple_profiler.zero_time();
+          const auto &zero_time = profiler.zero_time();
           const double start =
               std::chrono::duration<double>(*start_time - zero_time).count();
           const double end =

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -137,7 +137,7 @@ void Aggregate::InitializeGroupByColumn(Task* ctx, std::size_t group_index) {
   std::scoped_lock<std::mutex> lock(mutex_);
   group_by_index_map_.emplace(group_by_refs_[group_index].col_name,
                               group_index);
-  group_by_tables_[group_index].MaterializeColumn(
+  group_by_tables_[group_index]->MaterializeColumn(
       ctx, group_by_refs_[group_index].col_name, group_by_cols_[group_index]);
 }
 
@@ -399,7 +399,7 @@ void Aggregate::ComputeAggregates(Task* ctx) {
         auto table = aggregate_refs_[0].col_ref.table;
         auto col_name = aggregate_refs_[0].col_ref.col_name;
         agg_lazy_table_ = prev_result_->get_table(table);
-        agg_lazy_table_.MaterializeColumn(internal, col_name, agg_col_);
+        agg_lazy_table_->MaterializeColumn(internal, col_name, agg_col_);
       }),
       CreateLambdaTask([this](Task* internal) {
         // Initialize the slots to hold the current iteration value for each

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -54,7 +54,7 @@ Aggregate::Aggregate(const std::size_t query_id,
       group_by_refs_(group_by_refs),
       order_by_refs_(order_by_refs) {}
 
-void Aggregate::Execute(Task *ctx, int32_t flags) {
+void Aggregate::Execute(Task* ctx, int32_t flags) {
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([this](Task* internal) { Initialize(internal); }),
       CreateLambdaTask([this](Task* internal) { ComputeAggregates(internal); }),

--- a/src/operators/aggregate/aggregate.cc
+++ b/src/operators/aggregate/aggregate.cc
@@ -54,7 +54,7 @@ Aggregate::Aggregate(const std::size_t query_id,
       group_by_refs_(group_by_refs),
       order_by_refs_(order_by_refs) {}
 
-void Aggregate::execute(Task* ctx) {
+void Aggregate::Execute(Task *ctx, int32_t flags) {
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([this](Task* internal) { Initialize(internal); }),
       CreateLambdaTask([this](Task* internal) { ComputeAggregates(internal); }),

--- a/src/operators/aggregate/aggregate.h
+++ b/src/operators/aggregate/aggregate.h
@@ -132,7 +132,11 @@ class Aggregate : public BaseAggregate {
    * OperatorResult does not contain any of the LazyTables contained in the
    * prev_result paramter.
    */
-  void execute(Task* ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::AGGREGATE)->second;
+    }
 
   void Clear() override;
 

--- a/src/operators/aggregate/aggregate.h
+++ b/src/operators/aggregate/aggregate.h
@@ -209,8 +209,8 @@ class Aggregate : public BaseAggregate {
 
   // Map group-by column name to group_index in the group_by_refs_ table.
   std::unordered_map<std::string, int> group_by_index_map_;
-  std::vector<LazyTable> group_by_tables_;
-  LazyTable agg_lazy_table_;
+  std::vector<LazyTable::LazyTablePtr> group_by_tables_;
+  LazyTable::LazyTablePtr agg_lazy_table_;
 
   // If a thread wants to insert a group and its aggregate into group_builder_
   // and aggregate_builder_, then it must grab this mutex to ensure that the

--- a/src/operators/aggregate/aggregate.h
+++ b/src/operators/aggregate/aggregate.h
@@ -107,15 +107,13 @@ class Aggregate : public BaseAggregate {
    * @param order_by_refs vector of ColumnReferences denoting which columns
    * we should order by.
    */
-  Aggregate(const std::size_t query_id,
-            OperatorResult::OpResultPtr prev_result,
+  Aggregate(const std::size_t query_id, OperatorResult::OpResultPtr prev_result,
             OperatorResult::OpResultPtr output_result,
             std::vector<AggregateReference> aggregate_refs,
             std::vector<ColumnReference> group_by_refs,
             std::vector<OrderByReference> order_by_refs);
 
-  Aggregate(const std::size_t query_id,
-            OperatorResult::OpResultPtr prev_result,
+  Aggregate(const std::size_t query_id, OperatorResult::OpResultPtr prev_result,
             OperatorResult::OpResultPtr output_result,
             std::vector<AggregateReference> aggregate_refs,
             std::vector<ColumnReference> group_by_refs,
@@ -132,11 +130,11 @@ class Aggregate : public BaseAggregate {
    * OperatorResult does not contain any of the LazyTables contained in the
    * prev_result paramter.
    */
-  void Execute(Task *ctx, int32_t flags) override;
+  void Execute(Task* ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::AGGREGATE)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::AGGREGATE)->second;
+  }
 
   void Clear() override;
 

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -93,7 +93,7 @@ void HashAggregate::Initialize(Task *ctx) {
   for (std::size_t group_index = 0; group_index < group_by_refs_.size();
        group_index++) {
     ctx->spawnTask(CreateLambdaTask([this, group_index](Task *internal) {
-      group_by_tables_[group_index].MaterializeColumn(
+      group_by_tables_[group_index]->MaterializeColumn(
           internal, group_by_refs_[group_index].col_name,
           group_by_cols_[group_index]);
     }));
@@ -113,9 +113,9 @@ void HashAggregate::ComputeAggregates(Task *ctx) {
         auto col_name = aggregate_refs_[0].col_ref.col_name;
         if (aggregate_refs_[0].expr_ref == nullptr) {
           agg_lazy_table_ = prev_result_->get_table(table);
-          agg_lazy_table_.MaterializeColumn(internal, col_name, agg_col_);
-          filter_ = (agg_lazy_table_.filter.kind() != arrow::Datum::NONE)
-                        ? agg_lazy_table_.filter.chunked_array()
+          agg_lazy_table_->MaterializeColumn(internal, col_name, agg_col_);
+          filter_ = (agg_lazy_table_->filter.kind() != arrow::Datum::NONE)
+                        ? agg_lazy_table_->filter.chunked_array()
                         : nullptr;
         } else {
           // For expression case, create expression object and initialize

--- a/src/operators/aggregate/hash_aggregate.cc
+++ b/src/operators/aggregate/hash_aggregate.cc
@@ -53,7 +53,7 @@ HashAggregate::HashAggregate(const std::size_t query_id,
       group_by_refs_(group_by_refs),
       order_by_refs_(order_by_refs) {}
 
-void HashAggregate::execute(Task *ctx) {
+void HashAggregate::Execute(Task *ctx, int32_t flags) {
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([this](Task *internal) { Initialize(internal); }),
       CreateLambdaTask([this](Task *internal) { ComputeAggregates(internal); }),

--- a/src/operators/aggregate/hash_aggregate.h
+++ b/src/operators/aggregate/hash_aggregate.h
@@ -130,7 +130,11 @@ class HashAggregate : public BaseAggregate {
                 std::vector<OrderByReference> order_by_refs,
                 std::shared_ptr<OperatorOptions> options);
 
-  void execute(Task* ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::HASH_BASED_AGGREGATE)->second;
+    }
 
   inline void set_prev_result(OperatorResult::OpResultPtr prev_result) {
     prev_result_ = std::move(prev_result);

--- a/src/operators/aggregate/hash_aggregate.h
+++ b/src/operators/aggregate/hash_aggregate.h
@@ -115,26 +115,24 @@ class HashAggregate : public BaseAggregate {
   //      on the aggregate column. Hopefully this mapping won't change.
 
  public:
-  HashAggregate(std::size_t query_id,
-                OperatorResult::OpResultPtr prev_result,
+  HashAggregate(std::size_t query_id, OperatorResult::OpResultPtr prev_result,
                 OperatorResult::OpResultPtr output_result,
                 std::vector<AggregateReference> aggregate_refs,
                 std::vector<ColumnReference> group_by_refs,
                 std::vector<OrderByReference> order_by_refs);
 
-  HashAggregate(std::size_t query_id,
-                OperatorResult::OpResultPtr prev_result,
+  HashAggregate(std::size_t query_id, OperatorResult::OpResultPtr prev_result,
                 OperatorResult::OpResultPtr output_result,
                 std::vector<AggregateReference> aggregate_refs,
                 std::vector<ColumnReference> group_by_refs,
                 std::vector<OrderByReference> order_by_refs,
                 std::shared_ptr<OperatorOptions> options);
 
-  void Execute(Task *ctx, int32_t flags) override;
+  void Execute(Task* ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::HASH_BASED_AGGREGATE)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::HASH_BASED_AGGREGATE)->second;
+  }
 
   inline void set_prev_result(OperatorResult::OpResultPtr prev_result) {
     prev_result_ = std::move(prev_result);
@@ -293,6 +291,6 @@ class HashAggregate : public BaseAggregate {
   void SortResult(std::vector<arrow::Datum>& groups, arrow::Datum& aggregates);
 };
 
-}  // namespace hustle::operator
+}  // namespace hustle::operators
 
 #endif  // HUSTLE_HASH_AGGREGATE_H

--- a/src/operators/aggregate/hash_aggregate.h
+++ b/src/operators/aggregate/hash_aggregate.h
@@ -193,8 +193,8 @@ class HashAggregate : public BaseAggregate {
 
   // Map group-by column name to group_index in the group_by_refs_ table.
   std::unordered_map<std::string, int> group_by_index_map_;
-  std::vector<LazyTable> group_by_tables_;
-  LazyTable agg_lazy_table_;
+  std::vector<LazyTable::LazyTablePtr> group_by_tables_;
+  LazyTable::LazyTablePtr agg_lazy_table_;
 
   std::shared_ptr<Expression> expression_;
 

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -106,10 +106,10 @@ arrow::Datum Expression::ExecuteBlock(
 }
 
 template <typename ArrayType, typename ArrayPrimitiveType>
-arrow::Datum Expression::ExecuteBlock(
-    bool is_result, const arrow::Scalar& scalar, int op,
-    std::shared_ptr<arrow::Array> left_col,
-    std::shared_ptr<arrow::Array> right_col) {
+arrow::Datum Expression::ExecuteBlock(bool is_result,
+                                      const arrow::Scalar& scalar, int op,
+                                      std::shared_ptr<arrow::Array> left_col,
+                                      std::shared_ptr<arrow::Array> right_col) {
   if (is_result) {
     std::shared_ptr<ArrayType> result = std::static_pointer_cast<ArrayType>(
         arrow::MakeArrayFromScalar(scalar, left_col->length()).ValueOrDie());
@@ -155,7 +155,7 @@ arrow::Datum Expression::Evaluate(hustle::Task* ctx, int chunk_id) {
             "expression evaluation currently not supported.");
       }
 
-      auto execute_block_handler = [&, this]<typename T>(T * ptr_) {
+      auto execute_block_handler = [&, this]<typename T>(T* ptr_) {
         // Naturally handles block calculation
         if constexpr (arrow::has_c_type<T>::value &&
                       !std::is_same_v<T, arrow::DayTimeIntervalType>) {

--- a/src/operators/expression.cc
+++ b/src/operators/expression.cc
@@ -51,7 +51,7 @@ void Expression::ConvertPostfix(hustle::Task* ctx,
   if (expr->op == TK_COLUMN || expr->op == TK_AGG_COLUMN) {
     arrow::Datum col;
     prev_op_output_->get_table(expr->column_ref->table)
-        .MaterializeColumn(ctx, expr->column_ref->col_name, col);
+        ->MaterializeColumn(ctx, expr->column_ref->col_name, col);
     column = col.chunked_array();
     exp_num_chunks_ = std::max(exp_num_chunks_, column->num_chunks());
   }

--- a/src/operators/fused/filter_join.cc
+++ b/src/operators/fused/filter_join.cc
@@ -316,7 +316,7 @@ void FilterJoin::Initialize(Task *ctx) {
   }
 }
 
-void FilterJoin::execute(Task *ctx) {
+void FilterJoin::Execute(Task *ctx, int32_t flags) {
   for (auto &result : prev_result_vec_) {
     prev_result_->append(result);
   }

--- a/src/operators/fused/filter_join.cc
+++ b/src/operators/fused/filter_join.cc
@@ -311,7 +311,7 @@ void FilterJoin::Initialize(Task *ctx) {
     ctx->spawnLambdaTask([this, table_idx](Task *internal) {
       auto fact_join_col_name = fact_fk_col_names_[table_idx];
       fact_table_->MaterializeColumn(internal, fact_join_col_name,
-                                    fact_fk_cols_[fact_join_col_name]);
+                                     fact_fk_cols_[fact_join_col_name]);
     });
   }
 }
@@ -341,7 +341,8 @@ void FilterJoin::Execute(Task *ctx, int32_t flags) {
       if (left_ref.table == lazy_table->table) {
         fact_table_ = lazy_table;  // left table is always the same
         if (lazy_table->indices.kind() != arrow::Datum::NONE)
-          fact_indices_ = lazy_table->indices.array()->GetValues<uint32_t>(1, 0);
+          fact_indices_ =
+              lazy_table->indices.array()->GetValues<uint32_t>(1, 0);
         else
           fact_indices_ = nullptr;
       } else if (right_ref.table == lazy_table->table) {
@@ -426,15 +427,15 @@ void FilterJoin::Finish() {
 
   std::vector<LazyTable::LazyTablePtr> output_lazy_tables;
   // Create a new lazy fact table with the new index array
-  output_lazy_tables.emplace_back(std::make_shared<LazyTable>(fact_table_->table, arrow::Datum(),
-                                  fact_indices, fact_index_chunks));
+  output_lazy_tables.emplace_back(std::make_shared<LazyTable>(
+      fact_table_->table, arrow::Datum(), fact_indices, fact_index_chunks));
   // Add all dimension tables to the output without changing them.
   for (size_t dim_tbl_idx = 0; dim_tbl_idx < dim_tables_.size();
        dim_tbl_idx++) {
-    output_lazy_tables.emplace_back(std::make_shared<LazyTable>(dim_tables_[dim_tbl_idx]->table,
-                                    arrow::Datum(), dim_indices[dim_tbl_idx],
-                                    arrow::Datum(),
-                                    dim_tables_[dim_tbl_idx]->hash_table()));
+    output_lazy_tables.emplace_back(std::make_shared<LazyTable>(
+        dim_tables_[dim_tbl_idx]->table, arrow::Datum(),
+        dim_indices[dim_tbl_idx], arrow::Datum(),
+        dim_tables_[dim_tbl_idx]->hash_table()));
   }
   OperatorResult result({output_lazy_tables});
   output_result_->append(std::make_shared<OperatorResult>(result));

--- a/src/operators/fused/filter_join.h
+++ b/src/operators/fused/filter_join.h
@@ -113,11 +113,11 @@ class FilterJoin : public Operator {
   std::vector<LookupFilterJoin> dim_filters_;
 
   // Dimension (lazy) tables
-  std::vector<LazyTable> dim_tables_;
+  std::vector<LazyTable::LazyTablePtr> dim_tables_;
   // Dimension primary key col names
   std::vector<std::string> dim_pk_col_names_;
 
-  LazyTable fact_table_;
+  LazyTable::LazyTablePtr fact_table_;
   // Fact table foreign key col names to probe Bloom filters.
   std::vector<std::string> fact_fk_col_names_;
 

--- a/src/operators/fused/filter_join.h
+++ b/src/operators/fused/filter_join.h
@@ -34,7 +34,9 @@ namespace hustle::operators {
 
 struct LookupFilterJoin {
   std::shared_ptr<BloomFilter> bloom_filter;
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>> hash_table;
+  std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+      hash_table;
   std::vector<std::vector<uint32_t>> indices_;
 };
 
@@ -82,9 +84,9 @@ class FilterJoin : public Operator {
    */
   void Execute(Task *ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::FILTER_JOIN)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::FILTER_JOIN)->second;
+  }
 
   void Clear() override {}
 

--- a/src/operators/fused/filter_join.h
+++ b/src/operators/fused/filter_join.h
@@ -80,7 +80,11 @@ class FilterJoin : public Operator {
    *
    * @param ctx A scheduler task
    */
-  void execute(Task *ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::FILTER_JOIN)->second;
+    }
 
   void Clear() override {}
 

--- a/src/operators/fused/select_build_hash.cc
+++ b/src/operators/fused/select_build_hash.cc
@@ -55,7 +55,7 @@ SelectBuildHash::SelectBuildHash(const std::size_t query_id,
       phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>();
 }
 
-void SelectBuildHash::execute(Task *ctx) {
+void SelectBuildHash::Execute(Task *ctx, int32_t flags) {
   chunk_row_offsets_.resize(table_->get_num_rows());
   chunk_row_offsets_[0] = 0;
   for (std::size_t i = 1; i < table_->get_num_blocks(); i++) {

--- a/src/operators/fused/select_build_hash.h
+++ b/src/operators/fused/select_build_hash.h
@@ -68,7 +68,11 @@ class SelectBuildHash : public Select {
    *
    * @return a new OperatorResult with an updated filter.
    */
-  void execute(Task *ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::SELECT_BUILD_HASH)->second;
+    }
 
   void Clear() override {}
 

--- a/src/operators/fused/select_build_hash.h
+++ b/src/operators/fused/select_build_hash.h
@@ -70,9 +70,9 @@ class SelectBuildHash : public Select {
    */
   void Execute(Task *ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::SELECT_BUILD_HASH)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::SELECT_BUILD_HASH)->second;
+  }
 
   void Clear() override {}
 

--- a/src/operators/join/hash_join.cc
+++ b/src/operators/join/hash_join.cc
@@ -56,7 +56,7 @@ HashJoin::HashJoin(const std::size_t query_id,
   joined_indices_.resize(2);
 }
 
-void HashJoin::execute(Task *ctx) {
+void HashJoin::Execute(Task *ctx, int32_t flags) {
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([this](Task *internal) { Initialize(internal); }),
       CreateLambdaTask([&, this](Task *internal) { Join(internal); }),

--- a/src/operators/join/hash_join.cc
+++ b/src/operators/join/hash_join.cc
@@ -69,28 +69,28 @@ void HashJoin::Initialize(Task *ctx) {
   right_table_ =
       prev_result_.at(RIGHT_JOIN_REF_IDX)->get_table(predicate_->right_col_.table);
 
-  left_table_.MaterializeColumn(ctx, predicate_->left_col_.col_name, lcol_);
-  right_table_.MaterializeColumn(ctx, predicate_->right_col_.col_name, rcol_);
+  left_table_->MaterializeColumn(ctx, predicate_->left_col_.col_name, lcol_);
+  right_table_->MaterializeColumn(ctx, predicate_->right_col_.col_name, rcol_);
 }
 
 void HashJoin::Join(Task *ctx) {
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([&, this](Task *internal) {
         // Build phase
-        if (right_table_.hash_table() != nullptr) {
-          hash_table_ = right_table_.hash_table();
+        if (right_table_->hash_table() != nullptr) {
+          hash_table_ = right_table_->hash_table();
         } else {
           BuildHashTable(
               rcol_.chunked_array(),
-              (right_table_.filter.kind() == arrow::Datum::CHUNKED_ARRAY)
-                  ? right_table_.filter.chunked_array()
+              (right_table_->filter.kind() == arrow::Datum::CHUNKED_ARRAY)
+                  ? right_table_->filter.chunked_array()
                   : nullptr,
               internal);
         }
       }),
       CreateLambdaTask([&, this](Task *internal) {
-        ProbeHashTable(lcol_.chunked_array(), left_table_.filter,
-                       left_table_.indices, internal);
+        ProbeHashTable(lcol_.chunked_array(), left_table_->filter,
+                       left_table_->indices, internal);
       }),
       CreateLambdaTask([this](Task *internal) { FinishProbe(internal); })));
 }
@@ -266,7 +266,7 @@ OperatorResult::OpResultPtr HashJoin::BackPropogateResult(
   arrow::Status status;
 
   arrow::Datum indices, index_chunks;
-  std::vector<LazyTable> output_lazy_tables;
+  std::vector<LazyTable::LazyTablePtr> output_lazy_tables;
 
   /**
    * Update the indices of the LazyTable. If there was no previous
@@ -274,17 +274,17 @@ OperatorResult::OpResultPtr HashJoin::BackPropogateResult(
    * corresponds to indices in the left table, and we do not need to
    * call Take.
    */
-  auto update_indices = [&, this](LazyTable &table,
+  auto update_indices = [&, this](LazyTable::LazyTablePtr &table,
                                   arrow::Datum &join_indices) {
-    if (table.indices.kind() != arrow::Datum::NONE) {
-      status = arrow::compute::Take(table.indices, join_indices, take_options)
+    if (table->indices.kind() != arrow::Datum::NONE) {
+      status = arrow::compute::Take(table->indices, join_indices, take_options)
                    .Value(&indices);
       evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
     } else {
       indices = join_indices;
     }
-    output_lazy_tables.emplace_back(table.table, arrow::Datum(), indices,
-                                    index_chunks, table.hash_table());
+    output_lazy_tables.emplace_back(std::make_shared<LazyTable>(table->table, arrow::Datum(), indices,
+                                    index_chunks, table->hash_table()));
   };
 
   /**
@@ -295,24 +295,24 @@ OperatorResult::OpResultPtr HashJoin::BackPropogateResult(
   auto propogate_indices = [&, this](int index, DBTable::TablePtr table,
                                      arrow::Datum &join_indices) {
     for (auto &lazy_table : prev_result_.at(index)->lazy_tables_) {
-      if (lazy_table.table != table &&
-          lazy_table.indices.kind() != arrow::Datum::NONE) {
+      if (lazy_table->table != table &&
+          lazy_table->indices.kind() != arrow::Datum::NONE) {
         status =
-            arrow::compute::Take(lazy_table.indices, join_indices, take_options)
+            arrow::compute::Take(lazy_table->indices, join_indices, take_options)
                 .Value(&indices);
         evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
-        output_lazy_tables.emplace_back(lazy_table.table, arrow::Datum(),
+        output_lazy_tables.emplace_back(std::make_shared<LazyTable>(lazy_table->table, arrow::Datum(),
                                         indices, index_chunks,
-                                        lazy_table.hash_table());
+                                        lazy_table->hash_table()));
       }
     }
   };
 
   update_indices(left_table_, left_indices);
-  propogate_indices(LEFT_JOIN_REF_IDX, left_table_.table, left_indices);
+  propogate_indices(LEFT_JOIN_REF_IDX, left_table_->table, left_indices);
 
   update_indices(right_table_, right_indices);
-  propogate_indices(RIGHT_JOIN_REF_IDX, right_table_.table, right_indices);
+  propogate_indices(RIGHT_JOIN_REF_IDX, right_table_->table, right_indices);
 
   return std::make_shared<OperatorResult>(output_lazy_tables);
 }

--- a/src/operators/join/hash_join.h
+++ b/src/operators/join/hash_join.h
@@ -64,7 +64,11 @@ class HashJoin : public Operator {
    * that did not satisfy all join predicates specificed in the join graph
    * are not included.
    */
-  void execute(Task *ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::HASH_JOIN)->second;
+    }
 
   std::shared_ptr<JoinPredicate> predicate() { return predicate_; }
 

--- a/src/operators/join/hash_join.h
+++ b/src/operators/join/hash_join.h
@@ -66,9 +66,9 @@ class HashJoin : public Operator {
    */
   void Execute(Task *ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::HASH_JOIN)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::HASH_JOIN)->second;
+  }
 
   std::shared_ptr<JoinPredicate> predicate() { return predicate_; }
 
@@ -87,7 +87,8 @@ class HashJoin : public Operator {
   std::shared_ptr<JoinPredicate> predicate_;
 
   // Hash table for the join
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+  std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
       hash_table_;
 
   std::vector<std::vector<uint32_t>> left_indices_, right_indices_;

--- a/src/operators/join/hash_join.h
+++ b/src/operators/join/hash_join.h
@@ -80,7 +80,7 @@ class HashJoin : public Operator {
   // Results from upstream operators condensed into one object
   // Where the output result will be stored once the operator is executed.a
   OperatorResult::OpResultPtr output_result_;
-  LazyTable left_table_, right_table_;
+  LazyTable::LazyTablePtr left_table_, right_table_;
   arrow::Datum lcol_, rcol_;
 
   // join predicate

--- a/src/operators/join/lip.cc
+++ b/src/operators/join/lip.cc
@@ -306,8 +306,8 @@ void LIP::finish() {
   evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 
   // Create a new lazy fact table with the new index array
-  LazyTable::LazyTablePtr out_fact_table = std::make_shared<LazyTable>(fact_table_->table, fact_table_->filter, new_indices,
-                           index_chunks);
+  LazyTable::LazyTablePtr out_fact_table = std::make_shared<LazyTable>(
+      fact_table_->table, fact_table_->filter, new_indices, index_chunks);
   //    LazyTable out_fact_table(fact_table_.table, fact_table_.filter,
   //    new_indices, arrow::Datum());
 
@@ -330,8 +330,8 @@ void LIP::initialize(Task *ctx) {
   for (int i = 0; i < dim_tables_.size(); i++) {
     ctx->spawnLambdaTask([this, i](Task *internal) {
       auto fact_join_col_name = fact_fk_col_names_[i];
-        fact_table_->MaterializeColumn(internal, fact_join_col_name,
-                                      fact_fk_cols_[fact_join_col_name]);
+      fact_table_->MaterializeColumn(internal, fact_join_col_name,
+                                     fact_fk_cols_[fact_join_col_name]);
     });
   }
 }
@@ -360,7 +360,8 @@ void LIP::Execute(Task *ctx, int32_t flags) {
       if (left_ref.table == lazy_table->table) {
         fact_table_ = lazy_table;  // left table is always the same
         if (lazy_table->indices.kind() != arrow::Datum::NONE)
-          fact_indices_ = lazy_table->indices.array()->GetValues<uint32_t>(1, 0);
+          fact_indices_ =
+              lazy_table->indices.array()->GetValues<uint32_t>(1, 0);
         else
           fact_indices_ = nullptr;
       } else if (right_ref.table == lazy_table->table) {

--- a/src/operators/join/lip.cc
+++ b/src/operators/join/lip.cc
@@ -336,7 +336,7 @@ void LIP::initialize(Task *ctx) {
   }
 }
 
-void LIP::execute(Task *ctx) {
+void LIP::Execute(Task *ctx, int32_t flags) {
   for (auto &result : prev_result_vec_) {
     prev_result_->append(result);
   }

--- a/src/operators/join/lip.h
+++ b/src/operators/join/lip.h
@@ -34,7 +34,9 @@ namespace hustle::operators {
 
 struct LookupFilter {
   std::shared_ptr<BloomFilter> bloom_filter;
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>> hash_table;
+  std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+      hash_table;
 };
 
 static bool SortByBloomFilter(const LookupFilter &lhs,
@@ -76,9 +78,9 @@ class LIP : public Operator {
    */
   void Execute(Task *ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::LIP_OP)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::LIP_OP)->second;
+  }
 
   void Clear() override {}
 

--- a/src/operators/join/lip.h
+++ b/src/operators/join/lip.h
@@ -74,7 +74,11 @@ class LIP : public Operator {
    *
    * @param ctx A scheduler task
    */
-  void execute(Task *ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::LIP_OP)->second;
+    }
 
   void Clear() override {}
 

--- a/src/operators/join/lip.h
+++ b/src/operators/join/lip.h
@@ -117,13 +117,13 @@ class LIP : public Operator {
   std::vector<std::shared_ptr<arrow::ChunkedArray>> fact_col_filters_;
 
   // Dimension (lazy) tables
-  std::vector<LazyTable> dim_tables_;
+  std::vector<LazyTable::LazyTablePtr> dim_tables_;
   // Dimension primary key col names
   std::vector<std::string> dim_pk_col_names_;
   // Total number of chunks in each dimension table.
   std::vector<int> dim_join_col_num_chunks_;
 
-  LazyTable fact_table_;
+  LazyTable::LazyTablePtr fact_table_;
   // Fact table foreign key col names to probe Bloom filters.
   std::vector<std::string> fact_fk_col_names_;
 

--- a/src/operators/join/multiway_join.cc
+++ b/src/operators/join/multiway_join.cc
@@ -53,7 +53,7 @@ MultiwayJoin::MultiwayJoin(
   joined_index_chunks_.resize(2);
 }
 
-void MultiwayJoin::execute(Task *ctx) {
+void MultiwayJoin::Execute(Task *ctx, int32_t flags) {
   for (auto &result : prev_result_vec_) {
     prev_result_->append(result);
   }

--- a/src/operators/join/multiway_join.cc
+++ b/src/operators/join/multiway_join.cc
@@ -117,9 +117,9 @@ void MultiwayJoin::HashJoin(int join_id, Task *ctx) {
         left_ = prev_result_->get_table(lefts_[join_id]->table);
         right_ = prev_result_->get_table(rights_[join_id]->table);
         left_->MaterializeColumn(internal, left_col_names_[join_id],
-                                left_join_col_);
+                                 left_join_col_);
         right_->MaterializeColumn(internal, right_col_names_[join_id],
-                                 right_join_col_);
+                                  right_join_col_);
       }),
       CreateLambdaTask([this, join_id](Task *internal) {
         // Build phase
@@ -155,8 +155,8 @@ void MultiwayJoin::BuildHashTable(
     int join_id, const std::shared_ptr<arrow::ChunkedArray> &col,
     const std::shared_ptr<arrow::ChunkedArray> &filter, Task *ctx) {
   // NOTE: Do not forget to clear the hash table
-  hash_tables_[join_id] =
-      std::make_shared<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>();
+  hash_tables_[join_id] = std::make_shared<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>();
 
   // Precompute the row offsets of each chunk. A multithreaded build phase
   // requires that we know all offsets beforehand.
@@ -200,8 +200,9 @@ void MultiwayJoin::BuildHashTable(
                 {(uint32_t)chunk_row_offsets[i] + row, (uint16_t)i});
             (*hash_tables_[join_id])[val_getter(chunk, row)] = record_ids;
           } else {
-            (*hash_tables_[join_id])[val_getter(chunk, row)] = std::make_shared<std::vector<RecordID>>(std::vector<RecordID>({
-                {(uint32_t)chunk_row_offsets[i] + row, (uint16_t)i}}));
+            (*hash_tables_[join_id])[val_getter(chunk, row)] =
+                std::make_shared<std::vector<RecordID>>(std::vector<RecordID>(
+                    {{(uint32_t)chunk_row_offsets[i] + row, (uint16_t)i}}));
           }
         }
       }
@@ -499,7 +500,8 @@ OperatorResult::OpResultPtr MultiwayJoin::BackPropogateResult(
   } else {
     new_index_chunks = left_index_chunks;
   }
-  output_lazy_tables.emplace_back(std::make_shared<LazyTable>(left->table, arrow::Datum(), new_indices,
+  output_lazy_tables.emplace_back(
+      std::make_shared<LazyTable>(left->table, arrow::Datum(), new_indices,
                                   new_index_chunks, left->hash_table()));
 
   // Update the indices of the right LazyTable. If there was no previous
@@ -515,7 +517,8 @@ OperatorResult::OpResultPtr MultiwayJoin::BackPropogateResult(
     new_indices = right_indices_of_indices;
   }
   new_index_chunks = arrow::Datum();
-  output_lazy_tables.emplace_back(std::make_shared<LazyTable>(right->table, arrow::Datum(), new_indices,
+  output_lazy_tables.emplace_back(
+      std::make_shared<LazyTable>(right->table, arrow::Datum(), new_indices,
                                   new_index_chunks, right->hash_table()));
 
   // Propogate the join to the other tables in the previous OperatorResult.
@@ -529,9 +532,9 @@ OperatorResult::OpResultPtr MultiwayJoin::BackPropogateResult(
                      .Value(&new_indices);
         evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 
-        output_lazy_tables.emplace_back(std::make_shared<LazyTable>(lazy_table->table, arrow::Datum(),
-                                        new_indices, arrow::Datum(),
-                                        lazy_table->hash_table()));
+        output_lazy_tables.emplace_back(std::make_shared<LazyTable>(
+            lazy_table->table, arrow::Datum(), new_indices, arrow::Datum(),
+            lazy_table->hash_table()));
       } else {
         output_lazy_tables.emplace_back(std::make_shared<LazyTable>(
             lazy_table->table, arrow::Datum(), lazy_table->indices,

--- a/src/operators/join/multiway_join.cc
+++ b/src/operators/join/multiway_join.cc
@@ -78,11 +78,11 @@ void MultiwayJoin::Execute(Task *ctx, int32_t flags) {
     // LazyTables that we want to join.
     for (std::size_t i = 0; i < prev_result_->lazy_tables_.size(); i++) {
       auto lazy_table = prev_result_->get_table(i);
-      finished_[lazy_table.table] = false;
+      finished_[lazy_table->table] = false;
 
-      if (left_ref.table == lazy_table.table) {
+      if (left_ref.table == lazy_table->table) {
         lefts_.push_back(lazy_table);
-      } else if (right_ref.table == lazy_table.table) {
+      } else if (right_ref.table == lazy_table->table) {
         rights_.push_back(lazy_table);
       }
     }
@@ -114,20 +114,20 @@ void MultiwayJoin::HashJoin(int join_id, Task *ctx) {
   // anything going out of scope.
   ctx->spawnTask(CreateTaskChain(
       CreateLambdaTask([this, join_id](Task *internal) {
-        left_ = prev_result_->get_table(lefts_[join_id].table);
-        right_ = prev_result_->get_table(rights_[join_id].table);
-        left_.MaterializeColumn(internal, left_col_names_[join_id],
+        left_ = prev_result_->get_table(lefts_[join_id]->table);
+        right_ = prev_result_->get_table(rights_[join_id]->table);
+        left_->MaterializeColumn(internal, left_col_names_[join_id],
                                 left_join_col_);
-        right_.MaterializeColumn(internal, right_col_names_[join_id],
+        right_->MaterializeColumn(internal, right_col_names_[join_id],
                                  right_join_col_);
       }),
       CreateLambdaTask([this, join_id](Task *internal) {
         // Build phase
-        if (right_.hash_table() != nullptr) {
-          hash_tables_[join_id] = right_.hash_table();
-        } else if (right_.filter.kind() == arrow::Datum::CHUNKED_ARRAY) {
+        if (right_->hash_table() != nullptr) {
+          hash_tables_[join_id] = right_->hash_table();
+        } else if (right_->filter.kind() == arrow::Datum::CHUNKED_ARRAY) {
           BuildHashTable(join_id, right_join_col_.chunked_array(),
-                         right_.filter.chunked_array(), internal);
+                         right_->filter.chunked_array(), internal);
         } else {
           BuildHashTable(join_id, right_join_col_.chunked_array(), nullptr,
                          internal);
@@ -135,17 +135,17 @@ void MultiwayJoin::HashJoin(int join_id, Task *ctx) {
       }),
       CreateLambdaTask([this, join_id](Task *internal) {
         // Probe phase
-        ProbeHashTable(join_id, left_join_col_.chunked_array(), left_.filter,
-                       left_.indices, internal);
+        ProbeHashTable(join_id, left_join_col_.chunked_array(), left_->filter,
+                       left_->indices, internal);
       }),
       CreateLambdaTask([this, join_id](Task *internal) {
         FinishProbe(internal);
-        finished_[lefts_[join_id].table] = true;
-        finished_[rights_[join_id].table] = true;
+        finished_[lefts_[join_id]->table] = true;
+        finished_[rights_[join_id]->table] = true;
       }),
       CreateLambdaTask([this, join_id](Task *internal) {
-        auto left = prev_result_->get_table(lefts_[join_id].table);
-        auto right = prev_result_->get_table(rights_[join_id].table);
+        auto left = prev_result_->get_table(lefts_[join_id]->table);
+        auto right = prev_result_->get_table(rights_[join_id]->table);
         // Update indices of other LazyTables in the previous OperatorResult
         prev_result_ = BackPropogateResult(left, right, joined_indices_);
       })));
@@ -459,13 +459,13 @@ void MultiwayJoin::FinishProbe(Task *ctx) {
 }
 
 OperatorResult::OpResultPtr MultiwayJoin::BackPropogateResult(
-    LazyTable &left, LazyTable right,
+    LazyTable::LazyTablePtr &left, LazyTable::LazyTablePtr right,
     const std::vector<arrow::Datum> &joined_indices) {
   arrow::Status status;
   arrow::Datum new_indices;
   arrow::Datum new_index_chunks;
 
-  std::vector<LazyTable> output_lazy_tables;
+  std::vector<LazyTable::LazyTablePtr> output_lazy_tables;
 
   // The indices of the indices that were joined
   auto left_indices_of_indices = joined_indices_[kLeftJoinIndex];
@@ -483,31 +483,31 @@ OperatorResult::OpResultPtr MultiwayJoin::BackPropogateResult(
   // corresponds to indices in the left table, and we do not need to
   // call Take.
 
-  if (left.indices.kind() != arrow::Datum::NONE) {
-    status = arrow::compute::Take(left.indices, left_indices_of_indices,
+  if (left->indices.kind() != arrow::Datum::NONE) {
+    status = arrow::compute::Take(left->indices, left_indices_of_indices,
                                   take_options)
                  .Value(&new_indices);
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
   } else {
     new_indices = left_indices_of_indices;
   }
-  if (left.index_chunks.kind() != arrow::Datum::NONE) {
-    status = arrow::compute::Take(left.index_chunks, left_indices_of_indices,
+  if (left->index_chunks.kind() != arrow::Datum::NONE) {
+    status = arrow::compute::Take(left->index_chunks, left_indices_of_indices,
                                   take_options)
                  .Value(&new_index_chunks);
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
   } else {
     new_index_chunks = left_index_chunks;
   }
-  output_lazy_tables.emplace_back(left.table, arrow::Datum(), new_indices,
-                                  new_index_chunks, left.hash_table());
+  output_lazy_tables.emplace_back(std::make_shared<LazyTable>(left->table, arrow::Datum(), new_indices,
+                                  new_index_chunks, left->hash_table()));
 
   // Update the indices of the right LazyTable. If there was no previous
   // join on the right table, then right_indices_of_indices directly
   // corresponds to indices in the right table, and we do not need to
   // call Take.
-  if (right.indices.kind() != arrow::Datum::NONE) {
-    status = arrow::compute::Take(right.indices, right_indices_of_indices,
+  if (right->indices.kind() != arrow::Datum::NONE) {
+    status = arrow::compute::Take(right->indices, right_indices_of_indices,
                                   take_options)
                  .Value(&new_indices);
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
@@ -515,27 +515,27 @@ OperatorResult::OpResultPtr MultiwayJoin::BackPropogateResult(
     new_indices = right_indices_of_indices;
   }
   new_index_chunks = arrow::Datum();
-  output_lazy_tables.emplace_back(right.table, arrow::Datum(), new_indices,
-                                  new_index_chunks, right.hash_table());
+  output_lazy_tables.emplace_back(std::make_shared<LazyTable>(right->table, arrow::Datum(), new_indices,
+                                  new_index_chunks, right->hash_table()));
 
   // Propogate the join to the other tables in the previous OperatorResult.
   // This elimates tuples from other tables in the previous result that were
   // eliminated in the most recent join.
   for (auto &lazy_table : prev_result_->lazy_tables_) {
-    if (lazy_table.table != left.table && lazy_table.table != right.table) {
-      if (finished_[lazy_table.table]) {
-        status = arrow::compute::Take(lazy_table.indices,
+    if (lazy_table->table != left->table && lazy_table->table != right->table) {
+      if (finished_[lazy_table->table]) {
+        status = arrow::compute::Take(lazy_table->indices,
                                       left_indices_of_indices, take_options)
                      .Value(&new_indices);
         evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 
-        output_lazy_tables.emplace_back(lazy_table.table, arrow::Datum(),
+        output_lazy_tables.emplace_back(std::make_shared<LazyTable>(lazy_table->table, arrow::Datum(),
                                         new_indices, arrow::Datum(),
-                                        lazy_table.hash_table());
+                                        lazy_table->hash_table()));
       } else {
-        output_lazy_tables.emplace_back(
-            lazy_table.table, arrow::Datum(), lazy_table.indices,
-            lazy_table.index_chunks, lazy_table.hash_table());
+        output_lazy_tables.emplace_back(std::make_shared<LazyTable>(
+            lazy_table->table, arrow::Datum(), lazy_table->indices,
+            lazy_table->index_chunks, lazy_table->hash_table()));
       }
     }
   }

--- a/src/operators/join/multiway_join.h
+++ b/src/operators/join/multiway_join.h
@@ -67,13 +67,14 @@ class MultiwayJoin : public Operator {
    */
   void Execute(Task *ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::MULTI_JOIN)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::MULTI_JOIN)->second;
+  }
 
   void Clear() override;
 
-  inline void set_prev_result(std::vector<OperatorResult::OpResultPtr> prev_result) {
+  inline void set_prev_result(
+      std::vector<OperatorResult::OpResultPtr> prev_result) {
     prev_result_vec_ = prev_result;
   }
 
@@ -108,7 +109,8 @@ class MultiwayJoin : public Operator {
   JoinGraph graph_;
 
   // Hash table for the right table in each join
-  std::vector<std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>>
+  std::vector<std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>>
       hash_tables_;
 
   // new_left_indices_vector[i] = the indices of rows joined in chunk i in

--- a/src/operators/join/multiway_join.h
+++ b/src/operators/join/multiway_join.h
@@ -92,7 +92,7 @@ class MultiwayJoin : public Operator {
  private:
   // lefts_[i] = the left table in the ith join
   // rights_[i] = the right table in the ith join
-  std::vector<LazyTable> lefts_, rights_;
+  std::vector<LazyTable::LazyTablePtr> lefts_, rights_;
 
   // left_col_names[i] = the left join col name in the ith join
   // right_col_names[i] = the right join col name in the ith join
@@ -132,7 +132,7 @@ class MultiwayJoin : public Operator {
 
   arrow::Datum left_join_col_, right_join_col_;
 
-  LazyTable left_, right_;
+  LazyTable::LazyTablePtr left_, right_;
 
   std::unordered_map<DBTable::TablePtr, bool> finished_;
 
@@ -183,7 +183,7 @@ class MultiwayJoin : public Operator {
    *
    */
   OperatorResult::OpResultPtr BackPropogateResult(
-      LazyTable &left, LazyTable right,
+      LazyTable::LazyTablePtr &left, LazyTable::LazyTablePtr right,
       const std::vector<arrow::Datum> &joined_indices);
 
   /**

--- a/src/operators/join/multiway_join.h
+++ b/src/operators/join/multiway_join.h
@@ -65,7 +65,11 @@ class MultiwayJoin : public Operator {
    * that did not satisfy all join predicates specificed in the join graph
    * are not included.
    */
-  void execute(Task *ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::MULTI_JOIN)->second;
+    }
 
   void Clear() override;
 

--- a/src/operators/operator.h
+++ b/src/operators/operator.h
@@ -26,16 +26,59 @@
 #include "scheduler/task.h"
 #include "utils/config.h"
 #include "utils/event_profiler.h"
+#include <unordered_map>
 
 namespace hustle::operators {
 
-class Operator {
+    enum OperatorType
+    {
+        SELECT,
+        HASH_JOIN,
+        MULTI_JOIN, // i removed the rest since it's sequential
+        HASH_BASED_AGGREGATE,
+        AGGREGATE, // changed spelling
+        LIP_OP,
+        FILTER_JOIN,
+        SELECT_BUILD_HASH,
+    };
+
+
+    using OperatorName = std::string;
+    static const std::unordered_map<int, OperatorName> operator_names = {
+            { OperatorType::SELECT, "Select" },
+            { OperatorType::HASH_JOIN, "Hash Join" },
+            { OperatorType::MULTI_JOIN, "Multi Join" },
+            { OperatorType::HASH_BASED_AGGREGATE, "Hash Aggregate" },
+            { OperatorType::AGGREGATE, "Aggregate" },
+            { OperatorType::LIP_OP, "LIP" },
+            { OperatorType::FILTER_JOIN, "Filter Join" },
+            { OperatorType::SELECT_BUILD_HASH, "Select Build Hash" },
+    };
+
+
+
+
+
+
+    class Operator {
  public:
-  virtual void execute(Task *ctx) = 0;
 
-  virtual void Clear() = 0;
+     void execute(Task *ctx) {
+         auto container = profiler.getContainer();
+         container->startEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
+         this->Execute(ctx, 0);
+         container->endEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
+         profiler.summarizeToStream(std::cout);
+         //profiler.clear();
+     }
 
-  inline std::size_t operator_index() const { return op_index_; }
+    virtual void Execute(Task *ctx, int32_t flags) = 0;
+
+    virtual void Clear() = 0;
+
+    virtual std::string operator_name() = 0;
+
+    inline std::size_t operator_index() const { return op_index_; }
 
   inline void set_operator_index(const std::size_t op_index) {
     op_index_ = op_index;

--- a/src/operators/operator.h
+++ b/src/operators/operator.h
@@ -28,6 +28,8 @@
 #include "utils/event_profiler.h"
 #include <unordered_map>
 
+#define OP_PERF_ANALYSIS 0
+
 namespace hustle::operators {
 
     enum OperatorType
@@ -64,11 +66,15 @@ namespace hustle::operators {
  public:
 
      void execute(Task *ctx) {
-         auto container = profiler.getContainer();
-         container->startEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
-         this->Execute(ctx, 0);
-         container->endEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
-         profiler.summarizeToStream(std::cout);
+         if (OP_PERF_ANALYSIS) {
+             auto container = profiler.getContainer();
+             container->startEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
+             this->Execute(ctx, 0);
+             container->endEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
+             profiler.summarizeToStream(std::cout);
+         } else {
+             this->Execute(ctx, 0);
+         }
          //profiler.clear();
      }
 

--- a/src/operators/operator.h
+++ b/src/operators/operator.h
@@ -19,6 +19,7 @@
 #define HUSTLE_OPERATOR_H
 
 #include <cstdlib>
+#include <unordered_map>
 
 #include "operators/select/predicate.h"
 #include "operators/utils/operator_options.h"
@@ -26,65 +27,57 @@
 #include "scheduler/task.h"
 #include "utils/config.h"
 #include "utils/event_profiler.h"
-#include <unordered_map>
 
 #define OP_PERF_ANALYSIS 0
 
 namespace hustle::operators {
 
-    enum OperatorType
-    {
-        SELECT,
-        HASH_JOIN,
-        MULTI_JOIN, // i removed the rest since it's sequential
-        HASH_BASED_AGGREGATE,
-        AGGREGATE, // changed spelling
-        LIP_OP,
-        FILTER_JOIN,
-        SELECT_BUILD_HASH,
-    };
+enum OperatorType {
+  SELECT,
+  HASH_JOIN,
+  MULTI_JOIN,  // i removed the rest since it's sequential
+  HASH_BASED_AGGREGATE,
+  AGGREGATE,  // changed spelling
+  LIP_OP,
+  FILTER_JOIN,
+  SELECT_BUILD_HASH,
+};
 
+using OperatorName = std::string;
+static const std::unordered_map<int, OperatorName> operator_names = {
+    {OperatorType::SELECT, "Select"},
+    {OperatorType::HASH_JOIN, "Hash Join"},
+    {OperatorType::MULTI_JOIN, "Multi Join"},
+    {OperatorType::HASH_BASED_AGGREGATE, "Hash Aggregate"},
+    {OperatorType::AGGREGATE, "Aggregate"},
+    {OperatorType::LIP_OP, "LIP"},
+    {OperatorType::FILTER_JOIN, "Filter Join"},
+    {OperatorType::SELECT_BUILD_HASH, "Select Build Hash"},
+};
 
-    using OperatorName = std::string;
-    static const std::unordered_map<int, OperatorName> operator_names = {
-            { OperatorType::SELECT, "Select" },
-            { OperatorType::HASH_JOIN, "Hash Join" },
-            { OperatorType::MULTI_JOIN, "Multi Join" },
-            { OperatorType::HASH_BASED_AGGREGATE, "Hash Aggregate" },
-            { OperatorType::AGGREGATE, "Aggregate" },
-            { OperatorType::LIP_OP, "LIP" },
-            { OperatorType::FILTER_JOIN, "Filter Join" },
-            { OperatorType::SELECT_BUILD_HASH, "Select Build Hash" },
-    };
-
-
-
-
-
-
-    class Operator {
+class Operator {
  public:
+  void execute(Task *ctx) {
+    if (OP_PERF_ANALYSIS) {
+      auto container = profiler.getContainer();
+      container->startEvent(this->operator_name() + " " +
+                            std::to_string(this->operator_index()));
+      this->Execute(ctx, 0);
+      container->endEvent(this->operator_name() + " " +
+                          std::to_string(this->operator_index()));
+      profiler.summarizeToStream(std::cout);
+    } else {
+      this->Execute(ctx, 0);
+    }
+  }
 
-     void execute(Task *ctx) {
-         if (OP_PERF_ANALYSIS) {
-             auto container = profiler.getContainer();
-             container->startEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
-             this->Execute(ctx, 0);
-             container->endEvent(this->operator_name() + " " + std::to_string(this->operator_index()));
-             profiler.summarizeToStream(std::cout);
-         } else {
-             this->Execute(ctx, 0);
-         }
-         //profiler.clear();
-     }
+  virtual void Execute(Task *ctx, int32_t flags) = 0;
 
-    virtual void Execute(Task *ctx, int32_t flags) = 0;
+  virtual void Clear() = 0;
 
-    virtual void Clear() = 0;
+  virtual std::string operator_name() = 0;
 
-    virtual std::string operator_name() = 0;
-
-    inline std::size_t operator_index() const { return op_index_; }
+  inline std::size_t operator_index() const { return op_index_; }
 
   inline void set_operator_index(const std::size_t op_index) {
     op_index_ = op_index;

--- a/src/operators/select/select.cc
+++ b/src/operators/select/select.cc
@@ -53,7 +53,7 @@ Select::Select(const std::size_t query_id, DBTable::TablePtr table,
   filters_.resize(table_->get_num_blocks());
 }
 
-void Select::execute(Task *ctx) {
+void Select::Execute(Task *ctx, int32_t flags) {
   ctx->spawnTask(CreateTaskChain(
       // Task 1: perform selection on all blocks
       CreateLambdaTask([this](Task *internal) {

--- a/src/operators/select/select.h
+++ b/src/operators/select/select.h
@@ -67,17 +67,15 @@ class Select : public Operator {
    */
   void Execute(Task *ctx, int32_t flags) override;
 
-    std::string operator_name() override {
-        return operator_names.find(OperatorType::SELECT)->second;
-    }
+  std::string operator_name() override {
+    return operator_names.find(OperatorType::SELECT)->second;
+  }
 
   inline void set_output_result(OperatorResult::OpResultPtr output_result) {
     output_result_ = output_result;
   }
 
-  inline void set_table(DBTable::TablePtr table) {
-    table_ = table;
-  }
+  inline void set_table(DBTable::TablePtr table) { table_ = table; }
 
   inline void set_tree(std::shared_ptr<PredicateTree> tree) { tree_ = tree; }
 
@@ -125,8 +123,8 @@ class Select : public Operator {
 
   template <typename T, typename Op>
   arrow::Datum Filter(const std::shared_ptr<Block> &block,
-                      const ColumnReference &col_ref, const arrow::Datum& arrow_val,
-                      const T &value,
+                      const ColumnReference &col_ref,
+                      const arrow::Datum &arrow_val, const T &value,
                       arrow::compute::CompareOperator arrow_compare,
                       Op comparator);
 };

--- a/src/operators/select/select.h
+++ b/src/operators/select/select.h
@@ -65,7 +65,11 @@ class Select : public Operator {
    *
    * @return a new OperatorResult with an updated filter.
    */
-  void execute(Task *ctx) override;
+  void Execute(Task *ctx, int32_t flags) override;
+
+    std::string operator_name() override {
+        return operator_names.find(OperatorType::SELECT)->second;
+    }
 
   inline void set_output_result(OperatorResult::OpResultPtr output_result) {
     output_result_ = output_result;

--- a/src/operators/tests/select_build_hash_test.cc
+++ b/src/operators/tests/select_build_hash_test.cc
@@ -135,7 +135,7 @@ TEST_F(SelectTestFixture, SingleSelectTest) {
   status = int_builder.AppendValues({20, 30, 40, 50});
   status = int_builder.Finish(&expected_R_col_3);
 
-  auto hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0)->hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -212,7 +212,7 @@ TEST_F(SelectTestFixture, AndSelectTest) {
   status = int_builder.AppendValues({20, 30});
   status = int_builder.Finish(&expected_R_col_3);
 
-  auto hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0)->hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -290,7 +290,7 @@ TEST_F(SelectTestFixture, OrSelectTest) {
   status = int_builder.AppendValues({0, 20, 30, 40, 50});
   status = int_builder.Finish(&expected_R_col_3);
 
-  auto hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0)->hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -353,7 +353,7 @@ TEST_F(SelectTestFixture, SingleSelectManyBlocksTest) {
   status = int_builder.AppendValues({20, 30, 40, 50});
   status = int_builder.Finish(&expected_R_col_3);
 
-  auto hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0)->hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));
@@ -431,7 +431,7 @@ TEST_F(SelectTestFixture, AndSelectManyBlocksTest) {
   status = int_builder.AppendValues({20, 30});
   status = int_builder.Finish(&expected_R_col_3);
 
-  auto hash_table = out_result->get_table(0).hash_table();
+  auto hash_table = out_result->get_table(0)->hash_table();
 
   for (int i = 0; i < values.size(); i++) {
     EXPECT_TRUE(hash_table->contains(values[i]));

--- a/src/operators/utils/lazy_table.cc
+++ b/src/operators/utils/lazy_table.cc
@@ -49,7 +49,8 @@ LazyTable::LazyTable(DBTable::TablePtr table, arrow::Datum filter,
 LazyTable::LazyTable(
     DBTable::TablePtr table, arrow::Datum filter, arrow::Datum indices,
     arrow::Datum index_chunks,
-    std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+    std::shared_ptr<
+        phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
         hash_table)
     : LazyTable(table, filter, indices, index_chunks) {
   this->hash_table_ = hash_table;

--- a/src/operators/utils/lazy_table.h
+++ b/src/operators/utils/lazy_table.h
@@ -60,6 +60,9 @@ struct ExprReference {
  */
 class LazyTable {
  public:
+
+    using LazyTablePtr = std::shared_ptr<LazyTable>;
+
   LazyTable();
   /**
    * Construct a LazyTable

--- a/src/operators/utils/lazy_table.h
+++ b/src/operators/utils/lazy_table.h
@@ -60,8 +60,7 @@ struct ExprReference {
  */
 class LazyTable {
  public:
-
-    using LazyTablePtr = std::shared_ptr<LazyTable>;
+  using LazyTablePtr = std::shared_ptr<LazyTable>;
 
   LazyTable();
   /**
@@ -77,7 +76,8 @@ class LazyTable {
   LazyTable(
       DBTable::TablePtr table, arrow::Datum filter, arrow::Datum indices,
       arrow::Datum index_chunks,
-      std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+      std::shared_ptr<
+          phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
           hash_table);
 
   /**
@@ -91,7 +91,8 @@ class LazyTable {
    */
   std::shared_ptr<arrow::ChunkedArray> MaterializeColumn(int i);
 
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+  std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
   hash_table() {
     return hash_table_;
   }
@@ -117,7 +118,8 @@ class LazyTable {
   }
 
   inline void set_hash_table(
-      std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+      std::shared_ptr<
+          phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
           hash_table) {
     hash_table_ = hash_table;
   }
@@ -129,7 +131,8 @@ class LazyTable {
 
  private:
   // Hash table for the right table in each join
-  std::shared_ptr<phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
+  std::shared_ptr<
+      phmap::flat_hash_map<int64_t, std::shared_ptr<std::vector<RecordID>>>>
       hash_table_;
   std::vector<std::shared_ptr<arrow::ChunkedArray>> materialized_cols_;
   std::unordered_map<int, std::shared_ptr<arrow::ChunkedArray>> filtered_cols_;

--- a/src/operators/utils/operator_result.cc
+++ b/src/operators/utils/operator_result.cc
@@ -25,14 +25,16 @@
 
 namespace hustle::operators {
 
-OperatorResult::OperatorResult(std::vector<LazyTable::LazyTablePtr> lazy_tables) {
+OperatorResult::OperatorResult(
+    std::vector<LazyTable::LazyTablePtr> lazy_tables) {
   lazy_tables_ = lazy_tables;
 }
 
 OperatorResult::OperatorResult() = default;
 
 void OperatorResult::append(DBTable::TablePtr table) {
-    LazyTable::LazyTablePtr lazy_table_ptr = std::make_shared<LazyTable>(table, arrow::Datum(), arrow::Datum(), arrow::Datum());
+  LazyTable::LazyTablePtr lazy_table_ptr = std::make_shared<LazyTable>(
+      table, arrow::Datum(), arrow::Datum(), arrow::Datum());
   lazy_tables_.insert(lazy_tables_.begin(), lazy_table_ptr);
 }
 
@@ -51,10 +53,13 @@ void OperatorResult::append(const std::shared_ptr<OperatorResult>& result) {
   }
 }
 
-LazyTable::LazyTablePtr OperatorResult::get_table(int i) { return lazy_tables_[i]; }
+LazyTable::LazyTablePtr OperatorResult::get_table(int i) {
+  return lazy_tables_[i];
+}
 
-LazyTable::LazyTablePtr OperatorResult::get_table(const DBTable::TablePtr& table) {
-    LazyTable::LazyTablePtr result = nullptr;
+LazyTable::LazyTablePtr OperatorResult::get_table(
+    const DBTable::TablePtr& table) {
+  LazyTable::LazyTablePtr result = nullptr;
   for (auto& lazy_table : lazy_tables_) {
     if (lazy_table->table == table) {
       result = lazy_table;
@@ -94,7 +99,7 @@ DBTable::TablePtr OperatorResult::materialize(
                                              metadata_enabled);
 
   out_table->InsertRecords(out_cols);
-  if(metadata_enabled) {
+  if (metadata_enabled) {
     out_table->BuildMetadata();
   }
   return out_table;

--- a/src/operators/utils/operator_result.cc
+++ b/src/operators/utils/operator_result.cc
@@ -25,28 +25,24 @@
 
 namespace hustle::operators {
 
-OperatorResult::OperatorResult(std::vector<LazyTable> lazy_tables) {
+OperatorResult::OperatorResult(std::vector<LazyTable::LazyTablePtr> lazy_tables) {
   lazy_tables_ = lazy_tables;
 }
 
 OperatorResult::OperatorResult() = default;
 
 void OperatorResult::append(DBTable::TablePtr table) {
-  LazyTable lazy_table(table, arrow::Datum(), arrow::Datum(), arrow::Datum());
-  lazy_tables_.insert(lazy_tables_.begin(), lazy_table);
+    LazyTable::LazyTablePtr lazy_table_ptr = std::make_shared<LazyTable>(table, arrow::Datum(), arrow::Datum(), arrow::Datum());
+  lazy_tables_.insert(lazy_tables_.begin(), lazy_table_ptr);
 }
 
 void OperatorResult::set_materialized_col(
     DBTable::TablePtr table, int i, std::shared_ptr<arrow::ChunkedArray> col) {
-  get_table(table).set_materialized_column(i, col);
+  get_table(table)->set_materialized_column(i, col);
 }
 
-void OperatorResult::append(LazyTable lazy_table) {
+void OperatorResult::append(LazyTable::LazyTablePtr lazy_table) {
   lazy_tables_.insert(lazy_tables_.begin(), lazy_table);
-}
-
-void OperatorResult::append(std::shared_ptr<LazyTable> lazy_table) {
-  lazy_tables_.insert(lazy_tables_.begin(), *lazy_table);
 }
 
 void OperatorResult::append(const std::shared_ptr<OperatorResult>& result) {
@@ -55,12 +51,12 @@ void OperatorResult::append(const std::shared_ptr<OperatorResult>& result) {
   }
 }
 
-LazyTable OperatorResult::get_table(int i) { return lazy_tables_[i]; }
+LazyTable::LazyTablePtr OperatorResult::get_table(int i) { return lazy_tables_[i]; }
 
-LazyTable OperatorResult::get_table(const DBTable::TablePtr& table) {
-  LazyTable result;
+LazyTable::LazyTablePtr OperatorResult::get_table(const DBTable::TablePtr& table) {
+    LazyTable::LazyTablePtr result = nullptr;
   for (auto& lazy_table : lazy_tables_) {
-    if (lazy_table.table == table) {
+    if (lazy_table->table == table) {
       result = lazy_table;
       break;
     }
@@ -80,13 +76,13 @@ DBTable::TablePtr OperatorResult::materialize(
 
     // When we want to materialize a new aggregate table.
     if (table == nullptr) {
-      table = get_table(0).table;
+      table = get_table(0)->table;
     }
     status =
         schema_builder.AddField(table->get_schema()->GetFieldByName(col_name));
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 
-    auto col = get_table(table).MaterializeColumn(col_name);
+    auto col = get_table(table)->MaterializeColumn(col_name);
     out_cols.push_back(col);
   }
 

--- a/src/operators/utils/operator_result.h
+++ b/src/operators/utils/operator_result.h
@@ -102,12 +102,12 @@ class OperatorResult {
    * Construct a new table from the OperatorResult
    *
    * @param col_refs References to the columns to project in the output table.
-   * @param metadata_enabled true if the output DBTable should be metadata enabled
+   * @param metadata_enabled true if the output DBTable should be metadata
+   * enabled
    * @return A new table containing all columns specified by col_refs
    */
-  DBTable::TablePtr materialize(
-      const std::vector<ColumnReference>& col_refs,
-      bool metadata_enabled);
+  DBTable::TablePtr materialize(const std::vector<ColumnReference>& col_refs,
+                                bool metadata_enabled);
 
   /**
    * Construct a new table from the OperatorResult

--- a/src/operators/utils/operator_result.h
+++ b/src/operators/utils/operator_result.h
@@ -47,7 +47,7 @@ class OperatorResult {
    *
    * @param lazy_tables a vector of LazyTables
    */
-  explicit OperatorResult(std::vector<LazyTable> lazy_tables);
+  explicit OperatorResult(std::vector<LazyTable::LazyTablePtr> lazy_tables);
 
   /**
    * Construct an empty OperatorResult.
@@ -67,13 +67,13 @@ class OperatorResult {
    * Append a new lazy table to the OperatorResult.
    * @param table The lazy table to append
    */
-  void append(LazyTable lazy_table);
+  void append(LazyTable::LazyTablePtr lazy_table);
 
   /**
    * Append a new lazy table to the OperatorResult.
    * @param table Shared pointer to the lazy table to append
    */
-  void append(std::shared_ptr<LazyTable> lazy_table);
+  void append(std::shared_ptr<LazyTable::LazyTablePtr> lazy_table);
 
   /**
    * Append another OperatorResult to this OperatorResult.
@@ -88,7 +88,7 @@ class OperatorResult {
    * @param i
    * @return a LazyTable
    */
-  LazyTable get_table(int i);
+  LazyTable::LazyTablePtr get_table(int i);
 
   /**
    * Get the LazyTable that matches a particular table.
@@ -96,7 +96,7 @@ class OperatorResult {
    * @param table
    * @return a LazyTable
    */
-  LazyTable get_table(const DBTable::TablePtr& table);
+  LazyTable::LazyTablePtr get_table(const DBTable::TablePtr& table);
 
   /**
    * Construct a new table from the OperatorResult
@@ -120,7 +120,7 @@ class OperatorResult {
     return materialize(col_refs, ENABLE_METADATA_BY_DEFAULT);
   }
 
-  std::vector<LazyTable> lazy_tables_;
+  std::vector<LazyTable::LazyTablePtr> lazy_tables_;
 
   void set_materialized_col(DBTable::TablePtr table, int i,
                             std::shared_ptr<arrow::ChunkedArray> col);

--- a/src/resolver/cresolver.h
+++ b/src/resolver/cresolver.h
@@ -259,7 +259,7 @@ struct sqlite3;
 #define JT_RIGHT     0x0010    /* Right outer join */
 #define JT_OUTER     0x0020    /* The "OUTER" keyword is present */
 #define JT_ERROR     0x0040    /* unknown or unsupported join type */
-#define JT_UNSUPPORTED 0x007F
+#define JT_UNSUPPORTED 0x007E  /* Only Inner Join is supported */
 
 typedef int (*sqlite3_callback)(void*,int,char**, char**);
 

--- a/src/resolver/cresolver.h
+++ b/src/resolver/cresolver.h
@@ -247,6 +247,19 @@ struct sqlite3;
 #define TK_SPACE                          179
 #define TK_ILLEGAL                        180
 
+#define SF_NestedFrom    0x0000800 /* Part of a parenthesized FROM clause */
+
+/*
+** Permitted values of the SrcList.a.jointype field
+*/
+#define JT_INNER     0x0001    /* Any kind of inner or cross join */
+#define JT_CROSS     0x0002    /* Explicit use of the CROSS keyword */
+#define JT_NATURAL   0x0004    /* True for a "natural" join */
+#define JT_LEFT      0x0008    /* Left outer join */
+#define JT_RIGHT     0x0010    /* Right outer join */
+#define JT_OUTER     0x0020    /* The "OUTER" keyword is present */
+#define JT_ERROR     0x0040    /* unknown or unsupported join type */
+#define JT_UNSUPPORTED 0x007F
 
 typedef int (*sqlite3_callback)(void*,int,char**, char**);
 

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -63,6 +63,7 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
           join_predicates_[rRef.table->get_name()] = join_pred;
           predicates_.emplace_back(join_pred);
         }
+
       }
       break;
     }

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -53,7 +53,7 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
         ColumnReference rRef = {
             table_2, rightExpr->y.pTab->aCol[rightExpr->iColumn].zName};
 
-        if ((table_1 != nullptr && table_2 != nullptr ) &&
+        if ((table_1 != nullptr && table_2 != nullptr) &&
             (table_1->get_num_rows() < table_2->get_num_rows())) {
           std::swap(lRef, rRef);
         }
@@ -63,7 +63,6 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
           join_predicates_[rRef.table->get_name()] = join_pred;
           predicates_.emplace_back(join_pred);
         }
-
       }
       break;
     }
@@ -282,10 +281,10 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     }
     if (pTabList->a[i].pUsing) return false;
     if (pTabList->a[i].pOn) {
-        return false;
+      return false;
     }
-    if( pTabList->a[i].fg.jointype & JT_UNSUPPORTED) {
-        return false;
+    if (pTabList->a[i].fg.jointype & JT_UNSUPPORTED) {
+      return false;
     }
 
     select_predicates_.insert({pTabList->a[i].zName, nullptr});
@@ -297,7 +296,7 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
   }
 
   for (int k = 0; k < pEList->nExpr; k++) {
-      if (pEList->a[k].pExpr->op == TK_AGG_FUNCTION) {
+    if (pEList->a[k].pExpr->op == TK_AGG_FUNCTION) {
       Expr* expr = pEList->a[k].pExpr->x.pList->a[0].pExpr;
       char* zName = NULL;
       if (pEList->a[k].zEName != NULL) {
@@ -340,19 +339,19 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     } else if (pEList->a[k].pExpr->op == TK_COLUMN ||
                pEList->a[k].pExpr->op == TK_AGG_COLUMN) {
       Expr* expr = pEList->a[k].pExpr;
-        if (expr->iColumn == - 1) { // For ROWID case
-            return false;
-        }
+      if (expr->iColumn == -1) {  // For ROWID case
+        return false;
+      }
       ColumnReference colRef = {catalog_->GetTable(expr->y.pTab->zName),
                                 expr->y.pTab->aCol[expr->iColumn].zName};
       std::shared_ptr<ProjectReference> projRef =
           std::make_shared<ProjectReference>(ProjectReference{colRef});
       project_references_->emplace_back(projRef);
     } else {
-          // Other than AGG FUNCTION or COLUMN
-          // it is unsupported
-          return false;
-      }
+      // Other than AGG FUNCTION or COLUMN
+      // it is unsupported
+      return false;
+    }
   }
 
   if (queryTree->pNext) return false;

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -53,8 +53,8 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
         ColumnReference rRef = {
             table_2, rightExpr->y.pTab->aCol[rightExpr->iColumn].zName};
 
-        if ((table_1 != nullptr && table_1->get_num_rows()) <
-            (table_2 != nullptr && table_2->get_num_rows())) {
+        if ((table_1 != nullptr && table_2 != nullptr ) &&
+            (table_1->get_num_rows() < table_2->get_num_rows())) {
           std::swap(lRef, rRef);
         }
 

--- a/src/scheduler/tests/scheduler_test.cc
+++ b/src/scheduler/tests/scheduler_test.cc
@@ -33,9 +33,9 @@ class HustleSchedulerTest : public testing::Test {
 };
 
 TEST_F(HustleSchedulerTest, test1) {
-  //    EventProfiler<std::string> simple_profiler;
+  //    EventProfiler<std::string> profiler;
   //
-  //    auto *container = simple_profiler.getContainer();
+  //    auto *container = profiler.getContainer();
   //    container->startEvent("overall");
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
@@ -56,5 +56,5 @@ TEST_F(HustleSchedulerTest, test1) {
   scheduler.join();
   std::cout << x << std::endl;
   //    container->endEvent("overall");
-  //    simple_profiler.summarizeToStream(std::cout);
+  //    profiler.summarizeToStream(std::cout);
 }

--- a/src/utils/event_profiler.cc
+++ b/src/utils/event_profiler.cc
@@ -21,6 +21,6 @@
 
 namespace hustle {
 
-EventProfiler<std::string> simple_profiler;
+EventProfiler<std::string> profiler;
 
 }  // namespace hustle

--- a/src/utils/event_profiler.h
+++ b/src/utils/event_profiler.h
@@ -207,7 +207,7 @@ class EventProfiler {
   DISALLOW_COPY_AND_ASSIGN(EventProfiler);
 };
 
-extern EventProfiler<std::string> simple_profiler;
+extern EventProfiler<std::string> profiler;
 
 }  // namespace hustle
 


### PR DESCRIPTION
### Summary
* Refactored the operator to profile the execution time in performance analysis mode.
* Fixed the operator result to handle Lazy table ptr instead of object.
* Added rules in the resolver to detect the unsupported join  (NATURAL JOIN, CROSS JOIN, OUTER JOIN) and column with rowid.
* Added relevant Sqlite Join (a) tests.