### PR TITLE
Use sqlite3 select flags to redirect queries to fallback

### DIFF
--- a/src/api/hustle_db.h
+++ b/src/api/hustle_db.h
@@ -80,7 +80,7 @@ class HustleDB {
 
   inline const std::string get_sqlite_path() { return SqliteDBPath_; }
 
-  Catalog *get_catalog() { return catalog_.get(); }
+  std::shared_ptr<Catalog> get_catalog() { return catalog_; }
 
   ~HustleDB() { utils::close_sqlite3(db); }
 

--- a/src/resolver/cresolver.h
+++ b/src/resolver/cresolver.h
@@ -247,6 +247,29 @@ struct sqlite3;
 #define TK_SPACE                          179
 #define TK_ILLEGAL                        180
 
+#define SF_Distinct      0x0000001 /* Output should be DISTINCT */
+#define SF_All           0x0000002 /* Includes the ALL keyword */
+#define SF_Resolved      0x0000004 /* Identifiers have been resolved */
+#define SF_Aggregate     0x0000008 /* Contains agg functions or a GROUP BY */
+#define SF_HasAgg        0x0000010 /* Contains aggregate functions */
+#define SF_UsesEphemeral 0x0000020 /* Uses the OpenEphemeral opcode */
+#define SF_Expanded      0x0000040 /* sqlite3SelectExpand() called on this */
+#define SF_HasTypeInfo   0x0000080 /* FROM subqueries have Table metadata */
+#define SF_Compound      0x0000100 /* Part of a compound query */
+#define SF_Values        0x0000200 /* Synthesized from VALUES clause */
+#define SF_MultiValue    0x0000400 /* Single VALUES term with multiple rows */
+#define SF_NestedFrom    0x0000800 /* Part of a parenthesized FROM clause */
+#define SF_MinMaxAgg     0x0001000 /* Aggregate containing min() or max() */
+#define SF_Recursive     0x0002000 /* The recursive part of a recursive CTE */
+#define SF_FixedLimit    0x0004000 /* nSelectRow set by a constant LIMIT */
+#define SF_MaybeConvert  0x0008000 /* Need convertCompoundSelectToSubquery() */
+#define SF_Converted     0x0010000 /* By convertCompoundSelectToSubquery() */
+#define SF_IncludeHidden 0x0020000 /* Include hidden columns in output */
+#define SF_ComplexResult 0x0040000 /* Result contains subquery or function */
+#define SF_WhereBegin    0x0080000 /* Really a WhereBegin() call.  Debug Only */
+#define SF_WinRewrite    0x0100000 /* Window function rewrite accomplished */
+#define SF_View          0x0200000 /* SELECT statement is a view */
+
 #define SF_NestedFrom    0x0000800 /* Part of a parenthesized FROM clause */
 
 /*

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -61,6 +61,8 @@ void SelectResolver::ResolveJoinPredExpr(Expr* pExpr) {
         JoinPredicate join_pred = {lRef, arrow::compute::EQUAL, rRef};
         if (rRef.table != nullptr) {
           join_predicates_[rRef.table->get_name()] = join_pred;
+          join_graph_[rRef.table->get_name()].emplace_back(join_pred);
+          join_graph_[lRef.table->get_name()].emplace_back(join_pred);
           predicates_.emplace_back(join_pred);
         }
       }

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -274,6 +274,19 @@ bool SelectResolver::ResolveSelectTree(Sqlite3Select* queryTree) {
     return false;
   }
 
+  // Unsupported types of select queries in Hustle
+  if ((queryTree->selFlags & SF_Distinct)
+        || (queryTree->selFlags & SF_All)
+        || (queryTree->selFlags & SF_NestedFrom)
+        || (queryTree->selFlags & SF_View)
+        || (queryTree->selFlags & SF_Recursive)
+        || (queryTree->selFlags & SF_FixedLimit)
+        || (queryTree->selFlags & SF_Compound)
+        || (queryTree->selFlags & SF_Values)
+        || (queryTree->selFlags & SF_MultiValue)) {
+      return false;
+  }
+
   for (int i = 0; i < pTabList->nSrc; i++) {
     // Select as table source is not supported
     if (pTabList->a[i].pSelect != NULL) {

--- a/src/resolver/select_resolver.h
+++ b/src/resolver/select_resolver.h
@@ -50,6 +50,7 @@ class SelectResolver {
       select_predicates_;
 
   std::unordered_map<std::string, JoinPredicate> join_predicates_;
+  std::unordered_map<std::string, std::vector<JoinPredicate>> join_graph_;
   std::vector<JoinPredicate> predicates_;
 
   std::shared_ptr<std::vector<AggregateReference>> agg_references_;
@@ -65,7 +66,7 @@ class SelectResolver {
        {"COUNT", AggregateKernel::COUNT},
        {"MEAN", AggregateKernel::MEAN}};
 
-  Catalog* catalog_;
+  std::shared_ptr<Catalog> catalog_;
 
   bool resolve_status_;
 
@@ -73,7 +74,7 @@ class SelectResolver {
   void ResolveJoinPredExpr(Expr* pExpr);
 
  public:
-  SelectResolver(Catalog* catalog) : catalog_(catalog) {
+  SelectResolver(std::shared_ptr<Catalog> catalog) : catalog_(catalog) {
     agg_references_ = std::make_shared<std::vector<AggregateReference>>();
     group_by_references_ =
         std::make_shared<std::vector<std::shared_ptr<ColumnReference>>>();


### PR DESCRIPTION
### Summary

* In this pull request, used the SQLite parser flags to detect some of the unsupported queries and do the redirection upfront.
* Moved some of the naive ptr to shared ptr in the resolver and catalog.

