### PR TITLE
Handle chain join in Resolver

### DIFF
--- a/src/api/tests/sql_test_misc.cc
+++ b/src/api/tests/sql_test_misc.cc
@@ -227,7 +227,7 @@ TEST_F(SQLMiscTest, q_logical_AND_exception) {
     EXPECT_EQ(output, "");
 }
 
-TEST_F(SQLMiscTest, linear_join) {
+TEST_F(SQLMiscTest, linear_join1) {
     std::string query =
             "select Count(lo_quantity)\n"
             "from  lineorder, ddate, part, supplier, customer\n"
@@ -238,4 +238,16 @@ TEST_F(SQLMiscTest, linear_join) {
             "and s_suppkey = 20";
     std::string output = hustle_db->execute_query_result(query);
     EXPECT_EQ(output, "200\n");
+}
+
+TEST_F(SQLMiscTest, linear_join) {
+    std::string query =
+            "select Count(lo_quantity)\n"
+            "from  lineorder, ddate, part, supplier, customer\n"
+            "where d_datekey = lo_orderdate\n"
+            "and c_custkey = s_suppkey\n"
+            "and lo_custkey = c_custkey\n"
+            "and s_suppkey = p_partkey\n";
+    std::string output = hustle_db->execute_query_result(query);
+    EXPECT_EQ(output, "20000\n");
 }

--- a/src/api/tests/sql_test_misc.cc
+++ b/src/api/tests/sql_test_misc.cc
@@ -226,3 +226,16 @@ TEST_F(SQLMiscTest, q_logical_AND_exception) {
     output = hustle_db->execute_query_result(query);
     EXPECT_EQ(output, "");
 }
+
+TEST_F(SQLMiscTest, linear_join) {
+    std::string query =
+            "select Count(lo_quantity)\n"
+            "from  lineorder, ddate, part, supplier, customer\n"
+            "where d_datekey = lo_orderdate and\n"
+            "lo_custkey = c_custkey\n"
+            "and c_custkey = s_suppkey\n"
+            "and s_suppkey = p_partkey\n"
+            "and s_suppkey = 20";
+    std::string output = hustle_db->execute_query_result(query);
+    EXPECT_EQ(output, "200\n");
+}

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -23,8 +23,6 @@ target_link_libraries(hustle_src_benchmark PUBLIC
 add_executable(hustle_src_benchmark_main main.cc
         ../utils/bloom_filter.h
         ../utils/xxHash.h
-        ../operators/join/hash_join.cc
-        ../operators/join/hash_join.h
         aggregate_workload.cc aggregate_workload.h)
 target_link_libraries(hustle_src_benchmark_main PUBLIC
         hustle_src_benchmark

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(hustle_src_benchmark
 target_include_directories(hustle_src_benchmark PUBLIC ${ARROW_INCLUDE_DIR})
 target_link_libraries(hustle_src_benchmark PUBLIC
         hustle_src_storage
-        hustle_src_operators
         hustle_src_resolver
         hustle_src_scheduler_Scheduler
         hustle_src_optimizer_ExecutionPlan
@@ -24,6 +23,8 @@ target_link_libraries(hustle_src_benchmark PUBLIC
 add_executable(hustle_src_benchmark_main main.cc
         ../utils/bloom_filter.h
         ../utils/xxHash.h
+        ../operators/join/hash_join.cc
+        ../operators/join/hash_join.h
         aggregate_workload.cc aggregate_workload.h)
 target_link_libraries(hustle_src_benchmark_main PUBLIC
         hustle_src_benchmark

--- a/src/operators/join/hash_join.h
+++ b/src/operators/join/hash_join.h
@@ -46,12 +46,12 @@ class HashJoin : public Operator {
    * @param predicate join preicate on join column
    */
   HashJoin(const std::size_t query_id,
-           std::vector<std::shared_ptr<OperatorResult>> prev_result,
+           std::shared_ptr<std::vector<std::shared_ptr<OperatorResult>>> prev_result,
            OperatorResult::OpResultPtr output_result,
            std::shared_ptr<JoinPredicate> predicate);
 
   HashJoin(const std::size_t query_id,
-           std::vector<std::shared_ptr<OperatorResult>> prev_result,
+           std::shared_ptr<std::vector<std::shared_ptr<OperatorResult>>> prev_result,
            OperatorResult::OpResultPtr output_result,
            std::shared_ptr<JoinPredicate> predicate,
            std::shared_ptr<OperatorOptions> options);
@@ -74,9 +74,13 @@ class HashJoin : public Operator {
 
   void Clear() override {}
 
+  ~HashJoin() {
+
+  }
+
  private:
   // Results from upstream operators
-  std::vector<OperatorResult::OpResultPtr> prev_result_;
+  std::shared_ptr<std::vector<OperatorResult::OpResultPtr>> prev_result_;
   // Results from upstream operators condensed into one object
   // Where the output result will be stored once the operator is executed.a
   OperatorResult::OpResultPtr output_result_;

--- a/src/operators/join/hash_join.h
+++ b/src/operators/join/hash_join.h
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef HUSTLE_MULTIWAY_JOIN_H
-#define HUSTLE_JOIN_H
+#ifndef HUSTLE_HASH_JOIN_H
+#define HUSTLE_HASH_JOIN_H
 
 #include <arrow/compute/api.h>
 #include <utils/parallel_hashmap/phmap.h>
@@ -159,4 +159,4 @@ class HashJoin : public Operator {
 
 }  // namespace hustle::operators
 
-#endif  // HUSTLE_MULTIWAY_JOIN_H
+#endif  // HUSTLE_HASH_JOIN_H

--- a/src/operators/tests/hash_join_test.cc
+++ b/src/operators/tests/hash_join_test.cc
@@ -115,7 +115,10 @@ TEST_F(HashJoinTestFixture, EquiJoin1) {
 
   std::shared_ptr<JoinPredicate> join_pred = std::make_shared<JoinPredicate>(
       JoinPredicate{R_ref_1, arrow::compute::EQUAL, S_ref_1});
-  HashJoin join_op(0, {result1, result2}, out_result, join_pred);
+  auto input_vec_ptr =
+      std::make_shared<std::vector<std::shared_ptr<OperatorResult>>>();
+  input_vec_ptr->assign({result1, result2});
+  HashJoin join_op(0, input_vec_ptr, out_result, join_pred);
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
 
@@ -181,8 +184,11 @@ TEST_F(HashJoinTestFixture, EquiJoin2) {
   out_result_vec1.push_back(prev_out_result1);
   out_result_vec1.push_back(prev_out_result2);
 
-  std::unique_ptr<HashJoin> join_op =
-      std::make_unique<HashJoin>(0, out_result_vec1, out_result, join_pred_RS);
+  std::unique_ptr<HashJoin> join_op = std::make_unique<HashJoin>(
+      0,
+      std::make_shared<std::vector<std::shared_ptr<OperatorResult>>>(
+          out_result_vec1),
+      out_result, join_pred_RS);
 
   Scheduler &scheduler = Scheduler::GlobalInstance();
 
@@ -198,7 +204,10 @@ TEST_F(HashJoinTestFixture, EquiJoin2) {
   out_result_vec.push_back(out_result);
 
   std::unique_ptr<HashJoin> rs_join_op = std::make_unique<HashJoin>(
-      0, out_result_vec, next_out_result, join_pred_OS);
+      0,
+      std::make_shared<std::vector<std::shared_ptr<OperatorResult>>>(
+          out_result_vec),
+      next_out_result, join_pred_OS);
 
   std::shared_ptr<hustle::ExecutionPlan> plan =
       std::make_shared<hustle::ExecutionPlan>(0);

--- a/src/resolver/select_resolver.cc
+++ b/src/resolver/select_resolver.cc
@@ -57,10 +57,12 @@ bool SelectResolver::CheckJoinSupport() {
   std::string curr_table_name = start_table_name;
 
   std::set<std::string> visited_tables;
+  std::vector<JoinPredicate> ordered_predicates;
   while (covered_preds < predicates_.size()) {
     if (visited_tables.find(curr_table_name) != visited_tables.end())
       return false;
     visited_tables.insert(curr_table_name);
+    ordered_predicates.emplace_back(curr_predicate);
     std::string next_table =
         !curr_predicate.left_col_.table->get_name().compare(curr_table_name)
             ? curr_predicate.right_col_.table->get_name()
@@ -83,6 +85,7 @@ bool SelectResolver::CheckJoinSupport() {
       return false;
     }
   }
+  predicates_ = ordered_predicates;
   join_type_ = JoinType::LINEAR;
   return true;
 }

--- a/src/resolver/select_resolver.h
+++ b/src/resolver/select_resolver.h
@@ -113,28 +113,32 @@ class SelectResolver {
 
   inline JoinType join_type() { return join_type_; }
 
-  inline std::unordered_map<std::string, JoinPredicate> join_predicates() {
+  inline std::unordered_map<std::string, std::vector<JoinPredicate>> join_graph() const {
+      return join_graph_;
+  }
+
+  inline std::unordered_map<std::string, JoinPredicate> join_predicates() const {
     return join_predicates_;
   }
 
-  inline std::vector<JoinPredicate> predicates() { return predicates_; }
+  inline std::vector<JoinPredicate> predicates() const { return predicates_; }
 
-  inline std::shared_ptr<std::vector<AggregateReference>> agg_references() {
+  inline std::shared_ptr<std::vector<AggregateReference>> agg_references() const {
     return agg_references_;
   }
 
   inline std::shared_ptr<std::vector<std::shared_ptr<ColumnReference>>>
-  groupby_references() {
+  groupby_references() const {
     return group_by_references_;
   }
 
   inline std::shared_ptr<std::vector<std::shared_ptr<OrderByReference>>>
-  orderby_references() {
+  orderby_references() const {
     return order_by_references_;
   }
 
   inline std::shared_ptr<std::vector<std::shared_ptr<ProjectReference>>>
-  project_references() {
+  project_references() const {
     return project_references_;
   }
 


### PR DESCRIPTION
### Summary

* Handled the join graph as chain schema using a series of hash join and added unit tests.
* Fixes in the resolver and hash join on handling output result.
* Using shared_ptr instead of object in hash join
* Cmake fixes for the benchmark module.